### PR TITLE
A way to get user's real IP address

### DIFF
--- a/app/views/home_pages/_sign_up_form.html.haml
+++ b/app/views/home_pages/_sign_up_form.html.haml
@@ -1,8 +1,7 @@
 .text-left=render partial: 'layouts/error_messages', locals: {thing: @user, message: t('views.home_pages.sign_up_form.error_panel_caption')}
 =form_for @user, url: student_sign_up_url do |f|
   =f.hidden_field :locale, value: (params[:locale] || 'en')
-  -#=f.hidden_field :country_id, value: @user.country_id
-  =f.hidden_field :country_id, value: 236
+  =f.hidden_field :country_id, value: @user.country_id
   .form-group
     =f.text_field :first_name, placeholder: t('views.users.form.first_name'), required: true, class: 'form-control'
   .form-group

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,6 +103,8 @@ Rails.application.configure do
   }
 
   config.exceptions_app = self.routes
+  config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES +
+                                           ENV['aws_load_balancers'].split(',').map { |alp| IPAddr.new(ip) }
 end
 
 # Required by LogEntries

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -111,6 +111,8 @@ Rails.application.configure do
   }
 
   config.exceptions_app = self.routes
+  config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES +
+                                           ENV['aws_load_balancers'].split(',').map { |alp| IPAddr.new(ip) }
 end
 
 # Required by LogEntries

--- a/config/sample_application.yml
+++ b/config/sample_application.yml
@@ -29,3 +29,27 @@ mixpanel_key: mixpanel_api_key_goes_here
 
 # Mandrill
 learnsignal_mandrill_api_key: mandrill_api_key_goes_here
+
+# AWS Load Balancers
+# For each configuration we have to list all load balancer IPs in
+# order to get real request IP. Namely ActionDispatch::RemoteIp
+# middleware removes all IPs from ActionDispatch::RemoteIp::TRUSTED_PROXIES
+# leaving real request IP. If AWS load balancers are not added to
+# this array instead of user's IP address we will get load balancer's
+# IP addres.
+#
+# Format of values listed here are IP addresses (optionally with network
+# prefix length) separated by commas. In environemnts/<configuration>.rb
+# file we split this value on comma char and add each address is added to
+# the array of TRUSTED_PROXIES.
+#
+# Sample of value (first address is given with network prefix length 20,
+# and second is single IP).
+#
+# 172.31.0.0/20,54.154.194.123
+#
+# Configured value for load balancer's IP address with network
+# prefix length for can be seen from Availability Zones list
+# for each load balancer in AWS console (go to Load Balancers, select
+# load balancer and in bottom table all availability zones are listed).
+aws_load_balancers: aws_load_balancers_ips_go_here


### PR DESCRIPTION
For each configuration we have to list all load balancer IPs in
order to get real request IP. Namely ActionDispatch::RemoteIp
middleware removes all IPs from ActionDispatch::RemoteIp::TRUSTED_PROXIES
leaving real request IP. If AWS load balancers are not added to
this array instead of user's IP address we will get load balancer's
IP addres.

Format of values listed here are IP addresses (optionally with network
prefix length) separated by commas. In environemnts/<configuration>.rb
file we split this value on comma char and add each address is added to
the array of TRUSTED_PROXIES.

Sample of value (first address is given with network prefix length 20,
and second is single IP).

172.31.0.0/20,54.154.194.123

Configured value for load balancer's IP address with network
prefix length for can be seen from Availability Zones list
for each load balancer in AWS console (go to Load Balancers, select
load balancer and in bottom table all availability zones are listed).
