### PR TITLE
FIX: User account should show the last cancelled subscription

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: invoices
@@ -35,6 +34,7 @@
 #  tax                         :decimal(, )
 #  original_stripe_data        :text
 #  paypal_payment_guid         :string
+#  order_id                    :bigint(8)
 #
 
 class Invoice < ApplicationRecord

--- a/app/models/mock_exam.rb
+++ b/app/models/mock_exam.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: mock_exams
 #
 #  id                       :integer          not null, primary key
 #  subject_course_id        :integer
-#  product_id               :integer
 #  name                     :string
 #  sorting_order            :integer
 #  created_at               :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -445,11 +445,10 @@ class User < ApplicationRecord
   def viewable_subscriptions
     subs = []
     ExamBody.where(active: true).each do |body|
-      compliant_subs = subscriptions.for_exam_body(body.id)
-                                    .with_states(
-                                      :active, :paused, :errored,
-                                      :pending_cancellation
-                                    ).order(created_at: :desc)
+      compliant_subs = subscriptions.
+                       for_exam_body(body.id).
+                       where.not(state: :pending).
+                       order(created_at: :desc)
       if compliant_subs.any?
         subs << compliant_subs.first
       end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -33,6 +33,7 @@
 #  tax                         :decimal(, )
 #  original_stripe_data        :text
 #  paypal_payment_guid         :string
+#  order_id                    :bigint(8)
 #
 
 FactoryBot.define do

--- a/spec/factories/mock_exams.rb
+++ b/spec/factories/mock_exams.rb
@@ -4,7 +4,6 @@
 #
 #  id                       :integer          not null, primary key
 #  subject_course_id        :integer
-#  product_id               :integer
 #  name                     :string
 #  sorting_order            :integer
 #  created_at               :datetime         not null

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -33,6 +33,7 @@
 #  tax                         :decimal(, )
 #  original_stripe_data        :text
 #  paypal_payment_guid         :string
+#  order_id                    :bigint(8)
 #
 
 require 'rails_helper'

--- a/spec/models/mock_exam_spec.rb
+++ b/spec/models/mock_exam_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                       :integer          not null, primary key
 #  subject_course_id        :integer
-#  product_id               :integer
 #  name                     :string
 #  sorting_order            :integer
 #  created_at               :datetime         not null


### PR DESCRIPTION
Handles the case where the user's most recent subscription for an exam body is now cancelled.

- Specs covering the `viewable_subscriptions` method.
- Annotated some models that were missing updated schema annotations