### PR TITLE
FIX: Missed paypal webhooks

### DIFF
--- a/lib/tasks/requery_paypal_webhooks.rake
+++ b/lib/tasks/requery_paypal_webhooks.rake
@@ -1,13 +1,35 @@
 namespace :paypal do
-  desc 'Looking for missed paypal webhooks'
+  desc 'Looking for missed paypal subscription cancelled webhooks'
   task :requery_cancellation_webhooks => :environment do
     include PayPal::SDK::REST
-    puts 'Running command to find missed webhooks'
+    puts 'Running command to find missed subscription cancelled webhooks'
     hooks = WebhookEvent.all(
       page_size: 500,
       start_time: "2019-03-04T00:00:00Z",
       end_time: "2019-03-21T00:00:00Z",
       event_type: "BILLING.SUBSCRIPTION.CANCELLED"
+    )
+    hooks.events.each do |event|
+      unless PaypalWebhook.find_by(guid: event.id)
+        hook_service = PaypalWebhookService.new
+        if hook_service.record_webhook(JSON.parse(event.to_json))
+          hook_service.process_webhook
+        else
+          puts "Unable to process #{event.id}"
+        end
+      end
+    end
+  end
+
+  desc 'Looking for missed paypal payment succeeded webhooks'
+  task :requery_sale_completed_webhooks => :environment do
+    include PayPal::SDK::REST
+    puts 'Running command to find missed sale completed webhooks'
+    hooks = WebhookEvent.all(
+      page_size: 500,
+      start_time: "2019-03-04T00:00:00Z",
+      end_time: "2019-03-21T00:00:00Z",
+      event_type: "PAYMENT.SALE.COMPLETED"
     )
     hooks.events.each do |event|
       unless PaypalWebhook.find_by(guid: event.id)


### PR DESCRIPTION
This is a script to query for missed PayPal Webhooks within a certain time window. There are two tasks:
1. Subscription cancellation webhooks. This is important when the user cancels their subscription on the PayPal side. We need to know to cancel their subscription on our end.
2. Payment successful webhooks. This is for creating invoices for users.

I have run this in production over the time period of March 4th - 21st, which was when we seemed to miss a lot of webhooks from PayPal. This PR is purely to have the script available for future use.

https://learnsignal-team.monday.com/boards/224818924/pulses/260555480