### PR TITLE
Video tracking data sent to the server

### DIFF
--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -168,6 +168,11 @@ class CourseModule < ActiveRecord::Base
     self.save
   end
 
+  def total_time_watched_videos
+    total_seconds = CourseModuleElementUserLog.where(course_module_id: self.id).sum(:seconds_watched)
+    @time_watched ||= { hours: total_seconds / 3600, minutes: (total_seconds / 60) % 60, seconds: total_seconds % 60 }
+  end
+
   protected
 
   def calculate_estimated_time

--- a/app/models/course_module_element_user_log.rb
+++ b/app/models/course_module_element_user_log.rb
@@ -19,6 +19,7 @@
 #  updated_at                  :datetime
 #  course_module_jumbo_quiz_id :integer
 #  is_jumbo_quiz               :boolean          default(FALSE), not null
+#  seconds_watched             :integer          default(0)
 #
 
 class CourseModuleElementUserLog < ActiveRecord::Base
@@ -31,7 +32,7 @@ class CourseModuleElementUserLog < ActiveRecord::Base
                   :quiz_score_actual, :quiz_score_potential,
                   :is_video, :is_quiz, :is_jumbo_quiz, :course_module_id,
                   :corporate_customer_id, :course_module_jumbo_quiz_id,
-                  :quiz_attempts_attributes
+                  :quiz_attempts_attributes, :seconds_watched
 
   # Constants
 

--- a/app/views/courses/_show_video.html.haml
+++ b/app/views/courses/_show_video.html.haml
@@ -70,11 +70,25 @@
   });
 
   var completedDataSent = false;
+  var timeWatchedDataSent = false;
+  var videoCmeUserLog = #{@video_cme_user_log.id || 0};
+
   var onCompletedHandler = function() {
+    var duration = jwplayer().getDuration();
+    var position = +(jwplayer().getPosition()).toFixed(2);
+    // Prevent sending same data twice when video is ended and page unloaded.
+    if (false === timeWatchedDataSent) {
+      $.ajax({
+        url: '#{video_watched_data_courses_path}',
+        dataType: 'json',
+        data: JSON.stringify({'videoLogId': videoCmeUserLog, 'position': position, 'duration': duration}),
+        method: 'PATCH',
+        contentType: "application/json; charset=utf-8"
+      });
+      timeWatchedDataSent = true;
+    }
     // Avoid error in development mode where Mixpanel is turned off
     if (typeof mixpanel !== 'undefined' && completedDataSent === false) {
-      var duration = jwplayer().getDuration();
-      var position = +(jwplayer().getPosition()).toFixed(2);
       mixpanel.track("Video View End", {
         'Video Name': '#{cme.name}',
         'Course Module': '#{cme.course_module.name}',
@@ -94,6 +108,9 @@
   var playsNo = 0;
   jwplayer().onPlay(function(stateInfo) {
     if (stateInfo.newstate == 'PLAYING') {
+      // If user has clicked on play again after video is ended
+      // we have to send data again.
+      timeWatchedDataSent = false;
       playsNo += 1;
       // Avoid error in development mode where Mixpanel is turned off
       if (typeof mixpanel !== 'undefined' && 1 == playsNo) {

--- a/app/views/dashboard/_tutor.html.haml
+++ b/app/views/dashboard/_tutor.html.haml
@@ -8,7 +8,7 @@
           %th=t('views.course_modules.index.h1')
           %th=t('views.course_module_elements.form.active')
           %th=t('views.dashboard.tutor.course_module_element_quizzes')
-          %th=t('views.dashboard.tutor.course_module_element_videos')
+          %th="#{t('views.dashboard.tutor.course_module_element_videos')} / #{t('views.dashboard.tutor.total_time_watched')}"
           %th=t('views.dashboard.tutor.total_course_module_elements')
           %th=t('views.library.show.jumbo_quiz')
       %tbody
@@ -17,6 +17,11 @@
             %td=link_to(course_modules.name, course_module_special_link(course_modules), title: t('views.general.view_tooltip'))
             %td=tick_or_cross(course_modules.active?)
             %td=course_modules.course_module_element_quizzes.count
-            %td=course_modules.course_module_element_videos.count
+            - if course_modules.course_module_element_videos.count > 0
+              %td= "%d (%02d:%02d:%02d)" % [course_modules.course_module_element_videos.count,
+              course_modules.total_time_watched_videos[:hours], course_modules.total_time_watched_videos[:minutes],
+              course_modules.total_time_watched_videos[:seconds]]
+            - else
+              %td= course_modules.course_module_element_videos.count
             %td=course_modules.course_module_elements.count
             %td=tick_or_cross(course_modules.course_module_jumbo_quiz)

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -398,6 +398,7 @@ en:
         total_course_module_elements: Total Course Modules Elements
         course_module_element_videos: Number of Videos
         course_module_element_quizzes: Number of Quizzes
+        total_time_watched: Total Time Watched
 
       admin:
         user_data: User Data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,8 +72,9 @@ Rails.application.routes.draw do
     # general resources
     resources :corporate_customers
     resources :countries, concerns: :supports_reordering
-    resources :courses, only: [:create]
-    #resources :courses, only: [:show, :create]
+    resources :courses, only: [:create] do
+      match :video_watched_data, on: :collection, via: [:put, :patch]
+    end
     resources :course_modules, concerns: :supports_reordering
     get 'course_modules/:qualification_url', to: 'course_modules#show',
         as: :course_modules_for_qualification

--- a/db/migrate/20150602112246_add_seconds_watched_to_course_module_element_user_log.rb
+++ b/db/migrate/20150602112246_add_seconds_watched_to_course_module_element_user_log.rb
@@ -1,0 +1,5 @@
+class AddSecondsWatchedToCourseModuleElementUserLog < ActiveRecord::Migration
+  def change
+    add_column :course_module_element_user_logs, :seconds_watched, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150514094454) do
+ActiveRecord::Schema.define(version: 20150602112246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 20150514094454) do
     t.datetime "updated_at"
     t.integer  "course_module_jumbo_quiz_id"
     t.boolean  "is_jumbo_quiz",               default: false, null: false
+    t.integer  "seconds_watched",             default: 0
   end
 
   add_index "course_module_element_user_logs", ["corporate_customer_id"], name: "cme_user_logs_corporate_customer_id", using: :btree

--- a/spec/factories/course_module_element_user_logs.rb
+++ b/spec/factories/course_module_element_user_logs.rb
@@ -19,6 +19,7 @@
 #  updated_at                  :datetime
 #  course_module_jumbo_quiz_id :integer
 #  is_jumbo_quiz               :boolean          default(FALSE), not null
+#  seconds_watched             :integer          default(0)
 #
 
 FactoryGirl.define do

--- a/spec/models/course_module_element_user_log_spec.rb
+++ b/spec/models/course_module_element_user_log_spec.rb
@@ -19,6 +19,7 @@
 #  updated_at                  :datetime
 #  course_module_jumbo_quiz_id :integer
 #  is_jumbo_quiz               :boolean          default(FALSE), not null
+#  seconds_watched             :integer          default(0)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
Whenever student finishes watching video or leaves page total number of
seconds is watched to the server. On the server side we updating seconds
watched value and marking element as complete. If user does not leave
the page and replays video new seconds watched value is added to the
existing one.
