### PR TITLE
Removing ability for users to pause their subscriptions

### DIFF
--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -74,10 +74,7 @@
                 %div
                   -if subscription.can_change_plan?
                     =link_to 'Change Subscription Plan', new_subscriptions_plan_change_path(id: subscription.id), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
-                  -#if subscription.active?
-                    %button.btn.btn-secondary.btn-xs.mb-2{id: 'confirmPauseBtn', "data-target" => "#confirm-pause-modal", "data-toggle" => "modal", "data-sub" => subscription.id}
-                      Pause Subscription
-                  -#elsif subscription.paused?
+                  -if subscription.paused?
                     =link_to 'Reactivate Subscription', subscriptions_suspension_path(id: subscription.id), method: :delete, class: 'btn btn-secondary btn-xs', style: 'vertical-align: top;'
                   =link_to 'Cancel Subscription', new_subscriptions_cancellation_path(id: subscription.id), class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
 


### PR DESCRIPTION
I'm still allowing users who are paused to come out of the `paused` state (i.e. reactivate). But subscribed users can no longer pause a subscription.