### PR TITLE
Elasticbeanstalk

### DIFF
--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -186,7 +186,7 @@ class StudentSignUpsController < ApplicationController
         :email, :first_name, :last_name,
         :country_id, :locale,
         :password, :password_confirmation,
-        :topic_interest, :terms_and_conditions,
+        :terms_and_conditions,
         :communication_approval
     )
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 class UsersController < ApplicationController

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -83,10 +83,8 @@ class Subscription < ActiveRecord::Base
       if response[:status] == 'active' && response[:cancel_at_period_end] == true
         self.update_attribute(:current_status, 'canceled-pending')
       elsif response[:status] == 'past_due'
-        self.update_attribute(:current_status, 'canceled')
-        self.user.student_access.update_attributes(content_access: false)
-        #We don't send any email here!!
-        Rails.logger.error "ERROR: Subscription#cancel with a past_due status updated local sub from past_due to canceled StripeResponse:#{response}."
+        self.update_attribute(:current_status, 'canceled-pending')
+        Rails.logger.error "ERROR: Subscription#cancel with a past_due status updated local sub from past_due to canceled-pending StripeResponse:#{response}."
       else
         Rails.logger.error "ERROR: Subscription#cancel failed to cancel an 'active' sub. Self:#{self}. StripeResponse:#{response}."
         errors.add(:base, I18n.t('models.subscriptions.upgrade_plan.processing_error_at_stripe'))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 class User < ActiveRecord::Base
@@ -77,14 +70,11 @@ class User < ActiveRecord::Base
                   :stripe_customer_id, :password, :password_confirmation,
                   :current_password, :locale, :subscriptions_attributes,
                   :password_change_required, :address,
-                  :profile_image, :topic_interest,
-                  :email_verification_code, :email_verified_at,
+                  :profile_image, :email_verification_code, :email_verified_at,
                   :email_verified, :account_activated_at,
                   :account_activation_code, :session_key,
-                  :stripe_account_balance, :trial_limit_in_seconds,
-                  :free_trial, :trial_limit_in_days,
-                  :trial_ended_notification_sent_at, :terms_and_conditions,
-                  :date_of_birth, :description, :free_trial_ended_at,
+                  :stripe_account_balance, :free_trial,
+                  :terms_and_conditions, :date_of_birth, :description,
                   :student_number, :student_access_attributes,
                   :unsubscribed_from_emails, :communication_approval_datetime,
                   :communication_approval
@@ -102,7 +92,6 @@ class User < ActiveRecord::Base
            class_name: 'CourseModuleElementUserLog'
   has_many :course_tutor_details
   has_many :enrollments
-  has_and_belongs_to_many :subject_courses
   has_many :invoices
   has_many :quiz_attempts
   has_many :orders
@@ -154,7 +143,6 @@ class User < ActiveRecord::Base
   scope :this_week, -> { where(created_at: Time.now.beginning_of_week..Time.now.end_of_week) }
   scope :active_this_week, -> { where(last_request_at: Time.now.beginning_of_week..Time.now.end_of_week) }
   scope :with_course_tutor_details, -> { joins(:course_tutor_details) }
-  scope :all_free_trial, -> { where(free_trial: true).where("trial_limit_in_seconds <= #{ENV['FREE_TRIAL_LIMIT_IN_SECONDS'].to_i}") }
 
   def date_of_birth_is_possible?
     return if self.date_of_birth.blank?
@@ -294,35 +282,6 @@ class User < ActiveRecord::Base
   end
 
 
-  def days_or_seconds_valid?
-    if free_trial_days_valid? && free_trial_minutes_valid?
-      true
-    else
-      false
-    end
-  end
-
-  def free_trial_days_valid?
-    # 86400 is number of seconds in a day
-    trial_limit_days_in_seconds = self.trial_limit_in_days * 86400
-    current_date_time = Proc.new { Time.now }.call
-    trial_start_date = self.email_verified_at || self.created_at
-
-    if  current_date_time <= (trial_start_date + trial_limit_days_in_seconds)
-      true
-    else
-      false
-    end
-  end
-
-  def free_trial_minutes_valid?
-    #If the Number of seconds watched is less than the allowed free trial time limit then permission is allowed
-    if self.trial_limit_in_seconds <= ENV['FREE_TRIAL_LIMIT_IN_SECONDS'].to_i
-      true
-    else
-      false
-    end
-  end
 
   ### instance methods
 
