### PR TITLE
FIX: SubscriptionPlanWorker failure error

### DIFF
--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -185,7 +185,12 @@ class SubscriptionPlan < ActiveRecord::Base
   end
 
   def delete_remote_plans
-    SubscriptionPlanService.new(self).queue_async(:delete)
+    SubscriptionPlanWorker.perform_async(
+      self.id,
+      :delete,
+      self.stripe_guid,
+      self.paypal_guid
+    )
   end
 
   def update_remote_plans

--- a/app/services/subscription_plan_service.rb
+++ b/app/services/subscription_plan_service.rb
@@ -18,8 +18,6 @@ class SubscriptionPlanService
       create_remote_plans
     when :update
       update_remote_plans
-    when :delete
-      delete_remote_plans
     end
   end
 
@@ -33,10 +31,5 @@ class SubscriptionPlanService
   def update_remote_plans
     StripeService.new.update_plan(@plan)
     PaypalPlansService.new.update_plan(@plan)
-  end
-
-  def delete_remote_plans
-    StripeService.new.delete_plan(@plan.stripe_guid)
-    PaypalPlansService.new.delete_plan(@plan.paypal_guid)
   end
 end

--- a/app/workers/subscription_plan_worker.rb
+++ b/app/workers/subscription_plan_worker.rb
@@ -3,8 +3,13 @@ class SubscriptionPlanWorker
 
   sidekiq_options queue: 'high'
 
-  def perform(subscription_plan_id, action)
-    plan = SubscriptionPlan.find(subscription_plan_id)
-    SubscriptionPlanService.new(plan).async_action(action)
+  def perform(subscription_plan_id, action, stripe_guid=nil, paypal_guid=nil)
+    if action == 'delete'
+      StripeService.new.delete_plan(stripe_guid)
+      PaypalPlansService.new.delete_plan(paypal_guid)
+    else
+      plan = SubscriptionPlan.find(subscription_plan_id)
+      SubscriptionPlanService.new(plan).async_action(action)
+    end
   end
 end

--- a/spec/controllers/subscription_plans_controller_spec.rb
+++ b/spec/controllers/subscription_plans_controller_spec.rb
@@ -148,6 +148,9 @@ describe SubscriptionPlansController, type: :controller do
       end
 
       it 'should be OK as no dependencies exist' do
+        allow_any_instance_of(SubscriptionPlan).to(
+          receive(:delete_remote_plans).and_return(true)
+        )
         delete :destroy, params: { id: subscription_plan_gbp_q.id }
         expect_delete_success_with_model('subscription_plan', subscription_plans_url)
       end

--- a/spec/models/subscription_plan_spec.rb
+++ b/spec/models/subscription_plan_spec.rb
@@ -87,6 +87,29 @@ describe SubscriptionPlan do
     it { expect(SubscriptionPlan).to respond_to(:in_currency) }
   end
 
+  describe 'deletion' do
+    let(:test_plan) { create(:subscription_plan) }
+
+    before :each do
+      allow_any_instance_of(SubscriptionPlanService).to(
+        receive(:queue_async)
+      )
+    end
+
+    it 'calls the SubscriptionPlanWorker with the correct attributes' do
+      expect(SubscriptionPlanWorker).to(
+        receive(:perform_async).with(
+          test_plan.id,
+          :delete,
+          test_plan.stripe_guid,
+          test_plan.paypal_guid
+        )
+      )
+
+      test_plan.destroy
+    end
+  end
+
   describe 'instance methods' do
     let(:subscription_plan) { build_stubbed(:subscription_plan) }
     it { should respond_to(:destroyable?) }

--- a/spec/services/subscription_plan_service_spec.rb
+++ b/spec/services/subscription_plan_service_spec.rb
@@ -27,12 +27,6 @@ describe SubscriptionPlanService, type: :service do
       sub_plan_service.async_action(:update)
     end
 
-    it 'calls #delete_remote_plans when :delete is passed in' do
-      expect(sub_plan_service).to receive(:delete_remote_plans)
-
-      sub_plan_service.async_action(:delete)
-    end
-
     it 'can handle a string being passed in as a string' do
       expect(sub_plan_service).to receive(:create_remote_plans)
 
@@ -77,25 +71,6 @@ describe SubscriptionPlanService, type: :service do
       expect_any_instance_of(PaypalPlansService).to receive(:update_plan)
 
       sub_plan_service.send(:update_remote_plans)
-    end
-  end
-
-  describe '#delete_remote_plans' do
-    before :each do
-      allow_any_instance_of(StripeService).to receive(:delete_plan)
-      allow_any_instance_of(PaypalPlansService).to receive(:delete_plan)
-    end
-
-    it 'calls #delete_plan on an instance of StripeService' do
-      expect_any_instance_of(StripeService).to receive(:delete_plan)
-
-      sub_plan_service.send(:delete_remote_plans)
-    end
-
-    it 'calls #delete_plan on an instance of PaypalPlansService' do
-      expect_any_instance_of(PaypalPlansService).to receive(:delete_plan)
-
-      sub_plan_service.send(:delete_remote_plans)
     end
   end
 end


### PR DESCRIPTION
Handling the cleanup of Stripe and Paypal plans after a plan is deleted on learnsignal.

*FIX: SubscriptionPlanWorker fails when deleting a subscription plan because there is no plan to reference
*Fix for controller spec broken by changes.
*Specs covering the calling of the stripe and paypal deletion of plans after a subscription_plan is destroyed.