### PR TITLE
Fix prawn name encoding

### DIFF
--- a/app/pdfs/invoice_document.rb
+++ b/app/pdfs/invoice_document.rb
@@ -2,7 +2,6 @@ class InvoiceDocument < Prawn::Document
 
   def initialize(inv, view, description, vat_rate, invoice_date)
     #super()
-    @text_name = 'Piątek'
     super(top_margin: 70)
     @invoice = inv
     @view = view


### PR DESCRIPTION
Fixes issues around encoding UTF-8 chartacters. 

The fix involves setting the explicitly setting the font to a TrueType font before rendering the text. 