@@ -870,8 +829,10 @@ class User < ActiveRecord::Base
       #Callbacks should create SubscriptionTransactions and SubscriptionPaymentCard
 
       if subscription_saved
-        trial_ended_date = self.free_trial_ended_at ? self.free_trial_ended_at : Proc.new{Time.now}.call
-        self.update_attributes(free_trial: false, free_trial_ended_at: trial_ended_date)
+        time_now = Proc.new{Time.now.to_datetime}.call
+        self.student_access.update_attributes(trial_ended_date: time_now, content_access: true,
+                                              subscription_id: subscription_saved.id,
+                                              account_type: 'Subscription')
       end
     end
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1368,7 +1368,6 @@ en:
         email_placeholder: user@example.com
         phone_number: Phone Number
         interest: Topic
-        topic_interest: Select the topic you are interested in..
         phone_number_placeholder: Phone Number
         first_name: First Name
         your_first_name: Your first name

--- a/db/migrate/20180906115844_remove_subject_courses_users_table.rb
+++ b/db/migrate/20180906115844_remove_subject_courses_users_table.rb
@@ -1,0 +1,12 @@
+class RemoveSubjectCoursesUsersTable < ActiveRecord::Migration
+  def change
+    drop_table :subject_courses_users
+    remove_column :users, :trial_ended_notification_sent_at, :datetime
+    remove_column :users, :crush_offers_session_id, :string
+    remove_column :users, :topic_interest, :string
+    remove_column :users, :trial_limit_in_seconds, :integer
+    remove_column :users, :trial_limit_in_days, :integer
+    remove_column :users, :free_trial_ended_at, :datetime
+    remove_column :users, :discourse_user, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180823122311) do
+ActiveRecord::Schema.define(version: 20180906115844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -957,14 +957,6 @@ ActiveRecord::Schema.define(version: 20180823122311) do
 
   add_index "subject_courses", ["name"], name: "index_subject_courses_on_name", using: :btree
 
-  create_table "subject_courses_users", id: false, force: :cascade do |t|
-    t.integer "subject_course_id", null: false
-    t.integer "user_id",           null: false
-  end
-
-  add_index "subject_courses_users", ["subject_course_id"], name: "index_subject_courses_users_on_subject_course_id", using: :btree
-  add_index "subject_courses_users", ["user_id"], name: "index_subject_courses_users_on_user_id", using: :btree
-
   create_table "subscription_payment_cards", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "stripe_card_guid"
@@ -1140,13 +1132,13 @@ ActiveRecord::Schema.define(version: 20180823122311) do
     t.string   "last_name"
     t.text     "address"
     t.integer  "country_id"
-    t.string   "crypted_password",                 limit: 128, default: "",    null: false
-    t.string   "password_salt",                    limit: 128, default: "",    null: false
+    t.string   "crypted_password",                limit: 128, default: "",    null: false
+    t.string   "password_salt",                   limit: 128, default: "",    null: false
     t.string   "persistence_token"
-    t.string   "perishable_token",                 limit: 128
+    t.string   "perishable_token",                limit: 128
     t.string   "single_access_token"
-    t.integer  "login_count",                                  default: 0
-    t.integer  "failed_login_count",                           default: 0
+    t.integer  "login_count",                                 default: 0
+    t.integer  "failed_login_count",                          default: 0
     t.datetime "last_request_at"
     t.datetime "current_login_at"
     t.datetime "last_login_at"
@@ -1154,7 +1146,7 @@ ActiveRecord::Schema.define(version: 20180823122311) do
     t.string   "last_login_ip"
     t.string   "account_activation_code"
     t.datetime "account_activated_at"
-    t.boolean  "active",                                       default: false, null: false
+    t.boolean  "active",                                      default: false, null: false
     t.integer  "user_group_id"
     t.datetime "password_reset_requested_at"
     t.string   "password_reset_token"
@@ -1164,8 +1156,6 @@ ActiveRecord::Schema.define(version: 20180823122311) do
     t.datetime "updated_at"
     t.string   "locale"
     t.string   "guid"
-    t.datetime "trial_ended_notification_sent_at"
-    t.string   "crush_offers_session_id"
     t.integer  "subscription_plan_category_id"
     t.boolean  "password_change_required"
     t.string   "session_key"
@@ -1174,23 +1164,18 @@ ActiveRecord::Schema.define(version: 20180823122311) do
     t.string   "profile_image_content_type"
     t.integer  "profile_image_file_size"
     t.datetime "profile_image_updated_at"
-    t.string   "topic_interest"
     t.string   "email_verification_code"
     t.datetime "email_verified_at"
-    t.boolean  "email_verified",                               default: false, null: false
-    t.integer  "stripe_account_balance",                       default: 0
-    t.integer  "trial_limit_in_seconds",                       default: 0
-    t.boolean  "free_trial",                                   default: false
-    t.integer  "trial_limit_in_days",                          default: 0
-    t.boolean  "terms_and_conditions",                         default: false
-    t.boolean  "discourse_user",                               default: false
+    t.boolean  "email_verified",                              default: false, null: false
+    t.integer  "stripe_account_balance",                      default: 0
+    t.boolean  "free_trial",                                  default: false
+    t.boolean  "terms_and_conditions",                        default: false
     t.date     "date_of_birth"
     t.text     "description"
-    t.datetime "free_trial_ended_at"
     t.string   "analytics_guid"
     t.string   "student_number"
-    t.boolean  "unsubscribed_from_emails",                     default: false
-    t.boolean  "communication_approval",                       default: false
+    t.boolean  "unsubscribed_from_emails",                    default: false
+    t.boolean  "communication_approval",                      default: false
     t.datetime "communication_approval_datetime"
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 require 'rails_helper'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 FactoryBot.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 require 'rails_helper'
@@ -67,7 +60,7 @@ require 'rails_helper'
 describe User do
 
   # attr-accessible
-  black_list = %w(id created_at updated_at crypted_password password_salt persistence_token perishable_token single_access_token login_count failed_login_count last_request_at current_login_at last_login_at current_login_ip last_login_ip guid crush_offers_session_id subscription_plan_category_id profile_image_updated_at profile_image_file_size profile_image_content_type profile_image_file_name phone_number name_url analytics_guid discourse_user)
+  black_list = %w(id created_at updated_at crypted_password password_salt persistence_token perishable_token single_access_token login_count failed_login_count last_request_at current_login_at last_login_at current_login_ip last_login_ip guid subscription_plan_category_id profile_image_updated_at profile_image_file_size profile_image_content_type profile_image_file_name phone_number name_url analytics_guid)
 
   User.column_names.each do |column_name|
     if black_list.include?(column_name)
@@ -114,7 +107,6 @@ describe User do
   it { should validate_presence_of(:last_name) }
   it { should validate_length_of(:last_name).is_at_least(2).is_at_most(30) }
 
-  it { should_not validate_presence_of(:topic_interest) }
 
   it { should validate_presence_of(:password).on(:create) }
   it { should validate_confirmation_of(:password).on(:create) }
@@ -151,7 +143,6 @@ describe User do
   it { expect(User).to respond_to(:this_month) }
   it { expect(User).to respond_to(:this_week) }
   it { expect(User).to respond_to(:active_this_week) }
-  it { expect(User).to respond_to(:all_free_trial) }
 
   # class methods
   it { expect(User).to respond_to(:all_students) }

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -2,64 +2,57 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  email                            :string
-#  first_name                       :string
-#  last_name                        :string
-#  address                          :text
-#  country_id                       :integer
-#  crypted_password                 :string(128)      default(""), not null
-#  password_salt                    :string(128)      default(""), not null
-#  persistence_token                :string
-#  perishable_token                 :string(128)
-#  single_access_token              :string
-#  login_count                      :integer          default(0)
-#  failed_login_count               :integer          default(0)
-#  last_request_at                  :datetime
-#  current_login_at                 :datetime
-#  last_login_at                    :datetime
-#  current_login_ip                 :string
-#  last_login_ip                    :string
-#  account_activation_code          :string
-#  account_activated_at             :datetime
-#  active                           :boolean          default(FALSE), not null
-#  user_group_id                    :integer
-#  password_reset_requested_at      :datetime
-#  password_reset_token             :string
-#  password_reset_at                :datetime
-#  stripe_customer_id               :string
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  locale                           :string
-#  guid                             :string
-#  trial_ended_notification_sent_at :datetime
-#  crush_offers_session_id          :string
-#  subscription_plan_category_id    :integer
-#  password_change_required         :boolean
-#  session_key                      :string
-#  name_url                         :string
-#  profile_image_file_name          :string
-#  profile_image_content_type       :string
-#  profile_image_file_size          :integer
-#  profile_image_updated_at         :datetime
-#  topic_interest                   :string
-#  email_verification_code          :string
-#  email_verified_at                :datetime
-#  email_verified                   :boolean          default(FALSE), not null
-#  stripe_account_balance           :integer          default(0)
-#  trial_limit_in_seconds           :integer          default(0)
-#  free_trial                       :boolean          default(FALSE)
-#  trial_limit_in_days              :integer          default(0)
-#  terms_and_conditions             :boolean          default(FALSE)
-#  discourse_user                   :boolean          default(FALSE)
-#  date_of_birth                    :date
-#  description                      :text
-#  free_trial_ended_at              :datetime
-#  analytics_guid                   :string
-#  student_number                   :string
-#  unsubscribed_from_emails         :boolean          default(FALSE)
-#  communication_approval           :boolean          default(FALSE)
-#  communication_approval_datetime  :datetime
+#  id                              :integer          not null, primary key
+#  email                           :string
+#  first_name                      :string
+#  last_name                       :string
+#  address                         :text
+#  country_id                      :integer
+#  crypted_password                :string(128)      default(""), not null
+#  password_salt                   :string(128)      default(""), not null
+#  persistence_token               :string
+#  perishable_token                :string(128)
+#  single_access_token             :string
+#  login_count                     :integer          default(0)
+#  failed_login_count              :integer          default(0)
+#  last_request_at                 :datetime
+#  current_login_at                :datetime
+#  last_login_at                   :datetime
+#  current_login_ip                :string
+#  last_login_ip                   :string
+#  account_activation_code         :string
+#  account_activated_at            :datetime
+#  active                          :boolean          default(FALSE), not null
+#  user_group_id                   :integer
+#  password_reset_requested_at     :datetime
+#  password_reset_token            :string
+#  password_reset_at               :datetime
+#  stripe_customer_id              :string
+#  created_at                      :datetime
+#  updated_at                      :datetime
+#  locale                          :string
+#  guid                            :string
+#  subscription_plan_category_id   :integer
+#  password_change_required        :boolean
+#  session_key                     :string
+#  name_url                        :string
+#  profile_image_file_name         :string
+#  profile_image_content_type      :string
+#  profile_image_file_size         :integer
+#  profile_image_updated_at        :datetime
+#  email_verification_code         :string
+#  email_verified_at               :datetime
+#  email_verified                  :boolean          default(FALSE), not null
+#  stripe_account_balance          :integer          default(0)
+#  free_trial                      :boolean          default(FALSE)
+#  terms_and_conditions            :boolean          default(FALSE)
+#  date_of_birth                   :date
+#  description                     :text
+#  analytics_guid                  :string
+#  student_number                  :string
+#  unsubscribed_from_emails        :boolean          default(FALSE)
+#  communication_approval          :boolean          default(FALSE)
+#  communication_approval_datetime :datetime
 #
 
 require 'rails_helper'


### PR DESCRIPTION
Remove HABTM user - subject course relationship as it's replaced by new course_tutor_details link model. Also cleaned up the User model - removed old trial attributes as these are now stored in the StudentAccess model. Fixed issue with past_due subscriptions being set to canceled instead of canceled-pending.