### PR TITLE
Products filters.

### DIFF
--- a/.robocop.yml
+++ b/.robocop.yml
@@ -1,1 +1,0 @@
-require: rubocop-rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Layout/EndOfLine:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
 Metrics/LineLength:
   Enabled: false
 

--- a/app/controllers/admin/exercises_controller.rb
+++ b/app/controllers/admin/exercises_controller.rb
@@ -1,53 +1,65 @@
-class Admin::ExercisesController < ApplicationController
-  before_action :logged_in_required
-  before_action do
-    ensure_user_has_access_rights(%w(exercise_corrections_access))
-  end
-  before_action :set_exercise, except: :index
+# frozen_string_literal: true
 
-  layout 'management'
+module Admin
+  class ExercisesController < ApplicationController
+    before_action :logged_in_required
+    before_action do
+      ensure_user_has_access_rights(%w[exercise_corrections_access])
+    end
+    before_action :set_exercise, except: :index
 
-  def index
-    if request.post?
-      @filters = params.slice(:state, :product, :corrector, :search)
-      @exercises = Exercise.filter(@filters)
-      case params[:state]
-      when 'returned', 'all'
-        @exercises = @exercises.order(created_at: :desc)
-      else
-        @exercises = @exercises.order(created_at: :asc)
-      end
-      @exercises = @exercises.paginate(per_page: 50, page: params[:page])
-    else
+    layout 'management'
+
+    def index
       @filters = { state: 'submitted', product: '', corrector: '', search: '' }
-      @exercises = Exercise.with_state(:submitted).
-                            order(created_at: :asc).
-                            paginate(per_page: 50, page: params[:page])
+
+      if request.post?
+        @exercises = Exercise.where(nil)
+
+        filtering_params(params).each do |key, value|
+          @exercises = @exercises.public_send(key, value) if value.present?
+          @filters[key] = value
+        end
+
+        case params[:state]
+        when 'returned', 'all'
+          @exercises = @exercises.order(created_at: :desc)
+        else
+          @exercises = @exercises.order(created_at: :asc)
+        end
+        @exercises = @exercises.paginate(per_page: 50, page: params[:page])
+      else
+        @exercises = Exercise.with_state(:submitted).
+                       order(created_at: :asc).
+                       paginate(per_page: 50, page: params[:page])
+      end
     end
-  end
 
-  def show
-  end
+    def show; end
 
-  def edit
-  end
+    def edit; end
 
-  def update
-    if @exercise.update(exercise_params)
-      @exercise.return if @exercise.correction.present? && @exercise.correcting?
-      redirect_to admin_exercises_path, notice: I18n.t('controllers.exercises.update.flash.success')
-    else
-      render action: :edit
+    def update
+      if @exercise.update(exercise_params)
+        @exercise.return if @exercise.correction.present? && @exercise.correcting?
+        redirect_to admin_exercises_path, notice: I18n.t('controllers.exercises.update.flash.success')
+      else
+        render action: :edit
+      end
     end
-  end
 
-  private
+    private
 
-  def set_exercise
-    @exercise = Exercise.find(params[:id])
-  end
+    def filtering_params(params)
+      params.slice(:state, :product, :corrector, :search)
+    end
 
-  def exercise_params
-    params.require(:exercise).permit(:correction, :corrector_id)
+    def set_exercise
+      @exercise = Exercise.find(params[:id])
+    end
+
+    def exercise_params
+      params.require(:exercise).permit(:correction, :corrector_id)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
-# coding: utf-8
 require 'mailchimp'
 require 'prawn'
 require 'mandrill'
 require 'csv'
+require 'will_paginate/array'
 
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
@@ -17,30 +17,32 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user_session, :current_user
 
-  Time::DATE_FORMATS[:simple] = I18n.t('controllers.application.datetime_formats.simple')
+  Time::DATE_FORMATS[:simple]   = I18n.t('controllers.application.datetime_formats.simple')
   Time::DATE_FORMATS[:standard] = I18n.t('controllers.application.datetime_formats.standard')
-  Date::DATE_FORMATS[:simple] = I18n.t('controllers.application.date_formats.simple')
+  Date::DATE_FORMATS[:simple]   = I18n.t('controllers.application.date_formats.simple')
   Date::DATE_FORMATS[:standard] = I18n.t('controllers.application.date_formats.standard')
 
-  EXCLUDED_CONTROLLERS = %w(orders subscriptions)
+  EXCLUDED_CONTROLLERS = %w[orders subscriptions].freeze
 
   ### User access control and authentication
 
   def current_user_session
     return @current_user_session if defined?(@current_user_session)
+
     @current_user_session = UserSession.find
   end
 
   def current_user
     return @current_user if defined?(@current_user)
-    @current_user = current_user_session && current_user_session.record
+
+    @current_user = current_user_session&.record
   end
 
   def set_current_visit
-    if current_visit && !current_visit.user
-      current_visit.user = current_user
-      current_visit.save!
-    end
+    return unless current_visit && !current_visit.user
+
+    current_visit.user = current_user
+    current_visit.save!
   end
 
   def set_layout_variables
@@ -52,27 +54,26 @@ class ApplicationController < ActionController::Base
     @footer_content_pages = ContentPage.for_footer
     @footer_landing_pages = HomePage.for_footer
 
-    if ExternalBanner::BANNER_CONTROLLERS.include?(controller_name)
-      @banner = ExternalBanner.all_without_parent.render_for(controller_name).all_in_order.first
-    end
+    return if ExternalBanner::BANNER_CONTROLLERS.exclude?(controller_name)
 
+    @banner = ExternalBanner.all_without_parent.render_for(controller_name).all_in_order.first
   end
 
   def logged_in_required
-    unless current_user
-      session[:return_to] = request.original_url
-      flash[:error] = I18n.t('controllers.application.logged_in_required.flash_error')
-      redirect_to sign_in_url
-      false
-    end
+    return if current_user
+
+    session[:return_to] = request.original_url
+    flash[:error] = I18n.t('controllers.application.logged_in_required.flash_error')
+    redirect_to sign_in_url
+    false
   end
 
   def logged_out_required
-    if current_user
-      flash[:error] = I18n.t('controllers.application.logged_out_required.flash_error')
-      redirect_to root_url
-      false
-    end
+    return unless current_user
+
+    flash[:error] = I18n.t('controllers.application.logged_out_required.flash_error')
+    redirect_to root_url
+    false
   end
 
   def store_location
@@ -80,13 +81,9 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_back_or_default(default)
-    if session[:return_to]
-      destination = session[:return_to]
-      session[:return_to] = nil
-    else
-      destination = default
-      session[:return_to] = nil
-    end
+    destination = session[:return_to] || default
+    session[:return_to] = nil
+
     redirect_to(destination, flash: { just_signed_in: true })
   end
 
@@ -108,26 +105,27 @@ class ApplicationController < ActionController::Base
         permission_granted = true
       end
     end
-    unless permission_granted
-      flash[:error] = I18n.t('controllers.application.you_are_not_permitted_to_do_that')
-      redirect_to root_url
-      false
-    end
+
+    return if permission_granted
+
+    flash[:error] = I18n.t('controllers.application.you_are_not_permitted_to_do_that')
+    redirect_to root_url
+    false
   end
   helper_method :ensure_user_has_access_rights
 
   def authenticate_if_staging
-    if Rails.env.staging? && !%w(stripe_v02 paypal_webhooks).include?(controller_name)
-      authenticate_or_request_with_http_basic 'Staging' do |name, password|
-        name == 'signal' && password == '27(South!)'
-      end
+    return unless Rails.env.staging? && %w[stripe_v02 paypal_webhooks].exclude?(controller_name)
+
+    authenticate_or_request_with_http_basic 'Staging' do |name, password|
+      name == 'signal' && password == '27(South!)'
     end
   end
 
   def authorize_rack_profiler
-    if current_user && current_user.is_admin?
-      Rack::MiniProfiler.authorize_request
-    end
+    return unless current_user&.is_admin?
+
+    Rack::MiniProfiler.authorize_request
   end
 
   #### Locale
@@ -136,35 +134,34 @@ class ApplicationController < ActionController::Base
     I18n.locale = params[:locale] || I18n.default_locale
   end
 
-  def default_url_options(options={})
+  def default_url_options(options = {})
     Rails.logger.debug "DEBUG: ApplicationController#default_url_options: Received options: #{options.inspect}\n"
     { locale: I18n.locale }
   end
-
 
   #### Session GUIDs and user tracking
 
   def current_session_guid
     cookies.encrypted[:session_guid]
   end
+
   helper_method :current_session_guid
 
-
   def set_session_stuff
-    cookies.encrypted[:session_guid] ||= {value: ApplicationController.generate_random_code(64), httponly: true}
+    cookies.encrypted[:session_guid] ||= { value: ApplicationController.generate_random_code(64), httponly: true }
 
-    #TODO These are being filled with ConstructedResponse JSON in courses_controller tests (L125)
-    #cookies.encrypted[:first_session_landing_url] ||= {value: request.filtered_path, httponly: true}
-    #cookies.encrypted[:latest_session_landing_url] ||= {value: request.filtered_path, httponly: true}
-    #cookies.encrypted[:post_sign_up_redirect_path] ||= {value: nil, httponly: true}
+    # TODO, These are being filled with ConstructedResponse JSON in courses_controller tests (L125)
+    # cookies.encrypted[:first_session_landing_url] ||= {value: request.filtered_path, httponly: true}
+    # cookies.encrypted[:latest_session_landing_url] ||= {value: request.filtered_path, httponly: true}
+    # cookies.encrypted[:post_sign_up_redirect_path] ||= {value: nil, httponly: true}
   end
 
   def reset_latest_session_landing_url
-    cookies.encrypted[:latest_session_landing_url] = {value: request.filtered_path, httponly: true}
+    cookies.encrypted[:latest_session_landing_url] = { value: request.filtered_path, httponly: true }
   end
 
   def reset_post_sign_up_redirect_path(new_path)
-    cookies.encrypted[:post_sign_up_redirect_path] = {value: new_path, httponly: true} if new_path
+    cookies.encrypted[:post_sign_up_redirect_path] = { value: new_path, httponly: true } if new_path
   end
 
   def drop_referral_code_cookie(referral_code)
@@ -174,233 +171,182 @@ class ApplicationController < ActionController::Base
     # without altering expiration date. Therefore if we detect difference between
     # current referral data and data stored in the cookie we will always save new
     # data and set expiration to next 30 days.
-    if referral_code && referral_data != cookies.encrypted[:referral_data]
-      cookies.encrypted[:referral_data] = { value: referral_data, expires: 30.days.from_now, httponly: true }
-    end
+    return unless referral_code && referral_data != cookies.encrypted[:referral_data]
 
+    cookies.encrypted[:referral_data] = { value: referral_data, expires: 30.days.from_now, httponly: true }
   end
-
 
   #### General purpose code
 
-  def self.generate_random_code(number_of_characters=20)
+  def self.generate_random_code(number_of_characters = 20)
     possible_characters = ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a
     the_answer = ''
     possible_character_size = possible_characters.size
     number_of_characters.times do
       the_answer << possible_characters[rand(possible_character_size)]
     end
+
     the_answer
   end
 
-  def self.generate_random_number(number_of_characters=5)
+  def self.generate_random_number(number_of_characters = 5)
     possible_characters = ('0'..'9').to_a
     the_answer = ''
     possible_character_size = possible_characters.size
     number_of_characters.times do
       the_answer << possible_characters[rand(possible_character_size)]
     end
+
     the_answer
   end
 
   # content management links (non-student)
   def course_module_special_link(the_thing)
     # used for tutor-facing links
-
-    if the_thing.class == CourseModuleElement && !the_thing.id.nil?
-        edit_course_module_element_url(the_thing.id)
-
-    elsif the_thing.class == CourseModule
-      subject_course_url(
-                the_thing.subject_course)
-
-    elsif the_thing.class == CourseSection
-      subject_course_url(
-          the_thing.subject_course)
-
-    elsif the_thing.class == SubjectCourse
+    case the_thing
+    when CourseModule, CourseSection
+      subject_course_url(the_thing.subject_course)
+    when SubjectCourse
       new_course_modules_for_subject_course_and_name_url(the_thing.name_url)
-
-    elsif the_thing.class == ContentPage
+    when ContentPage
       content_pages_url
-
-    else # default route
+    when CourseModuleElement
+      the_thing.id.present? ? edit_course_module_element_url(the_thing.id) : subject_course_url
+    else
       subject_course_url
     end
   end
+
   helper_method :course_module_special_link
 
-
   def content_activation_special_link(the_thing)
-    if the_thing.class == CourseModuleElement || the_thing.class == CourseModule
+    case the_thing
+    when CourseModuleElement, CourseModule
       subject_course_url(the_thing.course_module.subject_course)
-    elsif the_thing.class == SubjectCourse
+    when SubjectCourse
       subject_course_url
-    elsif the_thing.class == ContentPage
+    when ContentPage
       content_pages_url
-    elsif the_thing.class == SubjectCourseResource
+    when SubjectCourseResource
       course_resources_url(the_thing.subject_course)
     else
       subject_course_url
     end
   end
+
   helper_method :content_activation_special_link
-
-
 
   # Library Navigation Links
   def library_special_link(the_thing)
-    if the_thing.class == (Group)
-      the_thing = the_thing
-      library_group_url(
-                  the_thing.name_url
-      )
-    elsif the_thing.class == SubjectCourse
-      the_thing = the_thing
-      if the_thing.parent
-        library_course_url(
-            the_thing.parent.name_url,
-            the_thing.name_url
-        )
-      else
-        library_url
-      end
-    elsif the_thing.class == CourseModule
-      the_thing = the_thing
-      library_course_url(
-          the_thing.parent.parent.name_url,
-          the_thing.parent.name_url
-      )
+    case the_thing
+    when Group
+      library_group_url(the_thing.name_url)
+    when SubjectCourse
+      the_thing.parent ? library_course_url(the_thing.parent.name_url, the_thing.name_url) : library_url
+    when CourseModule
+      library_course_url(the_thing.parent.parent.name_url, the_thing.parent.name_url)
     else
       library_url
     end
   end
+
   helper_method :library_special_link
 
   # Enrollment Navigation Links
   def course_enrollment_special_link(course_id)
     subject_course = SubjectCourse.where(id: course_id).first
-    if subject_course && subject_course.active
-      library_course_url(
-          subject_course.parent.name_url,
-          subject_course.name_url,
-          anchor: :bootcamp
-      )
+
+    if subject_course&.active
+      library_course_url(subject_course.parent.name_url,
+                         subject_course.name_url,
+                         anchor: :bootcamp)
     else
       student_dashboard_url
     end
   end
+
   helper_method :course_enrollment_special_link
 
   # Library Navigation Links
   def navigation_special_link(the_thing)
-    the_thing = the_thing
-    library_course_url(
-        the_thing.course_module.course_section.subject_course.group.name_url,
-        the_thing.course_module.course_section.subject_course.name_url,
-        anchor: the_thing.course_module.course_section.name_url,
-        cm: the_thing.course_module.id
-    )
+    library_course_url(the_thing.course_module.course_section.subject_course.group.name_url,
+                       the_thing.course_module.course_section.subject_course.name_url,
+                       anchor: the_thing.course_module.course_section.name_url,
+                       cm: the_thing.course_module.id)
   end
+
   helper_method :navigation_special_link
 
-
-  def course_special_link(the_thing, exam_body_id, scul=nil)
-    if the_thing.class == SubjectCourse
-      library_course_url(
-          the_thing.parent.name_url,
-          the_thing.name_url
-      )
-    elsif the_thing.class == CourseSection
-      library_course_url(
-          the_thing.subject_course.group.name_url,
-          the_thing.subject_course.name_url,
-          anchor: the_thing.name_url
-      )
-    elsif the_thing.class == CourseModule
-      library_course_url(
-          the_thing.course_section.subject_course.group.name_url,
-          the_thing.course_section.subject_course.name_url,
-          the_thing.course_section.name_url,
-          anchor: the_thing.name_url
-      )
-    elsif the_thing.class == CourseModuleElement
-      if current_user #current_user
-        if current_user.non_verified_user? #current_user.non_verified_user?
-          library_course_url(
-              the_thing.course_module.course_section.subject_course.group.name_url,
-              the_thing.course_module.course_section.subject_course.name_url,
-              anchor: 'verification-required'
-          )
-
-        elsif the_thing.related_course_module_element_id && the_thing.previous_cme_restriction(scul)
-          library_course_url(
-              the_thing.course_module.course_section.subject_course.group.name_url,
-              the_thing.course_module.course_section.subject_course.name_url,
-              anchor: 'related-lesson-restriction'
-          )
-        else
-          course_url(
-            the_thing.course_module.course_section.subject_course.name_url,
-            the_thing.course_module.course_section.name_url,
-            the_thing.course_module.name_url,
-            the_thing.name_url
-          )
-        end
-
-        #permission = the_thing.available_to_user(current_user, exam_body_id, scul)
-        #if permission[:view]
-        #  course_url(
-        #      the_thing.course_module.course_section.subject_course.name_url,
-        #      the_thing.course_module.course_section.name_url,
-        #      the_thing.course_module.name_url,
-        #      the_thing.name_url
-        #  )
-
-        #else
-        #  library_course_url(
-        #      the_thing.course_module.course_section.subject_course.group.name_url,
-        #      the_thing.course_module.course_section.subject_course.name_url,
-        #      anchor: permission[:reason]
-        #  )
-        #end
-      else
-        new_student_url
-      end
-
+  def course_special_link(the_thing, scul = nil)
+    case the_thing
+    when SubjectCourse
+      library_course_url(the_thing.parent.name_url, the_thing.name_url)
+    when CourseSection
+      library_course_url(the_thing.subject_course.group.name_url,
+                         the_thing.subject_course.name_url,
+                         anchor: the_thing.name_url)
+    when CourseModule
+      library_course_url(the_thing.course_section.subject_course.group.name_url,
+                         the_thing.course_section.subject_course.name_url,
+                         the_thing.course_section.name_url,
+                         anchor: the_thing.name_url)
+    when CourseModuleElement
+      user_course_correct_url(the_thing, scul)
     else
       library_special_link(the_thing)
     end
   end
+
   helper_method :course_special_link
+
+  def user_course_correct_url(the_thing, scul = nil)
+    return new_student_url unless current_user
+
+    if current_user.non_verified_user? # current_user.non_verified_user?
+      library_course_url(the_thing.course_module.course_section.subject_course.group.name_url,
+                         the_thing.course_module.course_section.subject_course.name_url,
+                         anchor: 'verification-required')
+
+    elsif the_thing.related_course_module_element_id && the_thing.previous_cme_restriction(scul)
+      library_course_url(the_thing.course_module.course_section.subject_course.group.name_url,
+                         the_thing.course_module.course_section.subject_course.name_url,
+                         anchor: 'related-lesson-restriction')
+    else
+      course_url(the_thing.course_module.course_section.subject_course.name_url,
+                 the_thing.course_module.course_section.name_url,
+                 the_thing.course_module.name_url,
+                 the_thing.name_url)
+    end
+  end
 
   def course_resource_special_link(the_thing)
     if the_thing.class == SubjectCourseResource
-
-      the_thing.external_url.blank? ? the_thing.file_upload.url : the_thing.external_url
-
+      the_thing.external_url.presence || the_thing.file_upload.url
     else
       library_special_link(the_thing)
     end
   end
+
   helper_method :course_resource_special_link
 
-  def subscription_checkout_special_link(exam_body_id, subscription_plan_guid=nil)
+  def subscription_checkout_special_link(exam_body_id, subscription_plan_guid = nil)
     if current_user
       new_subscription_url(exam_body_id: exam_body_id, plan_guid: subscription_plan_guid)
     else
       sign_in_or_register_url(exam_body_id: exam_body_id, plan_guid: subscription_plan_guid)
     end
   end
+
   helper_method :subscription_checkout_special_link
 
-  def product_checkout_special_link(exam_body_id, product_id=nil)
+  def product_checkout_special_link(exam_body_id, product_id = nil)
     if current_user
       new_order_url(product_id)
     else
       sign_in_or_register_url(exam_body_id: exam_body_id, product_id: product_id)
     end
   end
+
   helper_method :product_checkout_special_link
 
   def seo_title_maker(seo_title, seo_description, seo_no_index)

--- a/app/controllers/content_activations_controller.rb
+++ b/app/controllers/content_activations_controller.rb
@@ -1,37 +1,33 @@
-class ContentActivationsController < ApplicationController
+# frozen_string_literal: true
 
+class ContentActivationsController < ApplicationController
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access content_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access content_management_access])
   end
-  before_action :get_variables
+  before_action :set_layout
 
-  def new
-
-  end
+  def new; end
 
   def create
     record_type = params[:type].constantize
     @record = record_type.find(params[:id])
 
     # Defaults to 2AM for the selected date
-    @date = DateTime.new(params[:activation_date]["date(1i)"].to_i,
-                          params[:activation_date]["date(2i)"].to_i,
-                          params[:activation_date]["date(3i)"].to_i, 
-                          2
-                        )    
-                        
-    if @record && params[:activation_date]     
-      ContentActivationWorker.perform_at(@date, record_type, @record.id)
-      redirect_to content_activation_special_link(@record)
-    end
-  end
+    @date = DateTime.new(params[:activation_date]['date(1i)'].to_i,
+                         params[:activation_date]['date(2i)'].to_i,
+                         params[:activation_date]['date(3i)'].to_i,
+                         2)
 
+    return unless @record && params[:activation_date]
+
+    ContentActivationWorker.perform_at(@date, record_type, @record.id)
+    redirect_to content_activation_special_link(@record)
+  end
 
   protected
 
-  def get_variables
+  def set_layout
     @layout = 'management'
   end
-
 end

--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -1,27 +1,9 @@
-# == Schema Information
-#
-# Table name: content_pages
-#
-#  id              :integer          not null, primary key
-#  name            :string
-#  public_url      :string
-#  seo_title       :string
-#  seo_description :text
-#  text_content    :text
-#  h1_text         :string
-#  h1_subtext      :string
-#  nav_type        :string
-#  footer_link     :boolean          default(FALSE)
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  active          :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class ContentPagesController < ApplicationController
-
   before_action :logged_in_required, except: [:show]
   before_action except: [:show] do
-    ensure_user_has_access_rights(%w(system_requirements_access marketing_resources_access))
+    ensure_user_has_access_rights(%w[system_requirements_access marketing_resources_access])
   end
   before_action :get_variables, except: [:show]
 
@@ -31,7 +13,7 @@ class ContentPagesController < ApplicationController
 
   def show
     @content_page = ContentPage.where(public_url: params[:content_public_url]).first
-    if @content_page && @content_page.active
+    if @content_page&.active
       seo_title_maker(@content_page.seo_title, @content_page.seo_description, nil)
       @navbar = true
       @top_margin = true
@@ -61,7 +43,6 @@ class ContentPagesController < ApplicationController
     else
       @content_page = ContentPage.new
     end
-
   end
 
   def edit
@@ -70,6 +51,7 @@ class ContentPagesController < ApplicationController
 
   def create
     @content_page = ContentPage.new(allowed_params)
+
     if @content_page.save
       flash[:success] = I18n.t('controllers.content_pages.create.flash.success')
       redirect_to content_pages_url
@@ -87,22 +69,20 @@ class ContentPagesController < ApplicationController
     end
   end
 
-
   def destroy
     if @content_page.destroy
       flash[:success] = I18n.t('controllers.content_pages.destroy.flash.success')
     else
       flash[:error] = I18n.t('controllers.content_pages.destroy.flash.error')
     end
+
     redirect_to content_pages_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @content_page = ContentPage.where(id: params[:id]).first
-    end
+    @content_page = ContentPage.where(id: params[:id]).first if params[:id].to_i > 0
     @layout = 'management'
   end
 
@@ -114,5 +94,4 @@ class ContentPagesController < ApplicationController
                                                                             :sorting_order,
                                                                             :subject_course_id, :_destroy])
   end
-
 end

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,21 +1,6 @@
-# == Schema Information
-#
-# Table name: countries
-#
-#  id            :integer          not null, primary key
-#  name          :string
-#  iso_code      :string
-#  country_tld   :string
-#  sorting_order :integer
-#  in_the_eu     :boolean          default(FALSE), not null
-#  currency_id   :integer
-#  created_at    :datetime
-#  updated_at    :datetime
-#  continent     :string
-#
+# frozen_string_literal: true
 
 class CountriesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
     ensure_user_has_access_rights(%w(system_requirements_access))
@@ -29,8 +14,7 @@ class CountriesController < ApplicationController
                                   :currency).paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @country = Country.new(sorting_order: 1)
@@ -38,6 +22,7 @@ class CountriesController < ApplicationController
 
   def create
     @country = Country.new(allowed_params)
+
     if @country.save
       flash[:success] = I18n.t('controllers.countries.create.flash.success')
       redirect_to countries_url
@@ -46,8 +31,7 @@ class CountriesController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @country.update_attributes(allowed_params)
@@ -63,7 +47,8 @@ class CountriesController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       Country.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -72,6 +57,7 @@ class CountriesController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.countries.destroy.flash.error')
     end
+
     redirect_to countries_url
   end
 
@@ -79,9 +65,7 @@ class CountriesController < ApplicationController
 
   def get_variables
     @continents = Country::CONTINENTS
-    if params[:id].to_i > 0
-      @country = Country.where(id: params[:id]).first
-    end
+    @country = Country.where(id: params[:id]).first if params[:id].to_i > 0
     @currencies = Currency.all_in_order
     seo_title_maker(@country.try(:name) || 'Countries', '', true)
     @layout = 'management'
@@ -90,5 +74,4 @@ class CountriesController < ApplicationController
   def allowed_params
     params.require(:country).permit(:name, :iso_code, :country_tld, :sorting_order, :in_the_eu, :currency_id, :continent)
   end
-
 end

--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -1,30 +1,9 @@
-# == Schema Information
-#
-# Table name: coupons
-#
-#  id                 :integer          not null, primary key
-#  name               :string
-#  code               :string
-#  currency_id        :integer
-#  livemode           :boolean          default(FALSE)
-#  active             :boolean          default(FALSE)
-#  amount_off         :integer
-#  duration           :string
-#  duration_in_months :integer
-#  max_redemptions    :integer
-#  percent_off        :integer
-#  redeem_by          :datetime
-#  times_redeemed     :integer
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  stripe_coupon_data :text
-#
+# frozen_string_literal: true
 
 class CouponsController < ApplicationController
-
   before_action :logged_in_required
   before_action except: [:validate_coupon] do
-    ensure_user_has_access_rights(%w(stripe_management_access))
+    ensure_user_has_access_rights(%w[stripe_management_access])
   end
   before_action :get_variables
 
@@ -32,8 +11,7 @@ class CouponsController < ApplicationController
     @coupons = Coupon.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @coupon = Coupon.new
@@ -41,6 +19,7 @@ class CouponsController < ApplicationController
 
   def create
     @coupon = Coupon.new(allowed_params)
+
     if @coupon.save
       flash[:success] = I18n.t('controllers.coupons.create.flash.success')
       redirect_to coupons_url
@@ -55,27 +34,25 @@ class CouponsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.coupons.destroy.flash.error')
     end
+
     redirect_to coupons_url
   end
 
   def validate_coupon
     respond_to do |format|
-      format.json {
+      format.json do
         discount = Coupon.verify_coupon_and_get_discount(params[:coupon_code], params[:plan_id])
-        data = {valid: discount[0], discounted_price: discount[1]}
+        data = { valid: discount[0], discounted_price: discount[1] }
 
         render json: data, status: :ok
-      }
+      end
     end
-
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @coupon = Coupon.where(id: params[:id]).first
-    end
+    @coupon = Coupon.where(id: params[:id]).first if params[:id].to_i > 0
     @currencies = Currency.all_in_order.all_active
     @layout = 'management'
   end
@@ -84,5 +61,4 @@ class CouponsController < ApplicationController
     params.require(:coupon).permit(:name, :code, :currency_id, :amount_off, :duration, :max_redemptions,
                                    :duration_in_months, :percent_off, :redeem_by)
   end
-
 end

--- a/app/controllers/course_module_element_resources_controller.rb
+++ b/app/controllers/course_module_element_resources_controller.rb
@@ -1,22 +1,6 @@
-# == Schema Information
-#
-# Table name: course_module_element_resources
-#
-#  id                       :integer          not null, primary key
-#  course_module_element_id :integer
-#  name                     :string
-#  web_url                  :string
-#  created_at               :datetime
-#  updated_at               :datetime
-#  upload_file_name         :string
-#  upload_content_type      :string
-#  upload_file_size         :integer
-#  upload_updated_at        :datetime
-#  destroyed_at             :datetime
-#
+# frozen_string_literal: true
 
 class CourseModuleElementResourcesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
     ensure_user_has_access_rights(%w(content_management_access))
@@ -32,7 +16,6 @@ class CourseModuleElementResourcesController < ApplicationController
   end
 
   def create
-
     @course_module_element_resource = CourseModuleElementResource.new(allowed_params)
 
     if @course_module_element_resource.save
@@ -44,8 +27,7 @@ class CourseModuleElementResourcesController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @course_module_element_resource.update_attributes(allowed_params)
@@ -55,7 +37,6 @@ class CourseModuleElementResourcesController < ApplicationController
       render action: :edit
     end
   end
-
 
   def destroy
     if @course_module_element_resource.destroy
@@ -70,10 +51,7 @@ class CourseModuleElementResourcesController < ApplicationController
 
   def get_variables
     @course_module_element = CourseModuleElement.where(id: params[:course_module_element_id]).first
-    if params[:id].to_i > 0
-      @course_module_element_resource = CourseModuleElementResource.where(id: params[:id]).first
-    end
-
+    @course_module_element_resource = CourseModuleElementResource.where(id: params[:id]).first if params[:id].to_i > 0
     @mathjax_required = true
     @layout = 'management'
   end
@@ -83,5 +61,4 @@ class CourseModuleElementResourcesController < ApplicationController
                                                   :web_url, :upload, :upload_file_name, :upload_content_type,
                                                   :upload_file_size, :upload_updated_at, :_destroy)
   end
-
 end

--- a/app/controllers/course_modules_controller.rb
+++ b/app/controllers/course_modules_controller.rb
@@ -1,44 +1,13 @@
-# == Schema Information
-#
-# Table name: course_modules
-#
-#  id                         :integer          not null, primary key
-#  name                       :string
-#  name_url                   :string
-#  description                :text
-#  sorting_order              :integer
-#  estimated_time_in_seconds  :integer
-#  active                     :boolean          default(FALSE), not null
-#  created_at                 :datetime
-#  updated_at                 :datetime
-#  cme_count                  :integer          default(0)
-#  seo_description            :string
-#  seo_no_index               :boolean          default(FALSE)
-#  destroyed_at               :datetime
-#  number_of_questions        :integer          default(0)
-#  subject_course_id          :integer
-#  video_duration             :float            default(0.0)
-#  video_count                :integer          default(0)
-#  quiz_count                 :integer          default(0)
-#  highlight_colour           :string
-#  tuition                    :boolean          default(FALSE)
-#  test                       :boolean          default(FALSE)
-#  revision                   :boolean          default(FALSE)
-#  course_section_id          :integer
-#  constructed_response_count :integer          default(0)
-#
+# frozen_string_literal: true
 
 class CourseModulesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access))
+    ensure_user_has_access_rights(%w[content_management_access])
   end
   before_action :get_variables
 
-  # Standard Actions #
-  def show
-  end
+  def show; end
 
   def new
     @course_sections = @subject_course.course_sections.all_in_order
@@ -56,6 +25,7 @@ class CourseModulesController < ApplicationController
 
   def create
     @course_module = CourseModule.new(allowed_params)
+
     if @course_module.save
       flash[:success] = I18n.t('controllers.course_modules.create.flash.success')
       redirect_to subject_course_url(@course_module.subject_course_id)
@@ -70,6 +40,7 @@ class CourseModulesController < ApplicationController
 
   def update
     @course_module = CourseModule.where(id: params[:id]).first
+
     if @course_module.update_attributes(allowed_params)
       flash[:success] = I18n.t('controllers.course_modules.update.flash.success')
       redirect_to subject_course_url(@course_module.subject_course_id)
@@ -79,16 +50,16 @@ class CourseModulesController < ApplicationController
   end
 
   def reorder
-    
     array_of_ids = params[:array_of_ids]
     array_of_ids.each_with_index do |the_id, counter|
       CourseModule.find(the_id.to_i).update_attributes!(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
     @course_module = CourseModule.find(params[:id])
+
     if @course_module.destroy
       flash[:success] = I18n.t('controllers.course_modules.destroy.flash.success')
     else
@@ -115,5 +86,4 @@ class CourseModulesController < ApplicationController
                                           :highlight_colour, :tuition, :test, :revision, :course_section_id,
                                           :temporary_label)
   end
-
 end

--- a/app/controllers/course_sections_controller.rb
+++ b/app/controllers/course_sections_controller.rb
@@ -1,36 +1,15 @@
-# == Schema Information
-#
-# Table name: course_sections
-#
-#  id                         :integer          not null, primary key
-#  subject_course_id          :integer
-#  name                       :string
-#  name_url                   :string
-#  sorting_order              :integer
-#  active                     :boolean          default(FALSE)
-#  counts_towards_completion  :boolean          default(FALSE)
-#  assumed_knowledge          :boolean          default(FALSE)
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  cme_count                  :integer          default(0)
-#  video_count                :integer          default(0)
-#  quiz_count                 :integer          default(0)
-#  destroyed_at               :datetime
-#  constructed_response_count :integer          default(0)
-#
+# frozen_string_literal: true
 
 class CourseSectionsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access))
+    ensure_user_has_access_rights(%w[content_management_access])
   end
   before_action :get_variables
 
-  # Standard Actions #
-
   def new
     @subject_course = SubjectCourse.where(id: params[:id]).first
+
     if @subject_course && @subject_course.course_sections.count > 0
       @course_section = CourseSection.new(sorting_order: ((@subject_course.course_sections.any? && @subject_course.course_sections.all_in_order.last.sorting_order) ? @subject_course.course_sections.all_in_order.last.sorting_order + 1 : 1), subject_course_id: @subject_course.id)
     elsif @subject_course
@@ -42,6 +21,7 @@ class CourseSectionsController < ApplicationController
 
   def create
     @course_section = CourseSection.new(allowed_params)
+
     if @course_section.save
       flash[:success] = I18n.t('controllers.course_sections.create.flash.success')
       redirect_to course_module_special_link(@course_section)
@@ -50,8 +30,7 @@ class CourseSectionsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @course_section.update_attributes(allowed_params)
@@ -71,7 +50,8 @@ class CourseSectionsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       CourseSection.find(the_id.to_i).update_attributes!(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -80,15 +60,14 @@ class CourseSectionsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.course_sections.destroy.flash.error')
     end
+
     redirect_to course_module_special_link(@course_section)
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @course_section = CourseSection.where(id: params[:id]).first
-    end
+    @course_section = CourseSection.where(id: params[:id]).first if params[:id].to_i > 0
     @subject_courses = SubjectCourse.all_in_order
     @tutors = User.all_tutors.all_in_order
     @layout = 'management'
@@ -96,7 +75,6 @@ class CourseSectionsController < ApplicationController
 
   def allowed_params
     params.require(:course_section).permit(:name, :name_url, :sorting_order, :active, :subject_course_id,
-                                          :counts_towards_completion, :assumed_knowledge)
+                                           :counts_towards_completion, :assumed_knowledge)
   end
-
 end

--- a/app/controllers/course_tutor_details_controller.rb
+++ b/app/controllers/course_tutor_details_controller.rb
@@ -1,21 +1,9 @@
-# == Schema Information
-#
-# Table name: course_tutor_details
-#
-#  id                :integer          not null, primary key
-#  subject_course_id :integer
-#  user_id           :integer
-#  sorting_order     :integer
-#  title             :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#
+# frozen_string_literal: true
 
 class CourseTutorDetailsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access content_management_access user_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access content_management_access user_management_access])
   end
   before_action :get_variables
 
@@ -27,11 +15,11 @@ class CourseTutorDetailsController < ApplicationController
     @course_tutor_detail = CourseTutorDetail.new(subject_course_id: @subject_course.id, sorting_order: 1)
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @course_tutor_detail = CourseTutorDetail.new(allowed_params)
+
     if @course_tutor_detail.save
       flash[:success] = I18n.t('controllers.course_tutor_details.create.flash.success')
       redirect_to subject_course_course_tutor_details_url(@subject_course)
@@ -54,7 +42,8 @@ class CourseTutorDetailsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       CourseTutorDetail.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -63,18 +52,15 @@ class CourseTutorDetailsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.course_tutor_details.destroy.flash.error')
     end
+
     redirect_to subject_course_course_tutor_details_url(@subject_course)
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @course_tutor_detail = CourseTutorDetail.where(id: params[:id]).first
-    end
-    if params[:subject_course_id].to_i > 0
-      @subject_course = SubjectCourse.where(id: params[:subject_course_id]).first
-    end
+    @course_tutor_detail = CourseTutorDetail.where(id: params[:id]).first if params[:id].to_i > 0
+    @subject_course = SubjectCourse.where(id: params[:subject_course_id]).first if params[:subject_course_id].to_i > 0
     @layout = 'management'
     @tutor_users = User.all_tutors.all_in_order
   end
@@ -82,5 +68,4 @@ class CourseTutorDetailsController < ApplicationController
   def allowed_params
     params.require(:course_tutor_detail).permit(:subject_course_id, :user_id, :sorting_order, :title)
   end
-
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,9 +1,9 @@
 class CoursesController < ApplicationController
 
   skip_after_action :intercom_rails_auto_include, only: :show_constructed_response
-  skip_before_action :verify_authenticity_token, only: [:create_video_user_log, :video_watched_data]
+  skip_before_action :verify_authenticity_token, only: %i[create_video_user_log video_watched_data]
   before_action :logged_in_required
-  before_action :check_permission, only: [:show, :show_constructed_response]
+  before_action :check_permission, only: %i[show show_constructed_response]
 
   def show
     @subject_course_user_log = current_user.subject_course_user_logs.for_subject_course(@course.id).last if current_user.subject_course_user_logs.any?
@@ -48,7 +48,6 @@ class CoursesController < ApplicationController
       flash[:error] = I18n.t('controllers.courses.create.flash.error')
       redirect_to library_special_link(@course_module.parent)
     end
-
   end
 
   def video_watched_data
@@ -97,11 +96,11 @@ class CoursesController < ApplicationController
   end
 
   def show_constructed_response
-    if @course_module && @course_module.active_children
+    if @course_module&.active_children
       @course_module_element = @course_module.children.find_by(name_url: params[:course_module_element_name_url])
       current_user.non_student_user? && !@course_module_element.active ? (@preview_mode = true) : (@preview_mode = false)
 
-      #CME name is not in the seo title because it is html_safe
+      # CME name is not in the seo title because it is html_safe
       seo_title_maker("#{@course_module.name} - #{@course.name}", @course_module_element.try(:description), @course_module_element.try(:seo_no_index))
 
       if @course_module_element.is_constructed_response
@@ -125,13 +124,12 @@ class CoursesController < ApplicationController
     @course_module_element_user_log = CourseModuleElementUserLog.find(params[:course_module_element_user_log][:id])
 
     respond_to do |format|
-      #update_columns ?? to stop callback chain will be called on final submit
+      # update_columns ?? to stop callback chain will be called on final submit
       if @course_module_element_user_log.update_attributes(constructed_response_allowed_params)
         format.json { render json: @course_module_element_user_log, status: :created }
       else
         format.json { render json: @course_module_element_user_log.errors, status: :unprocessable_entity }
       end
-
     end
   end
 
@@ -144,82 +142,82 @@ class CoursesController < ApplicationController
 
     @course_module_element_user_log.update_attributes(element_completed: true)
 
-    redirect_to course_special_link(@course_module_element_user_log.course_module_element, @subject_course_user_log.subject_course.group.exam_body_id, @subject_course_user_log)
+    redirect_to course_special_link(@course_module_element_user_log.course_module_element, @subject_course_user_log)
   end
 
   private
 
   def allowed_params
     params.require(:course_module_element_user_log).permit(
-            :preview_mode,
-            :subject_course_id,
-            :student_exam_track_id,
-            :subject_course_user_log_id,
-            :course_section_id,
-            :course_section_user_log_id,
-            :course_module_id,
-            :course_module_element_id,
-            :user_id,
-            :time_taken_in_seconds,
-            quiz_attempts_attributes: [
-                    :id,
-                    :user_id,
-                    :quiz_question_id,
-                    :quiz_answer_id,
-                    :answer_array
-            ]
+      :preview_mode,
+      :subject_course_id,
+      :student_exam_track_id,
+      :subject_course_user_log_id,
+      :course_section_id,
+      :course_section_user_log_id,
+      :course_module_id,
+      :course_module_element_id,
+      :user_id,
+      :time_taken_in_seconds,
+      quiz_attempts_attributes: [
+        :id,
+        :user_id,
+        :quiz_question_id,
+        :quiz_answer_id,
+        :answer_array
+      ]
     )
   end
 
   def constructed_response_allowed_params
     params.require(:course_module_element_user_log).permit(
-            constructed_response_attempt_attributes: [
-                    :id,
-                    :constructed_response_id,
-                    :scenario_id,
-                    :course_module_element_id,
-                    :user_id,
-                    :original_scenario_text_content,
-                    :user_edited_scenario_text_content,
-                    :scratch_pad_text,
-                    scenario_question_attempts_attributes: [
-                        :id,
-                        :constructed_response_attempt_id,
-                        :user_id,
-                        :scenario_question_id,
-                        :status,
-                        :flagged_for_review,
-                        :original_scenario_question_text,
-                        :user_edited_scenario_question_text,
-                        scenario_answer_attempts_attributes: [
-                            :id,
-                            :scenario_question_attempt_id,
-                            :user_id,
-                            :scenario_answer_template_id,
-                            :original_answer_template_text,
-                            :user_edited_answer_template_text,
-                            :editor_type
-                        ]
-
-                    ]
-            ]
+      constructed_response_attempt_attributes: [
+        :id,
+        :constructed_response_id,
+        :scenario_id,
+        :course_module_element_id,
+        :user_id,
+        :original_scenario_text_content,
+        :user_edited_scenario_text_content,
+        :scratch_pad_text,
+        scenario_question_attempts_attributes: [
+          :id,
+          :constructed_response_attempt_id,
+          :user_id,
+          :scenario_question_id,
+          :status,
+          :flagged_for_review,
+          :original_scenario_question_text,
+          :user_edited_scenario_question_text,
+          scenario_answer_attempts_attributes: [
+            :id,
+            :scenario_question_attempt_id,
+            :user_id,
+            :scenario_answer_template_id,
+            :original_answer_template_text,
+            :user_edited_answer_template_text,
+            :editor_type
+          ]
+        ]
+      ]
     )
   end
 
   def set_up_quiz
     #Creates QUIZ log when page renders but does not save log, data is sent as params to create method where a new CMEUL is initiated and saved
     @course_module_element_user_log = CourseModuleElementUserLog.new(
-            session_guid: current_session_guid,
-            course_module_element_id: @course_module_element.id,
-            course_module_id: @course_module_element.course_module_id,
-            course_section_id: @course_module_element.course_module.course_section_id,
-            subject_course_id: @course_module_element.course_module.subject_course_id,
-            subject_course_user_log_id: @subject_course_user_log.try(:id),
-            course_section_user_log_id: @course_section_user_log.try(:id),
-            student_exam_track_id: @student_exam_track.try(:id),
-            is_quiz: true,
-            is_video: false,
-            user_id: current_user.try(:id))
+      session_guid: current_session_guid,
+      course_module_element_id: @course_module_element.id,
+      course_module_id: @course_module_element.course_module_id,
+      course_section_id: @course_module_element.course_module.course_section_id,
+      subject_course_id: @course_module_element.course_module.subject_course_id,
+      subject_course_user_log_id: @subject_course_user_log.try(:id),
+      course_section_user_log_id: @course_section_user_log.try(:id),
+      student_exam_track_id: @student_exam_track.try(:id),
+      is_quiz: true,
+      is_video: false,
+      user_id: current_user.try(:id)
+    )
     @number_of_questions = @course_module_element.course_module_element_quiz.number_of_questions
 
     @number_of_questions.times do
@@ -231,19 +229,18 @@ class CoursesController < ApplicationController
     if @strategy == 'random'
       all_ids_random = @course_module_element.course_module_element_quiz.all_ids_random
       @all_ids = all_ids_random.sample(@number_of_questions)
-      @quiz_questions = QuizQuestion.includes(:quiz_contents).find(@all_ids)
     else
       all_ids_ordered = @course_module_element.course_module_element_quiz.all_ids_ordered
       @all_ids = all_ids_ordered[0..@number_of_questions]
-      @quiz_questions = QuizQuestion.includes(:quiz_contents).find(@all_ids)
     end
+
+    @quiz_questions = QuizQuestion.includes(:quiz_contents).find(@all_ids)
     @mathjax_required = true
   end
 
   def set_up_constructed_response_start_screen
     #Order by most recently updated_at
     @course_module_element_user_logs = @subject_course_user_log.course_module_element_user_logs.for_course_module_element(@course_module_element.id).reverse[0...8] if @subject_course_user_log
-
   end
 
   def set_up_new_constructed_response
@@ -258,68 +255,62 @@ class CoursesController < ApplicationController
 
     #Creates CONSTRUCTED_RESPONSE log when page renders
     @course_module_element_user_log = CourseModuleElementUserLog.create!(
-        preview_mode: @preview_mode,
-        session_guid: current_session_guid,
-        course_module_id: @course_module_element.course_module_id,
-        course_section_id: @course_module_element.course_module.course_section_id,
-        subject_course_id: @course_module_element.course_module.course_section.subject_course_id,
-        subject_course_user_log_id: @preview_mode ? nil : @subject_course_user_log.try(:id),
-        course_section_user_log_id: @preview_mode ? nil : @course_section_user_log.try(:id),
-        student_exam_track_id: @preview_mode ? nil : @student_exam_track.try(:id),
-        course_module_element_id: @course_module_element.id,
-        time_taken_in_seconds: @course_module_element.estimated_time_in_seconds,
-        is_quiz: false,
-        is_video: false,
-        is_constructed_response: true,
-        user_id: current_user.id
+      preview_mode: @preview_mode,
+      session_guid: current_session_guid,
+      course_module_id: @course_module_element.course_module_id,
+      course_section_id: @course_module_element.course_module.course_section_id,
+      subject_course_id: @course_module_element.course_module.course_section.subject_course_id,
+      subject_course_user_log_id: @preview_mode ? nil : @subject_course_user_log.try(:id),
+      course_section_user_log_id: @preview_mode ? nil : @course_section_user_log.try(:id),
+      student_exam_track_id: @preview_mode ? nil : @student_exam_track.try(:id),
+      course_module_element_id: @course_module_element.id,
+      time_taken_in_seconds: @course_module_element.estimated_time_in_seconds,
+      is_quiz: false,
+      is_video: false,
+      is_constructed_response: true,
+      user_id: current_user.id
     )
     @constructed_response_attempt = ConstructedResponseAttempt.create!(
-        constructed_response_id: @constructed_response.id,
-        scenario_id: @constructed_response.scenario.id,
-        course_module_element_id: @constructed_response.course_module_element_id,
-        course_module_element_user_log_id: @course_module_element_user_log.id,
-        user_id: current_user.id,
-        status: 'Incomplete',
-        original_scenario_text_content: @constructed_response.scenario.text_content,
-        user_edited_scenario_text_content: @constructed_response.scenario.text_content,
-        guid: ApplicationController.generate_random_code(6),
-        scratch_pad_text: 'You can write notes here...'
-
+      constructed_response_id: @constructed_response.id,
+      scenario_id: @constructed_response.scenario.id,
+      course_module_element_id: @constructed_response.course_module_element_id,
+      course_module_element_user_log_id: @course_module_element_user_log.id,
+      user_id: current_user.id,
+      status: 'Incomplete',
+      original_scenario_text_content: @constructed_response.scenario.text_content,
+      user_edited_scenario_text_content: @constructed_response.scenario.text_content,
+      guid: ApplicationController.generate_random_code(6),
+      scratch_pad_text: 'You can write notes here...'
     )
     @all_questions.each do |scenario_question|
       scenario_question_attempt = ScenarioQuestionAttempt.create!(
-          constructed_response_attempt_id: @constructed_response_attempt.id,
-          user_id: current_user.id,
-          scenario_question_id: scenario_question.id,
-          status: 'Unseen',
-          flagged_for_review: false,
-          sorting_order: scenario_question.sorting_order,
-          original_scenario_question_text: scenario_question.text_content,
-          user_edited_scenario_question_text: scenario_question.text_content
+        constructed_response_attempt_id: @constructed_response_attempt.id,
+        user_id: current_user.id,
+        scenario_question_id: scenario_question.id,
+        status: 'Unseen',
+        flagged_for_review: false,
+        sorting_order: scenario_question.sorting_order,
+        original_scenario_question_text: scenario_question.text_content,
+        user_edited_scenario_question_text: scenario_question.text_content
       )
 
       scenario_question.scenario_answer_templates.each do |scenario_answer_template|
-
         text_content = scenario_answer_template.spreadsheet_editor? ? scenario_answer_template.spreadsheet_editor_content : scenario_answer_template.text_editor_content
-
-        scenario_answer_attempt = ScenarioAnswerAttempt.create!(
-            scenario_question_attempt_id: scenario_question_attempt.id,
-            user_id: current_user.id,
-            scenario_answer_template_id: scenario_answer_template.id,
-            original_answer_template_text: text_content,
-            user_edited_answer_template_text: text_content,
-            editor_type: scenario_answer_template.editor_type,
-            sorting_order: scenario_answer_template.sorting_order
+        ScenarioAnswerAttempt.create!(
+          scenario_question_attempt_id: scenario_question_attempt.id,
+          user_id: current_user.id,
+          scenario_answer_template_id: scenario_answer_template.id,
+          original_answer_template_text: text_content,
+          user_edited_answer_template_text: text_content,
+          editor_type: scenario_answer_template.editor_type,
+          sorting_order: scenario_answer_template.sorting_order
         )
-
-
       end
     end
+
     @all_scenario_question_attempt = @constructed_response_attempt.scenario_question_attempts.all_in_order
     @all_scenario_question_attempt_ids = @constructed_response_attempt.scenario_question_attempts.all_in_order.map(&:id)
-
   end
-
 
   def set_up_previous_constructed_response
     @mathjax_required = true
@@ -349,13 +340,12 @@ class CoursesController < ApplicationController
     @subject_course_user_log = current_user.subject_course_user_logs.for_subject_course(@course.id).all_in_order.last
     @valid_subscription = current_user.active_subscriptions_for_exam_body(@group.exam_body_id).all_valid.first
 
-    unless @course && @course.active && @course_section && @course_section.active && @course_module &&
-        @course_module.active && @course_module_element && @course_module_element.active &&
-        current_user && (@valid_subscription || @course_module_element.available_to_user(current_user, @group.exam_body_id, @subject_course_user_log)[:view])
+    unless @course&.active && @course_section && @course_section.active && @course_module &&
+           @course_module.active && @course_module_element && @course_module_element.active &&
+           current_user && (@valid_subscription || @course_module_element.available_to_user(current_user, @group.exam_body_id, @subject_course_user_log)[:view])
 
       flash[:warning] = 'Sorry, you are not permitted to access that content. '
       redirect_to library_special_link(@course)
     end
   end
-
 end

--- a/app/controllers/currencies_controller.rb
+++ b/app/controllers/currencies_controller.rb
@@ -1,33 +1,17 @@
-# == Schema Information
-#
-# Table name: currencies
-#
-#  id              :integer          not null, primary key
-#  iso_code        :string
-#  name            :string
-#  leading_symbol  :string
-#  trailing_symbol :string
-#  active          :boolean          default(FALSE), not null
-#  sorting_order   :integer
-#  created_at      :datetime
-#  updated_at      :datetime
-#
+# frozen_string_literal: true
 
 class CurrenciesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access stripe_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access stripe_management_access])
   end
   before_action :get_variables
 
-  # Standard Actions #
   def index
     @currencies = Currency.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @currency = Currency.new(sorting_order: 1)
@@ -43,8 +27,7 @@ class CurrenciesController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @currency.update_attributes(allowed_params)
@@ -60,7 +43,7 @@ class CurrenciesController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       Currency.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -75,9 +58,7 @@ class CurrenciesController < ApplicationController
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @currency = Currency.where(id: params[:id]).first
-    end
+    @currency = Currency.where(id: params[:id]).first if params[:id].to_i > 0
     seo_title_maker(@currency.try(:name) || 'Currencies', '', true)
     @layout = 'management'
   end
@@ -85,5 +66,4 @@ class CurrenciesController < ApplicationController
   def allowed_params
     params.require(:currency).permit(:iso_code, :name, :leading_symbol, :trailing_symbol, :active, :sorting_order)
   end
-
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,8 +1,8 @@
-class DashboardController < ApplicationController
+# frozen_string_literal: true
 
+class DashboardController < ApplicationController
   before_action :logged_in_required
   before_action :get_variables
-
 
   def show
     @default_group = current_user&.preferred_exam_body&.group || Group.all_active.all_active.first
@@ -10,13 +10,10 @@ class DashboardController < ApplicationController
     @sculs = current_user.subject_course_user_logs.includes(:enrollments).where(enrollments: { id: nil })
   end
 
-
-
   protected
 
   def get_variables
     @courses = SubjectCourse.all_active.all_in_order
     seo_title_maker('Dashboard', 'Progress through all your courses will be recorded here.', false)
   end
-
 end

--- a/app/controllers/exam_bodies_controller.rb
+++ b/app/controllers/exam_bodies_controller.rb
@@ -1,21 +1,9 @@
-# == Schema Information
-#
-# Table name: exam_bodies
-#
-#  id            :integer          not null, primary key
-#  name          :string
-#  url           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  modal_heading :string
-#  modal_text    :text
-#
+# frozen_string_literal: true
 
 class ExamBodiesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access))
+    ensure_user_has_access_rights(%w[system_requirements_access])
   end
   before_action :get_variables
 
@@ -23,18 +11,17 @@ class ExamBodiesController < ApplicationController
     @exam_bodies = ExamBody.all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @exam_body = ExamBody.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @exam_body = ExamBody.new(allowed_params)
+
     if @exam_body.save
       flash[:success] = I18n.t('controllers.exam_bodies.create.flash.success')
       redirect_to exam_bodies_url
@@ -52,22 +39,20 @@ class ExamBodiesController < ApplicationController
     end
   end
 
-
   def destroy
     if @exam_body.destroy
       flash[:success] = I18n.t('controllers.exam_bodies.destroy.flash.success')
     else
       flash[:error] = I18n.t('controllers.exam_bodies.destroy.flash.error')
     end
+
     redirect_to exam_bodies_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @exam_body = ExamBody.where(id: params[:id]).first
-    end
+    @exam_body = ExamBody.where(id: params[:id]).first if params[:id].to_i > 0
     @layout = 'management'
   end
 
@@ -80,5 +65,4 @@ class ExamBodiesController < ApplicationController
                                       :logo_image, :registration_form_heading,
                                       :login_form_heading)
   end
-
 end

--- a/app/controllers/exam_sittings_controller.rb
+++ b/app/controllers/exam_sittings_controller.rb
@@ -1,50 +1,37 @@
-# == Schema Information
-#
-# Table name: exam_sittings
-#
-#  id                :integer          not null, primary key
-#  name              :string
-#  subject_course_id :integer
-#  date              :date
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  exam_body_id      :integer
-#  active            :boolean          default(TRUE)
-#  computer_based    :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class ExamSittingsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access content_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access content_management_access])
   end
   before_action :get_variables
 
   def index
     @sort_choices = ExamSitting::SORT_OPTIONS
-    case params[:sort_by]
-    when 'all'
-      @exam_sittings = ExamSitting.paginate(per_page: 50, page: params[:page]).all_in_order
-    when 'not-active'
-      @exam_sittings = ExamSitting.all_not_active.paginate(per_page: 50, page: params[:page]).all_in_order
-    else 
-      @exam_sittings = ExamSitting.all_active.paginate(per_page: 50, page: params[:page]).all_in_order
-    end
+
+    @exam_sittings =
+      case params[:sort_by]
+      when 'all'
+        ExamSitting.paginate(per_page: 50, page: params[:page]).all_in_order
+      when 'not-active'
+        ExamSitting.all_not_active.paginate(per_page: 50, page: params[:page]).all_in_order
+      else
+        ExamSitting.all_active.paginate(per_page: 50, page: params[:page]).all_in_order
+      end
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @exam_sitting = ExamSitting.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @exam_sitting = ExamSitting.new(allowed_params)
+
     if @exam_sitting.save
       flash[:success] = I18n.t('controllers.exam_sittings.create.flash.success')
       redirect_to exam_sittings_url
@@ -62,13 +49,13 @@ class ExamSittingsController < ApplicationController
     end
   end
 
-
   def destroy
     if @exam_sitting.destroy
       flash[:success] = I18n.t('controllers.exam_sittings.destroy.flash.success')
     else
       flash[:error] = I18n.t('controllers.exam_sittings.destroy.flash.error')
     end
+
     redirect_to exam_sittings_url
   end
 
@@ -81,15 +68,12 @@ class ExamSittingsController < ApplicationController
       format.csv { send_data @enrollments.to_csv() }
       format.xls { send_data @enrollments.to_csv(col_sep: "\t", headers: true), filename: "exam-sitting-#{@exam_sitting.id}-#{Date.today}.xls" }
     end
-
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @exam_sitting = ExamSitting.where(id: params[:id]).first
-    end
+    @exam_sitting = ExamSitting.where(id: params[:id]).first if params[:id].to_i > 0
     @subject_courses = SubjectCourse.all_active.all_in_order
     @exam_bodies = ExamBody.all_in_order
     @layout = 'management'
@@ -102,5 +86,4 @@ class ExamSittingsController < ApplicationController
   def update_params
     params.require(:exam_sitting).permit(:name, :subject_course_id, :exam_body_id, :active)
   end
-
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExercisesController < ApplicationController
   before_action :logged_in_required
   before_action :set_exercise, except: :index
@@ -7,8 +9,7 @@ class ExercisesController < ApplicationController
     @exercise = @exercises.last
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @exercise.update(exercise_params)
@@ -33,8 +34,9 @@ class ExercisesController < ApplicationController
 
   def set_exercise
     @exercise = Exercise.find(params[:id])
-    unless @exercise.user_id == current_user.id
-      redirect_to user_exercises_path(current_user)
-    end
+
+    return if @exercise.user_id == current_user.id
+
+    redirect_to user_exercises_path(current_user)
   end
 end

--- a/app/controllers/external_banners_controller.rb
+++ b/app/controllers/external_banners_controller.rb
@@ -1,29 +1,9 @@
-# == Schema Information
-#
-# Table name: external_banners
-#
-#  id                 :integer          not null, primary key
-#  name               :string
-#  sorting_order      :integer
-#  active             :boolean          default(FALSE)
-#  background_colour  :string
-#  text_content       :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  user_sessions      :boolean          default(FALSE)
-#  library            :boolean          default(FALSE)
-#  subscription_plans :boolean          default(FALSE)
-#  footer_pages       :boolean          default(FALSE)
-#  student_sign_ups   :boolean          default(FALSE)
-#  home_page_id       :integer
-#  content_page_id    :integer
-#
+# frozen_string_literal: true
 
 class ExternalBannersController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access marketing_resources_access))
+    ensure_user_has_access_rights(%w[content_management_access marketing_resources_access])
   end
   before_action :get_variables
 
@@ -32,7 +12,7 @@ class ExternalBannersController < ApplicationController
   end
 
   def show
-    #Preview for managers
+    # Preview for managers
     @banner = @external_banner
   end
 
@@ -40,11 +20,11 @@ class ExternalBannersController < ApplicationController
     @external_banner = ExternalBanner.new(sorting_order: 1, active: true, background_colour: '#FFFFFF')
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @external_banner = ExternalBanner.new(allowed_params)
+
     if @external_banner.save
       flash[:success] = I18n.t('controllers.external_banners.create.flash.success')
       redirect_to external_banners_url
@@ -67,7 +47,7 @@ class ExternalBannersController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       ExternalBanner.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -76,15 +56,14 @@ class ExternalBannersController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.external_banners.destroy.flash.error')
     end
+
     redirect_to external_banners_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @external_banner = ExternalBanner.where(id: params[:id]).first
-    end
+    @external_banner = ExternalBanner.where(id: params[:id]).first if params[:id].to_i > 0
     @layout = 'management'
   end
 
@@ -92,5 +71,4 @@ class ExternalBannersController < ApplicationController
     params.require(:external_banner).permit(:name, :sorting_order, :active, :background_colour, :text_content,
                                             :user_sessions, :library, :subscription_plans, :footer_pages, :student_sign_ups)
   end
-
 end

--- a/app/controllers/faq_sections_controller.rb
+++ b/app/controllers/faq_sections_controller.rb
@@ -1,22 +1,9 @@
-# == Schema Information
-#
-# Table name: faq_sections
-#
-#  id            :integer          not null, primary key
-#  name          :string
-#  name_url      :string
-#  description   :text
-#  active        :boolean          default(TRUE)
-#  sorting_order :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#
+# frozen_string_literal: true
 
 class FaqSectionsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access marketing_resources_access))
+    ensure_user_has_access_rights(%w[content_management_access marketing_resources_access])
   end
   before_action :get_variables
 
@@ -28,11 +15,11 @@ class FaqSectionsController < ApplicationController
     @faq_section = FaqSection.new(sorting_order: 1)
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @faq_section = FaqSection.new(allowed_params)
+
     if @faq_section.save
       flash[:success] = I18n.t('controllers.faq_sections.create.flash.success')
       redirect_to public_resources_url
@@ -55,7 +42,8 @@ class FaqSectionsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       FaqSection.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -64,20 +52,18 @@ class FaqSectionsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.faq_sections.destroy.flash.error')
     end
+
     redirect_to public_resources_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @faq_section = FaqSection.where(id: params[:id]).first
-    end
+    @faq_section = FaqSection.where(id: params[:id]).first if params[:id].to_i > 0
     @layout = 'management'
   end
 
   def allowed_params
     params.require(:faq_section).permit(:name, :name_url, :description, :active, :sorting_order)
   end
-
 end

--- a/app/controllers/faqs_controller.rb
+++ b/app/controllers/faqs_controller.rb
@@ -1,25 +1,9 @@
-# == Schema Information
-#
-# Table name: faqs
-#
-#  id              :integer          not null, primary key
-#  name            :string
-#  name_url        :string
-#  active          :boolean          default(TRUE)
-#  sorting_order   :integer
-#  faq_section_id  :integer
-#  question_text   :text
-#  answer_text     :text
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  pre_answer_text :text
-#
+# frozen_string_literal: true
 
 class FaqsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access marketing_resources_access))
+    ensure_user_has_access_rights(%w[content_management_access marketing_resources_access])
   end
   before_action :get_variables
 
@@ -27,11 +11,11 @@ class FaqsController < ApplicationController
     @faq = Faq.new(sorting_order: 1, faq_section_id: params[:faq_section_id])
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @faq = Faq.new(allowed_params)
+
     if @faq.save
       flash[:success] = I18n.t('controllers.faqs.create.flash.success')
       redirect_to public_resources_url
@@ -54,7 +38,7 @@ class FaqsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       Faq.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -69,9 +53,7 @@ class FaqsController < ApplicationController
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @faq = Faq.where(id: params[:id]).first
-    end
+    @faq = Faq.where(id: params[:id]).first if params[:id].to_i > 0
     @faq_sections = FaqSection.all_in_order
     @layout = 'management'
   end
@@ -80,5 +62,4 @@ class FaqsController < ApplicationController
     params.require(:faq).permit(:name, :name_url, :active, :sorting_order, :faq_section_id,
                                 :question_text, :answer_text, :pre_answer_text)
   end
-
 end

--- a/app/controllers/footer_pages_controller.rb
+++ b/app/controllers/footer_pages_controller.rb
@@ -1,6 +1,7 @@
-class FooterPagesController < ApplicationController
+# frozen_string_literal: true
 
-  before_action :get_variables, except: [:missing_page]
+class FooterPagesController < ApplicationController
+  before_action :get_variables, except: :missing_page
 
   def privacy_policy
     seo_title_maker('Read Our Privacy Policy | LearnSignal', 'Read the Privacy Policy for learnsignal.com. Find out about our privacy and cookies policy here including how your data is used.', nil)
@@ -19,6 +20,7 @@ class FooterPagesController < ApplicationController
 
   def terms_and_conditions
     @content_page = ContentPage.where(public_url: 'terms_and_conditions').all_active.first
+
     if @content_page
       seo_title_maker(@content_page.seo_title, @content_page.seo_description, nil)
       render 'content_pages/show'
@@ -34,43 +36,43 @@ class FooterPagesController < ApplicationController
   end
 
   def media_library
-    seo_title_maker('ACCA Correction Packs and Mock Exams | LearnSignal', "Get access to ACCA question and solution correction packs and mock exams designed by experts to help you pass your exams the first time.", nil)
+    seo_title_maker('ACCA Correction Packs and Mock Exams | LearnSignal', 'Get access to ACCA question and solution correction packs and mock exams designed by experts to help you pass your exams the first time.', nil)
+
     if current_user
       country = IpAddress.get_country(request.remote_ip) || current_user.country
       currency = current_user.get_currency(country)
       @currency_id = currency.id
     else
-      country = IpAddress.get_country(request.remote_ip) || Country.find_by_name('United Kingdom')
+      country = IpAddress.get_country(request.remote_ip) || Country.find_by(name: 'United Kingdom')
       @currency_id = country.currency_id
     end
 
-    @products = Product.in_currency(@currency_id)
-                       .all_active
-                       .all_in_order
-                       .where("mock_exam_id IS NOT NULL")
-                       .where("product_type = ?", Product.product_types[:mock_exam])
-    @questions = Product.in_currency(@currency_id)
-                       .all_active
-                       .all_in_order
-                       .where("mock_exam_id IS NOT NULL")
-                       .where("product_type = ?", Product.product_types[:correction_pack])
+    @products = Product.in_currency(@currency_id).
+                        all_active.
+                        all_in_order.
+                        where('mock_exam_id IS NOT NULL').
+                        where('product_type = ?', Product.product_types[:mock_exam])
+    @questions = Product.in_currency(@currency_id).
+                         all_active.
+                         all_in_order.
+                         where('mock_exam_id IS NOT NULL').
+                         where('product_type = ?', Product.product_types[:correction_pack])
   end
 
-
   def profile
-
     @tutor = User.all_tutors.where(name_url: params[:name_url]).first
-    if @tutor && @tutor.course_tutor_details.any?
+
+    if @tutor&.course_tutor_details&.any?
       @course_ids = []
       @tutor.course_tutor_details.each do |course_tutor|
         @course_ids << course_tutor.subject_course if course_tutor.subject_course
       end
       @courses = SubjectCourse.where(id: @course_ids)
       seo_title_maker("#{@tutor.full_name} Tutor | LearnSignal", @tutor.description, nil)
-
     else
       redirect_to tutors_url
     end
+
     @navbar = true
     @top_margin = true
   end
@@ -87,10 +89,10 @@ class FooterPagesController < ApplicationController
     if params[:first_element].to_s == '' && current_user
       redirect_to student_dashboard_url
     elsif params[:first_element].to_s == '500-page'
-      render file: 'public/500.html', layout: nil, status: 500
+      render file: 'public/500.html', layout: nil, status: :internal_server_error
     else
       @top_margin = true
-      render 'footer_pages/404_page.html.haml', status: 404
+      render 'footer_pages/404_page.html.haml', status: :not_found
     end
     seo_title_maker('404 Page', "Sorry, we couldn't find what you are looking for. We missed the mark!
       but don't worry. We're working on fixing this link.", nil)
@@ -98,38 +100,39 @@ class FooterPagesController < ApplicationController
 
   def info_subscribe
     email = params[:email][:address]
-    name = params[:first_name][:address]
-    #list_id = '866fa91d62' # Dev List
+    name  = params[:first_name][:address]
+    # list_id = '866fa91d62' # Dev List
     list_id = 'a716c282e2' # Production List
-    if !email.blank?
+
+    if email.present?
       begin
-        @mc.lists.subscribe(list_id, {'email' => email}, {'fname' => name})
+        @mc.lists.subscribe(list_id, { 'email' => email }, { 'fname' => name })
 
         respond_to do |format|
-          format.json{render json: {message: "Success! Check your email to confirm your subscription."}}
+          format.json { render json: { message: 'Success! Check your email to confirm your subscription.' } }
         end
       rescue Mailchimp::ListAlreadySubscribedError
         respond_to do |format|
-          format.json{render json: {message: "#{email} is already subscribed to the list"}}
+          format.json { render json: { message: "#{email} is already subscribed to the list" } }
         end
       rescue Mailchimp::ListDoesNotExistError
         respond_to do |format|
-          format.json{render json: {message: "The list could not be found."}}
+          format.json { render json: { message: 'The list could not be found.' } }
         end
-      rescue Mailchimp::Error => ex
-        if ex.message
+      rescue Mailchimp::Error => e
+        if e.message
           respond_to do |format|
-            format.json{render json: {message: "There is an error. Please enter valid email id."}}
+            format.json { render json: { message: 'There is an error. Please enter valid email id.' } }
           end
         else
           respond_to do |format|
-            format.json{render json: {message: "An unknown error occurred."}}
+            format.json { render json: { message: 'An unknown error occurred.' } }
           end
         end
       end
     else
       respond_to do |format|
-        format.json{render json: {message: "Email Address Cannot be blank. Please enter valid email id."}}
+        format.json{ render json: { message: 'Email Address Cannot be blank. Please enter valid email id.' } }
       end
     end
   end
@@ -151,9 +154,8 @@ class FooterPagesController < ApplicationController
   protected
 
   def get_variables
-    @navbar = 'standard'
+    @navbar     = 'standard'
     @top_margin = true
-    @footer = true
+    @footer     = true
   end
-
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,35 +1,12 @@
-# == Schema Information
-#
-# Table name: groups
-#
-#  id                            :integer          not null, primary key
-#  name                          :string
-#  name_url                      :string
-#  active                        :boolean          default(FALSE), not null
-#  sorting_order                 :integer
-#  description                   :text
-#  created_at                    :datetime         not null
-#  updated_at                    :datetime         not null
-#  destroyed_at                  :datetime
-#  image_file_name               :string
-#  image_content_type            :string
-#  image_file_size               :integer
-#  image_updated_at              :datetime
-#  background_image_file_name    :string
-#  background_image_content_type :string
-#  background_image_file_size    :integer
-#  background_image_updated_at   :datetime
-#
+# frozen_string_literal: true
 
 class GroupsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access))
+    ensure_user_has_access_rights(%w[content_management_access])
   end
   before_action :get_variables
 
-  # Standard Actions #
   def index
     @groups = Group.paginate(per_page: 50, page: params[:page])
   end
@@ -43,11 +20,11 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @group = Group.new(allowed_params)
+
     if @group.save
       flash[:success] = I18n.t('controllers.groups.create.flash.success')
       redirect_to groups_url
@@ -70,7 +47,7 @@ class GroupsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       Group.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -79,6 +56,7 @@ class GroupsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.groups.destroy.flash.error')
     end
+
     redirect_to groups_url
   end
 

--- a/app/controllers/home_pages_controller.rb
+++ b/app/controllers/home_pages_controller.rb
@@ -1,37 +1,9 @@
-# == Schema Information
-#
-# Table name: home_pages
-#
-#  id                            :integer          not null, primary key
-#  seo_title                     :string
-#  seo_description               :string
-#  subscription_plan_category_id :integer
-#  public_url                    :string
-#  created_at                    :datetime         not null
-#  updated_at                    :datetime         not null
-#  subject_course_id             :integer
-#  custom_file_name              :string
-#  group_id                      :integer
-#  name                          :string
-#  home                          :boolean          default(FALSE)
-#  header_heading                :string
-#  header_paragraph              :text
-#  header_button_text            :string
-#  background_image              :string
-#  header_button_link            :string
-#  header_button_subtext         :string
-#  footer_link                   :boolean          default(FALSE)
-#  mailchimp_list_guid           :string
-#  mailchimp_section_heading     :string
-#  mailchimp_section_subheading  :string
-#  mailchimp_subscribe_section   :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class HomePagesController < ApplicationController
-
   before_action :logged_in_required
   before_action  do
-    ensure_user_has_access_rights(%w(system_requirements_access marketing_resources_access))
+    ensure_user_has_access_rights(%w[system_requirements_access marketing_resources_access])
   end
   before_action :get_variables
 
@@ -52,6 +24,7 @@ class HomePagesController < ApplicationController
 
   def create
     @home_page = HomePage.new(allowed_params)
+
     if @home_page.save
       flash[:success] = I18n.t('controllers.home_pages.create.flash.success')
       redirect_to home_pages_url
@@ -76,15 +49,14 @@ class HomePagesController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.home_pages.destroy.flash.error')
     end
+
     redirect_to home_pages_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @home_page = HomePage.where(id: params[:id]).first
-    end
+    @home_page = HomePage.where(id: params[:id]).first if params[:id].to_i > 0
     @subscription_plan_categories = SubscriptionPlanCategory.all_in_order
     @subject_courses = SubjectCourse.all_active.all_in_order
     @groups = Group.all_active.all_in_order
@@ -113,9 +85,6 @@ class HomePagesController < ApplicationController
                                       ],
                                       external_banners_attributes: [:id, :name, :background_colour,
                                                                     :text_content, :sorting_order,
-                                                                    :_destroy]
-    )
-
+                                                                    :_destroy])
   end
-
 end

--- a/app/controllers/management_consoles_controller.rb
+++ b/app/controllers/management_consoles_controller.rb
@@ -1,18 +1,16 @@
+# frozen_string_literal: true
+
 class ManagementConsolesController < ApplicationController
-
   before_action :logged_in_required
-  before_action except: [:system_requirements] do
-    ensure_user_has_access_rights(%w(non_student_user))
+  before_action except: :system_requirements do
+    ensure_user_has_access_rights(%w[non_student_user])
   end
-  before_action only: [:system_requirements] do
-    ensure_user_has_access_rights(%w(marketing_resources_access system_requirements_access))
+  before_action only: :system_requirements do
+    ensure_user_has_access_rights(%w[marketing_resources_access system_requirements_access])
   end
-  before_action :get_variables
+  before_action :set_layout
 
-
-  def index
-
-  end
+  def index; end
 
   def system_requirements
     @home_pages = HomePage.paginate(per_page: 40, page: params[:page]).all_in_order
@@ -22,12 +20,9 @@ class ManagementConsolesController < ApplicationController
     @faq_sections = FaqSection.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-
-
   protected
 
-  def get_variables
+  def set_layout
     @layout = 'management'
   end
-
 end

--- a/app/controllers/mock_exams_controller.rb
+++ b/app/controllers/mock_exams_controller.rb
@@ -1,29 +1,9 @@
-# == Schema Information
-#
-# Table name: mock_exams
-#
-#  id                       :integer          not null, primary key
-#  subject_course_id        :integer
-#  product_id               :integer
-#  name                     :string
-#  sorting_order            :integer
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  file_file_name           :string
-#  file_content_type        :string
-#  file_file_size           :integer
-#  file_updated_at          :datetime
-#  cover_image_file_name    :string
-#  cover_image_content_type :string
-#  cover_image_file_size    :integer
-#  cover_image_updated_at   :datetime
-#
+# frozen_string_literal: true
 
 class MockExamsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access))
+    ensure_user_has_access_rights(%w[content_management_access])
   end
   before_action :get_variables
 
@@ -64,7 +44,8 @@ class MockExamsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       MockExam.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -79,9 +60,7 @@ class MockExamsController < ApplicationController
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @mock_exam = MockExam.where(id: params[:id]).first
-    end
+    @mock_exam = MockExam.find_by(id: params[:id]) if params[:id].to_i > 0
     @subject_courses = SubjectCourse.all_active.all_in_order
     @products = Product.all_in_order
     @currencies = Currency.all_in_order
@@ -91,5 +70,4 @@ class MockExamsController < ApplicationController
   def allowed_params
     params.require(:mock_exam).permit(:subject_course_id, :name, :sorting_order, :file, :cover_image)
   end
-
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,29 +1,5 @@
 # frozen_string_literal: true
 
-# == Schema Information
-#
-# Table name: orders
-#
-#  id                        :integer          not null, primary key
-#  product_id                :integer
-#  subject_course_id         :integer
-#  user_id                   :integer
-#  stripe_guid               :string
-#  stripe_customer_id        :string
-#  live_mode                 :boolean          default(FALSE)
-#  stripe_status             :string
-#  coupon_code               :string
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  stripe_order_payment_data :text
-#  mock_exam_id              :integer
-#  terms_and_conditions      :boolean          default(FALSE)
-#  reference_guid            :string
-#  paypal_guid               :string
-#  paypal_status             :string
-#  state                     :string
-#
-
 class OrdersController < ApplicationController
   # TODO, Review this controller split student and admin actions
 

--- a/app/controllers/preferred_exam_bodies_controller.rb
+++ b/app/controllers/preferred_exam_bodies_controller.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 class PreferredExamBodiesController < ApplicationController
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(student_user))
+    ensure_user_has_access_rights(%w[student_user])
   end
   before_action :set_user
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @user.update(user_params)

--- a/app/controllers/quiz_questions_controller.rb
+++ b/app/controllers/quiz_questions_controller.rb
@@ -1,30 +1,13 @@
-# == Schema Information
-#
-# Table name: quiz_questions
-#
-#  id                            :integer          not null, primary key
-#  course_module_element_quiz_id :integer
-#  course_module_element_id      :integer
-#  difficulty_level              :string
-#  created_at                    :datetime
-#  updated_at                    :datetime
-#  destroyed_at                  :datetime
-#  subject_course_id             :integer
-#  sorting_order                 :integer
-#  custom_styles                 :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class QuizQuestionsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
     ensure_user_has_access_rights(%w(content_management_access))
   end
   before_action :get_variables, except: :reorder
 
-  def show
-
-  end
+  def show; end
 
   def new
     @quiz_question.quiz_contents.build
@@ -62,7 +45,8 @@ class QuizQuestionsController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       QuizQuestion.find(the_id.to_i).update_attributes!(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -71,6 +55,7 @@ class QuizQuestionsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.quiz_questions.destroy.flash.error')
     end
+
     redirect_to edit_course_module_element_url(@quiz_question.course_module_element_id)
   end
 
@@ -78,14 +63,16 @@ class QuizQuestionsController < ApplicationController
 
   def get_variables
     @mathjax_required = true
-    if params[:id].to_i > 0
-      ## Finds the qq record ##
-      @quiz_question = QuizQuestion.find(params[:id])
-    elsif params[:cme_quiz_id].to_i > 0
-      @quiz_question = QuizQuestion.new(course_module_element_quiz_id: params[:cme_quiz_id])
-    else
-      @quiz_question = QuizQuestion.new(allowed_params)
-    end
+    @quiz_question =
+      if params[:id].to_i > 0
+        ## Finds the qq record ##
+        QuizQuestion.find(params[:id])
+      elsif params[:cme_quiz_id].to_i > 0
+        QuizQuestion.new(course_module_element_quiz_id: params[:cme_quiz_id])
+      else
+        QuizQuestion.new(allowed_params)
+      end
+
     @quiz_questions = QuizQuestion.all_in_order
     seo_title_maker("Quiz Questions #{@quiz_question.try(:id)}", '', true)
     @layout = 'management'
@@ -93,44 +80,43 @@ class QuizQuestionsController < ApplicationController
 
   def allowed_params
     params.require(:quiz_question).permit(
-        :course_module_element_quiz_id,
-        :difficulty_level,
+      :course_module_element_quiz_id,
+      :difficulty_level,
+      :sorting_order,
+      quiz_solutions_attributes: [
+        :id,
+        :quiz_question_id,
+        :quiz_answer_id,
+        :quiz_solution_id,
+        :text_content,
         :sorting_order,
-        quiz_solutions_attributes: [
-            :id,
-            :quiz_question_id,
-            :quiz_answer_id,
-            :quiz_solution_id,
-            :text_content,
-            :sorting_order,
-            :_destroy,
-            :image
-        ],
-        quiz_answers_attributes: [
-            :id,
-            :quiz_question_id,
-            :correct,
-            :degree_of_wrongness,
-            quiz_contents_attributes: [
-                :id,
-                :quiz_question_id,
-                :quiz_answer_id,
-                :text_content,
-                :sorting_order,
-                :_destroy,
-                :image
-            ]
-        ],
+        :_destroy,
+        :image
+      ],
+      quiz_answers_attributes: [
+        :id,
+        :quiz_question_id,
+        :correct,
+        :degree_of_wrongness,
         quiz_contents_attributes: [
-            :id,
-            :quiz_question_id,
-            :quiz_answer_id,
-            :text_content,
-            :sorting_order,
-            :_destroy,
-            :image
+          :id,
+          :quiz_question_id,
+          :quiz_answer_id,
+          :text_content,
+          :sorting_order,
+          :_destroy,
+          :image
         ]
+      ],
+      quiz_contents_attributes: [
+        :id,
+        :quiz_question_id,
+        :quiz_answer_id,
+        :text_content,
+        :sorting_order,
+        :_destroy,
+        :image
+      ]
     )
   end
-
 end

--- a/app/controllers/referral_codes_controller.rb
+++ b/app/controllers/referral_codes_controller.rb
@@ -1,30 +1,23 @@
-# == Schema Information
-#
-# Table name: referral_codes
-#
-#  id         :integer          not null, primary key
-#  user_id    :integer
-#  code       :string(7)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#
+# frozen_string_literal: true
 
 class ReferralCodesController < ApplicationController
   include ApplicationHelper
 
   before_action :logged_in_required, except: [:referral]
   before_action except: [:referral] do
-    ensure_user_has_access_rights(%w(user_management_access))
+    ensure_user_has_access_rights(%w[user_management_access])
   end
-  before_action :get_variables, except: [:referral]
+  before_action :set_layout, except: [:referral]
 
   def index
     @referral_codes = ReferralCode.paginate(per_page: 50, page: params[:page]).with_children.all_in_order
 
-    @codes = params[:search].to_s.blank? ?
-                 @codes = @referral_codes.with_children.all_in_order :
-                 @codes = @referral_codes.with_children.search(params[:search])
-
+    @codes =
+      if params[:search].to_s.blank?
+        @referral_codes.with_children.all_in_order
+      else
+        @referral_codes.with_children.search(params[:search])
+      end
   end
 
   def show
@@ -35,23 +28,25 @@ class ReferralCodesController < ApplicationController
 
   def destroy
     @referral_code = ReferralCode.where(id: params[:id]).first
+
     if @referral_code.destroy
       flash[:success] = I18n.t('controllers.referral_codes.destroy.flash.success')
     else
       flash[:error] = I18n.t('controllers.referral_codes.destroy.flash.error')
     end
+
     redirect_to referral_codes_url
   end
 
   def referral
-    referral_code = ReferralCode.find_by_code(request.params[:ref_code]) if params[:ref_code]
+    referral_code = ReferralCode.find_by(code: request.params[:ref_code]) if params[:ref_code]
     drop_referral_code_cookie(referral_code) if params[:ref_code] && referral_code
     redirect_to root_url
   end
 
-
   def export_referral_codes
     @referral_codes = ReferralCode.with_children.all_in_order
+
     respond_to do |format|
       format.html
       format.csv { send_data @referral_codes.to_csv() }
@@ -61,8 +56,7 @@ class ReferralCodesController < ApplicationController
 
   protected
 
-  def get_variables
+  def set_layout
     @layout = 'management'
   end
-
 end

--- a/app/controllers/referred_signups_controller.rb
+++ b/app/controllers/referred_signups_controller.rb
@@ -1,42 +1,24 @@
-# == Schema Information
-#
-# Table name: referred_signups
-#
-#  id               :integer          not null, primary key
-#  referral_code_id :integer
-#  user_id          :integer
-#  referrer_url     :string(2048)
-#  subscription_id  :integer
-#  maturing_on      :datetime
-#  payed_at         :datetime
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#
+# frozen_string_literal: true
 
 class ReferredSignupsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_management_access))
+    ensure_user_has_access_rights(%w[user_management_access])
   end
 
   def index
-    @referred_signups = params[:payed].to_i == 1 ?
-                          @referred_signups = ReferredSignup
-                                              .where("payed_at is not null")
-                                              .paginate(per_page: 50, page: params[:page]).all_in_order :
-                          @referred_signups = ReferredSignup
-                                              .where(payed_at: nil)
-                                              .paginate(per_page: 50, page: params[:page]).all_in_order
+    condition = params[:payed].to_i == 1 ? 'payed_at is not null' : 'payed_at is null'
+    @referred_signups = ReferredSignup.where(condition).
+                                       paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
   def edit
-    @referred_signup = ReferredSignup.find_by_id(params[:id])
+    @referred_signup = ReferredSignup.find_by(id: params[:id])
   end
 
   def update
-    @referred_signup = ReferredSignup.find_by_id(params[:id])
-    if @referred_signup && @referred_signup.update_attributes(allowed_params)
+    @referred_signup = ReferredSignup.find_by(id: params[:id])
+    if @referred_signup&.update_attributes(allowed_params)
       flash[:success] = I18n.t('controllers.referred_signups.update.flash.success')
       redirect_to referred_signups_url
     else
@@ -44,14 +26,13 @@ class ReferredSignupsController < ApplicationController
     end
   end
 
-
   def export_referred_signups
     referral_code = ReferralCode.find(params[:id])
     @referred_signups = ReferredSignup.where(referral_code_id: params[:id]).all_in_order
 
     respond_to do |format|
       format.html
-      format.csv { send_data @referred_signups.to_csv() }
+      format.csv { send_data @referred_signups.to_csv }
       format.xls { send_data @referred_signups.to_csv(col_sep: "\t", headers: true), filename: "RefCode-#{referral_code.code}-referred-signups-#{Date.today}.xls" }
     end
   end

--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -1,34 +1,14 @@
-# == Schema Information
-#
-# Table name: refunds
-#
-#  id                 :integer          not null, primary key
-#  stripe_guid        :string
-#  charge_id          :integer
-#  stripe_charge_guid :string
-#  invoice_id         :integer
-#  subscription_id    :integer
-#  user_id            :integer
-#  manager_id         :integer
-#  amount             :integer
-#  reason             :text
-#  status             :string
-#  livemode           :boolean          default(TRUE)
-#  stripe_refund_data :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#
+# frozen_string_literal: true
 
 class RefundsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_management_access stripe_management_access))
+    ensure_user_has_access_rights(%w[user_management_access stripe_management_access])
   end
-  before_action :get_variables
+  before_action :set_layout
 
   def show
-    @refund = Refund.where(id: params[:id]).first
+    @refund = Refund.find_by(id: params[:id])
     @user = @refund.user
     @subscription = @refund.subscription
     @invoice = @refund.invoice
@@ -45,6 +25,7 @@ class RefundsController < ApplicationController
 
   def create
     @refund = Refund.new(allowed_params)
+
     if @refund.save
       flash[:success] = I18n.t('controllers.refunds.create.flash.success')
       redirect_to subscription_management_invoice_charge_url(@refund.subscription_id, @refund.invoice_id, @refund.charge_id)
@@ -56,12 +37,11 @@ class RefundsController < ApplicationController
 
   protected
 
-  def get_variables
+  def set_layout
     @layout = 'management'
   end
 
   def allowed_params
     params.require(:refund).permit(:stripe_charge_guid, :charge_id, :invoice_id, :subscription_id, :user_id, :manager_id, :amount, :reason)
   end
-
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,14 +1,12 @@
-class ReportsController < ApplicationController
+# frozen_string_literal: true
 
+class ReportsController < ApplicationController
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access user_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access user_management_access])
   end
 
-
-  def index
-
-  end
+  def index; end
 
   def export_enrollments
     @exam_sitting = ExamSitting.find(params[:exam_sitting_id])
@@ -40,6 +38,4 @@ class ReportsController < ApplicationController
       format.xls { send_data @courses.to_csv(col_sep: "\t", headers: true), filename: "courses-#{Date.today}.xls" }
     end
   end
-
-
 end

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -1,5 +1,6 @@
-class RoutesController < ApplicationController
+# frozen_string_literal: true
 
+class RoutesController < ApplicationController
   def root
     if current_user
       redirect_to student_dashboard_url

--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -1,13 +1,15 @@
-class StudentSignUpsController < ApplicationController
+# frozen_string_literal: true
 
-  before_action :check_logged_in_status, except: [:landing, :subscribe]
+class StudentSignUpsController < ApplicationController
+  before_action :check_logged_in_status, except: %i[landing subscribe]
   before_action :get_variables
-  before_action :create_user_object, only: [:new, :sign_in_or_register, :landing]
-  before_action :create_user_session_object, only: [:sign_in_or_register, :landing]
-  before_action :layout_variables, only: [:home, :landing]
+  before_action :create_user_object, only: %i[new sign_in_or_register landing]
+  before_action :create_user_session_object, only: %i[sign_in_or_register landing]
+  before_action :layout_variables, only: %i[home landing]
 
   def home
     @home_page = HomePage.where(home: true).where(public_url: '/').first
+
     if @home_page
       seo_title_maker(@home_page.seo_title, @home_page.seo_description, @home_page.seo_no_index)
       @footer = @home_page.footer_option
@@ -17,10 +19,10 @@ class StudentSignUpsController < ApplicationController
                       false)
       @footer = 'white'
     end
-    #TODO - Is this call to get subscription plans needed ??
+    # TODO, Is this call to get subscription plans needed ??
     @subscription_plans = SubscriptionPlan.where(subscription_plan_category_id: nil).includes(:currency).in_currency(@currency_id).all_active.all_in_order.limit(3)
     @form_type = 'Home Page Contact'
-    #Added respond block to stop the missing template errors with image, text, json types
+    # Added respond block to stop the missing template errors with image, text, json types
     respond_to do |format|
       format.html
       format.all { redirect_to(missing_page_url) }
@@ -28,7 +30,8 @@ class StudentSignUpsController < ApplicationController
   end
 
   def landing
-    @home_page = HomePage.find_by_public_url(params[:public_url])
+    @home_page = HomePage.find_by(public_url: params[:public_url])
+
     if @home_page
       @public_url = params[:public_url]
       @group = @home_page.group
@@ -36,22 +39,23 @@ class StudentSignUpsController < ApplicationController
 
       if current_user
         ip_country = IpAddress.get_country(request.remote_ip)
-        country = ip_country ? ip_country : Country.find_by_name('United Kingdom')
+        country = ip_country || Country.find_by_name('United Kingdom')
         @currency_id = country.currency_id
       end
 
-      if @home_page.subscription_plan_category && @home_page.subscription_plan_category.current
-        @subscription_plans = @home_page.subscription_plan_category.subscription_plans.for_exam_body(@group.exam_body_id).in_currency(@currency_id).all_active.all_in_order
-      else
-        @subscription_plans = SubscriptionPlan.where(
-            subscription_plan_category_id: nil, exam_body_id: @group.exam_body_id
-        ).includes(:currency).in_currency(@currency_id).all_active.all_in_order.limit(3)
-      end
+      @subscription_plans =
+        if @home_page&.subscription_plan_category&.current
+          @home_page.subscription_plan_category.subscription_plans.for_exam_body(@group.exam_body_id).in_currency(@currency_id).all_active.all_in_order
+        else
+          SubscriptionPlan.where(subscription_plan_category_id: nil, exam_body_id: @group.exam_body_id).
+            includes(:currency).in_currency(@currency_id).all_active.all_in_order.limit(3)
+        end
+
       @preferred_plan = @subscription_plans.where(payment_frequency_in_months: @home_page.preferred_payment_frequency).first
       flash[:plan_guid] = @preferred_plan.guid if @preferred_plan
       flash[:exam_body] = @exam_body.id if @exam_body
 
-      referral_code = ReferralCode.find_by_code(request.params[:ref_code]) if params[:ref_code]
+      referral_code = ReferralCode.find_by(code: request.params[:ref_code]) if params[:ref_code]
       drop_referral_code_cookie(referral_code) if params[:ref_code] && referral_code
       # This is for sticky sub plans
 
@@ -59,6 +63,7 @@ class StudentSignUpsController < ApplicationController
     else
       redirect_to root_url
     end
+
     @footer = @home_page ? @home_page.footer_option : 'white'
     @form_type = 'Landing Page Contact'
   end
@@ -77,7 +82,6 @@ class StudentSignUpsController < ApplicationController
     seo_title_maker('Free Basic Plan Registration | LearnSignal',
                     'Register for our basic membership plan to access your essential course materials and discover the smarter way to study with learnsignal.',
                     false)
-
   end
 
   def create
@@ -93,6 +97,7 @@ class StudentSignUpsController < ApplicationController
         currency: user_currency
       )
     )
+
     @user.pre_creation_setup
 
     if @user.valid? && @user.save
@@ -112,8 +117,7 @@ class StudentSignUpsController < ApplicationController
         flash[:datalayer_body] = @user.try(:preferred_exam_body).try(:name)
         redirect_to personal_sign_up_complete_url
       end
-
-    elsif request && request.referrer
+    elsif request&.referrer
       set_session_errors(@user)
       redirect_to request.referrer
     else
@@ -124,17 +128,12 @@ class StudentSignUpsController < ApplicationController
   def show
     @banner = nil
     seo_title_maker('Thank You for Registering | LearnSignal',
-                    "Thank you for registering to our basic membership plan you can now explore our course content and discover the smarter way to study with learnsignal.",
+                    'Thank you for registering to our basic membership plan you can now explore our course content and discover the smarter way to study with learnsignal.',
                     false)
   end
 
   def subscribe
-    if params[:mailchimp_list_guid] && !params[:mailchimp_list_guid].empty?
-      list_id = params[:mailchimp_list_guid]
-    else
-      list_id = 'a716c282e2' # Newsletter List
-    end
-
+    list_id = params[:mailchimp_list_guid].presence || 'a716c282e2' # Newsletter List
     email = params[:email][:address]
     full_name = params[:full_name][:address] if params[:full_name]
     first_name = params[:first_name][:address] if params[:first_name]
@@ -143,7 +142,7 @@ class StudentSignUpsController < ApplicationController
     course_name = params[:course]
     date_of_birth = params[:date_of_birth][:address] if params[:date_of_birth]
 
-    if !email.blank?
+    if email.present?
       begin
         # Bootcamp Guarantee List has Student Number Field other do not
         if params[:student_number]
@@ -158,33 +157,32 @@ class StudentSignUpsController < ApplicationController
         end
 
         respond_to do |format|
-          format.json{render json: {message: 'Success! Check your email to confirm your subscription.'}}
+          format.json { render json: { message: 'Success! Check your email to confirm your subscription.' } }
         end
       rescue Mailchimp::ListAlreadySubscribedError
         respond_to do |format|
-          format.json{render json: {message: "#{email} is already subscribed to the list"}}
+          format.json { render json: { message: "#{email} is already subscribed to the list" } }
         end
       rescue Mailchimp::ListDoesNotExistError
         respond_to do |format|
-          format.json{render json: {message: 'The list could not be found.'}}
+          format.json { render json: { message: 'The list could not be found.' } }
         end
-      rescue Mailchimp::Error => ex
-        if ex.message
+      rescue Mailchimp::Error => e
+        if e.message
           respond_to do |format|
-            format.json{render json: {message: 'There was an error. Please enter valid email.'}}
+            format.json { render json: { message: 'There was an error. Please enter valid email.' } }
           end
-          Rails.logger.error "ERROR: Mailchimp#error - Returned #{ex.message}"
+          Rails.logger.error "ERROR: Mailchimp#error - Returned #{e.message}"
         else
           respond_to do |format|
-            format.json{render json: {message: 'An unknown error occurred.'}}
+            format.json { render json: { message: 'An unknown error occurred.' } }
           end
         end
       end
     else
       respond_to do |format|
-        format.json{render json: {message: 'Email Address Cannot be blank. Please enter valid email.'}}
+        format.json { render json: { message: 'Email Address Cannot be blank. Please enter valid email.' } }
       end
-
     end
   end
 
@@ -192,7 +190,7 @@ class StudentSignUpsController < ApplicationController
 
   def student_allowed_params
     params.require(:user).permit(
-      :email, :first_name, :last_name, :preferred_exam_body_id, :country_id, 
+      :email, :first_name, :last_name, :preferred_exam_body_id, :country_id,
       :locale, :password, :password_confirmation, :terms_and_conditions,
       :communication_approval
     )
@@ -202,43 +200,44 @@ class StudentSignUpsController < ApplicationController
     @user = User.new
     # Setting the country and currency by the IP look-up, if it fails both values are set for primary marketing audience (currently GB). This also insures values are set for test environment.
     ip_country = IpAddress.get_country(request.remote_ip)
-    @country = ip_country ? ip_country : Country.find_by_name('United Kingdom')
+    @country = ip_country || Country.find_by(name: 'United Kingdom')
     if @country
       @user.country_id = @country.id
       @currency_id = @country.currency_id
     end
-    #To allow displaying of sign_up_errors and valid params since a redirect is used at the end of student_create because it might have to redirect to home or landing actions
-    if session[:sign_up_errors] && session[:valid_params]
-      session[:sign_up_errors].each do |k, v|
-        v.each { |err| @user.errors.add(k, err) }
-      end
-      @user.first_name = session[:valid_params][0]
-      @user.last_name = session[:valid_params][1]
-      @user.email = session[:valid_params][2]
-      @user.terms_and_conditions = session[:valid_params][3]
-      @user.preferred_exam_body_id = session[:valid_params][4]
-      session.delete(:sign_up_errors)
-      session.delete(:valid_params)
+
+    # To allow displaying of sign_up_errors and valid params since a redirect is used at the end of student_create because it might have to redirect to home or landing actions
+    return unless session[:sign_up_errors] && session[:valid_params]
+
+    session[:sign_up_errors].each do |k, v|
+      v.each { |err| @user.errors.add(k, err) }
     end
+    @user.first_name = session[:valid_params][0]
+    @user.last_name = session[:valid_params][1]
+    @user.email = session[:valid_params][2]
+    @user.terms_and_conditions = session[:valid_params][3]
+    @user.preferred_exam_body_id = session[:valid_params][4]
+    session.delete(:sign_up_errors)
+    session.delete(:valid_params)
   end
 
   def create_user_session_object
     @user_session = UserSession.new
-    #To allow displaying of user_session_errors
-    if session[:login_errors] && session[:valid_user_session_params]
-      session[:login_errors].each do |k, v|
-        v.each { |err| @user_session.errors.add(k, err) }
-      end
-      @user_session.email = session[:valid_user_session_params][0]
-      @user_session.password = session[:valid_user_session_params][1]
-      session.delete(:login_errors)
-      session.delete(:valid_user_session_params)
+    # To allow displaying of user_session_errors
+    return unless session[:login_errors] && session[:valid_user_session_params]
+
+    session[:login_errors].each do |k, v|
+      v.each { |err| @user_session.errors.add(k, err) }
     end
+    @user_session.email = session[:valid_user_session_params][0]
+    @user_session.password = session[:valid_user_session_params][1]
+    session.delete(:login_errors)
+    session.delete(:valid_user_session_params)
   end
 
   def check_logged_in_status
     if params[:home_pages_public_url].to_s == '500-page'
-      render file: 'public/500.html', layout: nil, status: 500
+      render file: 'public/500.html', layout: nil, status: :internal_server_error
     elsif current_user
       redirect_to student_dashboard_url
     end
@@ -270,13 +269,13 @@ class StudentSignUpsController < ApplicationController
   end
 
   def set_session_errors(user)
-    session[:sign_up_errors] = user.errors unless user.errors.empty?
-    session[:valid_params] = [
-      user.first_name,
-      user.last_name,
-      user.email,
-      user.terms_and_conditions,
-      user.preferred_exam_body_id
-    ] unless user.errors.empty?
+    return if user.errors.empty?
+
+    session[:sign_up_errors] = user.errors
+    session[:valid_params] = [user.first_name,
+                              user.last_name,
+                              user.email,
+                              user.terms_and_conditions,
+                              user.preferred_exam_body_id]
   end
 end

--- a/app/controllers/subject_course_resources_controller.rb
+++ b/app/controllers/subject_course_resources_controller.rb
@@ -1,28 +1,9 @@
-# == Schema Information
-#
-# Table name: subject_course_resources
-#
-#  id                       :integer          not null, primary key
-#  name                     :string
-#  subject_course_id        :integer
-#  description              :text
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  file_upload_file_name    :string
-#  file_upload_content_type :string
-#  file_upload_file_size    :integer
-#  file_upload_updated_at   :datetime
-#  external_url             :string
-#  active                   :boolean          default(FALSE)
-#  sorting_order            :integer
-#  available_on_trial       :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class SubjectCourseResourcesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(content_management_access))
+    ensure_user_has_access_rights(%w[content_management_access])
   end
   before_action :get_variables
 
@@ -30,18 +11,17 @@ class SubjectCourseResourcesController < ApplicationController
     @subject_course_resources = SubjectCourseResource.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @subject_course_resource = SubjectCourseResource.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @subject_course_resource = SubjectCourseResource.new(allowed_params)
+
     if @subject_course_resource.save
       flash[:success] = I18n.t('controllers.subject_course_resources.create.flash.success')
       redirect_to course_resources_url(@subject_course_resource.subject_course)
@@ -64,7 +44,7 @@ class SubjectCourseResourcesController < ApplicationController
     array_of_ids.each_with_index do |the_id, counter|
       SubjectCourseResource.find(the_id.to_i).update_attributes(sorting_order: (counter + 1))
     end
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def destroy
@@ -73,15 +53,14 @@ class SubjectCourseResourcesController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.subject_course_resources.destroy.flash.error')
     end
+
     redirect_to subject_course_resources_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @subject_course_resource = SubjectCourseResource.where(id: params[:id]).first
-    end
+    @subject_course_resource = SubjectCourseResource.find_by(id: params[:id]) if params[:id].to_i > 0
     @subject_courses = SubjectCourse.all_active.all_in_order
     @layout = 'management'
   end
@@ -91,5 +70,4 @@ class SubjectCourseResourcesController < ApplicationController
                                                     :file_upload, :external_url, :active,
                                                     :sorting_order, :available_on_trial)
   end
-
 end

--- a/app/controllers/subscription_management_controller.rb
+++ b/app/controllers/subscription_management_controller.rb
@@ -1,40 +1,35 @@
-class SubscriptionManagementController < ApplicationController
+# frozen_string_literal: true
 
+class SubscriptionManagementController < ApplicationController
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_management_access))
+    ensure_user_has_access_rights(%w[user_management_access])
   end
-  before_action :get_variables
-
+  before_action :set_layout
+  before_action :set_subscrition, except: %i[show pdf_invoice]
+  before_action :set_invoice, only: %i[invoice pdf_invoice charge]
 
   def show
-    @subscription = Subscription.where(id: params[:id]).first
-    @user = @subscription.user
+    @subscription = Subscription.find_by(id: params[:id])
+    @user         = @subscription.user
   end
 
   def invoice
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
-    @invoice = Invoice.where(id: params[:invoice_id]).first
-    @user = @invoice.user
+    @user    = @invoice.user
     @charges = @invoice.charges
   end
 
   def pdf_invoice
-    invoice = Invoice.where(id: params[:invoice_id]).first
-    if invoice
-      @invoice = invoice
-      @invoice_date = invoice.issued_at
-      description = t("views.general.subscription_in_months.a#{@invoice.subscription.subscription_plan.payment_frequency_in_months}")
-      if @invoice.vat_rate
-        vat_rate = @invoice.vat_rate.percentage_rate.to_s + '%'
-      else
-        vat_rate = '0%'
-      end
+    if @invoice
+      @invoice_date = @invoice.issued_at
+      description   = t("views.general.subscription_in_months.a#{@invoice.subscription.subscription_plan.payment_frequency_in_months}")
+      vat_rate      = @invoice.vat_rate ? @invoice.vat_rate.percentage_rate.to_s + '%' : '0%'
+
       respond_to do |format|
         format.html
         format.pdf do
           pdf = InvoiceDocument.new(@invoice, view_context, description, vat_rate, @invoice_date)
-          send_data pdf.render, filename: "invoice_#{@invoice.created_at.strftime("%d/%m/%Y")}.pdf", type: "application/pdf", disposition: "inline"
+          send_data pdf.render, filename: "invoice_#{@invoice.created_at.strftime('%d/%m/%Y')}.pdf", type: 'application/pdf', disposition: 'inline'
         end
       end
     else
@@ -43,40 +38,37 @@ class SubscriptionManagementController < ApplicationController
   end
 
   def charge
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
-    @invoice = Invoice.where(id: params[:invoice_id]).first
-    @charge = Charge.where(id: params[:id]).first
+    @charge       = Charge.find_by(id: params[:id])
     @subscription = @invoice.subscription
-    @user = @invoice.user
-    @charges = @invoice.charges
+    @user         = @invoice.user
+    @charges      = @invoice.charges
   end
 
   def un_cancel_subscription
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
-    if @subscription && @subscription.stripe_status == 'canceled-pending'
+    if @subscription&.stripe_status == 'canceled-pending'
       @subscription.un_cancel
 
-      if @subscription && @subscription.errors.count == 0
+      if @subscription&.errors&.count&.zero?
         flash[:success] = I18n.t('controllers.subscription_management.un_cancel_subscription.flash.success')
       else
         Rails.logger.error "ERROR: SubscriptionManagement#un_cancel_subscription - something went wrong. Errors:#{@subscription.errors.inspect}"
         flash[:error] = I18n.t('controllers.subscription_management.un_cancel_subscription.flash.error')
       end
-      redirect_to subscription_management_url(@subscription)
     else
       flash[:error] = I18n.t('controllers.subscription_management.un_cancel_subscription.flash.not_pending_sub')
-      redirect_to subscription_management_url(@subscription)
     end
+
+    redirect_to subscription_management_url(@subscription)
   end
 
   def cancel
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
     if SubscriptionService.new(@subscription).cancel_subscription
       flash[:success] = I18n.t('controllers.subscription_management.cancel.flash.success')
     else
       Rails.logger.warn "WARN: SubscriptionManagement#cancel failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
       flash[:error] = I18n.t('controllers.subscription_management.cancel.flash.error')
     end
+
     redirect_to subscription_management_url(@subscription)
   rescue Learnsignal::SubscriptionError => e
     flash[:error] = e.message
@@ -84,13 +76,13 @@ class SubscriptionManagementController < ApplicationController
   end
 
   def immediate_cancel
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
     if SubscriptionService.new(@subscription).cancel_subscription_immediately
       flash[:success] = I18n.t('controllers.subscription_management.immediately_cancel.flash.success')
     else
       Rails.logger.warn "WARN: SubscriptionManagement#immediately_cancel failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
       flash[:error] = I18n.t('controllers.subscription_management.immediately_cancel.flash.error')
     end
+
     redirect_to subscription_management_url(@subscription)
   rescue Learnsignal::SubscriptionError => e
     flash[:error] = e.message
@@ -98,22 +90,27 @@ class SubscriptionManagementController < ApplicationController
   end
 
   def reactivate_subscription
-    @subscription = Subscription.where(id: params[:subscription_management_id]).first
     if @subscription.reactivate_canceled
       flash[:success] = I18n.t('controllers.subscription_management.reactivate_canceled.flash.success')
     else
       Rails.logger.warn "WARN: SubscriptionManagement#reactivate_canceled failed to reactivate a subscription. Errors:#{@subscription.errors.inspect}"
       flash[:error] = I18n.t('controllers.subscription_management.reactivate_canceled.flash.error') << @subscription.errors[:base].to_s
     end
+
     redirect_to subscription_management_url(@subscription)
   end
 
-
   protected
 
-  def get_variables
-    @layout = 'management'
-
+  def set_subscrition
+    @subscription = Subscription.find_by(id: params[:subscription_management_id])
   end
 
+  def set_invoice
+    @invoice = Invoice.find_by(id: params[:invoice_id])
+  end
+
+  def set_layout
+    @layout = 'management'
+  end
 end

--- a/app/controllers/subscription_payment_cards_controller.rb
+++ b/app/controllers/subscription_payment_cards_controller.rb
@@ -1,77 +1,47 @@
-# == Schema Information
-#
-# Table name: subscription_payment_cards
-#
-#  id                  :integer          not null, primary key
-#  user_id             :integer
-#  stripe_card_guid    :string
-#  status              :string
-#  brand               :string
-#  last_4              :string
-#  expiry_month        :integer
-#  expiry_year         :integer
-#  address_line1       :string
-#  account_country     :string
-#  account_country_id  :integer
-#  created_at          :datetime
-#  updated_at          :datetime
-#  stripe_object_name  :string
-#  funding             :string
-#  cardholder_name     :string
-#  fingerprint         :string
-#  cvc_checked         :string
-#  address_line1_check :string
-#  address_zip_check   :string
-#  dynamic_last4       :string
-#  customer_guid       :string
-#  is_default_card     :boolean          default(FALSE)
-#  address_line2       :string
-#  address_city        :string
-#  address_state       :string
-#  address_zip         :string
-#  address_country     :string
-#
+# frozen_string_literal: true
 
 class SubscriptionPaymentCardsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(student_user user_management_access))
+    ensure_user_has_access_rights(%w[student_user user_management_access])
   end
-  before_action :get_variables
+  before_action :set_subscription_payment_card, except: %i[create]
 
   def create
     @subscription_payment_card = SubscriptionPaymentCard.new(create_params)
+
     if @subscription_payment_card.save
       flash[:success] = I18n.t('controllers.subscription_payment_cards.create.flash.success')
       redirect_to account_url(anchor: 'payment-details')
     else
-      if @subscription_payment_card.errors.any?
-        flash[:error] = @subscription_payment_card.errors.first[1]
-      else
-        flash[:error] = I18n.t('controllers.subscription_payment_cards.create.flash.error')
-      end
+      flash[:error] =
+        if @subscription_payment_card.errors.any?
+          @subscription_payment_card.errors.first[1]
+        else
+          I18n.t('controllers.subscription_payment_cards.create.flash.error')
+        end
+
       redirect_to account_url(anchor: 'add-card-modal')
     end
   end
 
   def update
-    @subscription_payment_card = SubscriptionPaymentCard.find_by_id(params[:id])
     if @subscription_payment_card.update_as_the_default_card
       flash[:success] = I18n.t('controllers.subscription_payment_cards.update.flash.success')
     else
       flash[:error] = I18n.t('controllers.subscription_payment_cards.update.flash.error')
     end
+
     redirect_to account_url(anchor: 'payment-details')
   end
 
   def destroy
-    @subscription_payment_card = SubscriptionPaymentCard.find_by_id(params[:id])
     if @subscription_payment_card.destroy
       flash[:success] = I18n.t('controllers.subscription_payment_cards.delete.flash.success')
     else
       flash[:error] = I18n.t('controllers.subscription_payment_cards.delete.flash.error')
     end
+
     redirect_to account_url(anchor: 'payment-details')
   end
 
@@ -81,12 +51,11 @@ class SubscriptionPaymentCardsController < ApplicationController
     params.require(:subscription_payment_card).permit(:stripe_token, :user_id)
   end
 
-  def get_variables
-    @subscription_payment_card = current_user.subscription_payment_cards.find_by_id(params[:id]) if params[:id]
+  def set_subscription_payment_card
+    @subscription_payment_card = SubscriptionPaymentCard.find_by(id: params[:id])
   end
 
   def update_params
     params.require(:subscription_payment_card).permit(:make_default_card)
   end
-
 end

--- a/app/controllers/subscription_plan_categories_controller.rb
+++ b/app/controllers/subscription_plan_categories_controller.rb
@@ -1,22 +1,9 @@
-# == Schema Information
-#
-# Table name: subscription_plan_categories
-#
-#  id                   :integer          not null, primary key
-#  name                 :string
-#  available_from       :datetime
-#  available_to         :datetime
-#  guid                 :string
-#  created_at           :datetime
-#  updated_at           :datetime
-#  trial_period_in_days :integer
-#
+# frozen_string_literal: true
 
 class SubscriptionPlanCategoriesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(stripe_management_access))
+    ensure_user_has_access_rights(%w[stripe_management_access])
   end
   before_action :get_variables
 
@@ -24,18 +11,17 @@ class SubscriptionPlanCategoriesController < ApplicationController
     @subscription_plan_categories = SubscriptionPlanCategory.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @subscription_plan_category = SubscriptionPlanCategory.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @subscription_plan_category = SubscriptionPlanCategory.new(allowed_params)
+
     if @subscription_plan_category.save
       flash[:success] = I18n.t('controllers.subscription_plan_categories.create.flash.success')
       redirect_to subscription_plan_categories_url
@@ -53,27 +39,24 @@ class SubscriptionPlanCategoriesController < ApplicationController
     end
   end
 
-
   def destroy
     if @subscription_plan_category.destroy
       flash[:success] = I18n.t('controllers.subscription_plan_categories.destroy.flash.success')
     else
       flash[:error] = I18n.t('controllers.subscription_plan_categories.destroy.flash.error')
     end
+
     redirect_to subscription_plan_categories_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @subscription_plan_category = SubscriptionPlanCategory.where(id: params[:id]).first
-    end
-    @layout = 'management'
+    @layout                     = 'management'
+    @subscription_plan_category = SubscriptionPlanCategory.where(id: params[:id]).first if params[:id].to_i > 0
   end
 
   def allowed_params
     params.require(:subscription_plan_category).permit(:name, :available_from, :available_to, :sub_heading_text)
   end
-
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,33 +1,5 @@
 # frozen_string_literal: true
 
-# == Schema Information
-#
-# Table name: subscriptions
-#
-#  id                       :integer          not null, primary key
-#  user_id                  :integer
-#  subscription_plan_id     :integer
-#  stripe_guid              :string
-#  next_renewal_date        :date
-#  complimentary            :boolean          default(FALSE), not null
-#  stripe_status            :string
-#  created_at               :datetime
-#  updated_at               :datetime
-#  stripe_customer_id       :string
-#  stripe_customer_data     :text
-#  livemode                 :boolean          default(FALSE)
-#  active                   :boolean          default(FALSE)
-#  terms_and_conditions     :boolean          default(FALSE)
-#  coupon_id                :integer
-#  paypal_subscription_guid :string
-#  paypal_token             :string
-#  paypal_status            :string
-#  state                    :string
-#  cancelled_at             :datetime
-#  cancellation_reason      :string
-#  cancellation_note        :text
-#
-
 class SubscriptionsController < ApplicationController
   before_action :logged_in_required
   before_action do
@@ -149,17 +121,17 @@ class SubscriptionsController < ApplicationController
     if @subscription&.stripe_status == 'canceled-pending'
       @subscription.un_cancel
 
-      if @subscription && @subscription.errors.count == 0
+      if @subscription&.errors&.count&.zero?
         flash[:success] = I18n.t('controllers.subscriptions.un_cancel.flash.success')
       else
         Rails.logger.error 'ERROR: SubscriptionsController#un_cancel_subscription - something went wrong.'
         flash[:error] = I18n.t('controllers.subscriptions.un_cancel.flash.error')
       end
-      redirect_to account_url(anchor: 'subscriptions')
     else
       flash[:error] = I18n.t('controllers.application.you_are_not_permitted_to_do_that')
-      redirect_to account_url(anchor: 'subscriptions')
     end
+
+    redirect_to account_url(anchor: 'subscriptions')
   end
 
   # Setting current subscription to cancel-pending or canceled. We don't actually delete the Subscription Record

--- a/app/controllers/user_accounts_controller.rb
+++ b/app/controllers/user_accounts_controller.rb
@@ -1,8 +1,8 @@
-class UserAccountsController < ApplicationController
+# frozen_string_literal: true
 
+class UserAccountsController < ApplicationController
   before_action :logged_in_required
   before_action :get_variables
-
 
   def account_show
     @orders = @user.orders
@@ -25,7 +25,6 @@ class UserAccountsController < ApplicationController
                     'Log in to view your learnsignal account details including personal information, account information, orders, enrolments and referral program.',
                     false)
 
-
     #Restoring errors that could arise for user updating personal details in modal
     if session[:user_update_errors] && session[:valid_params]
       session[:user_update_errors].each do |k, v|
@@ -41,7 +40,7 @@ class UserAccountsController < ApplicationController
   end
 
   def update_user
-    if @user && @user.update_attributes(allowed_params)
+    if @user&.update_attributes(allowed_params)
       flash[:success] = I18n.t('controllers.users.update.flash.success')
       redirect_to account_url
     else
@@ -54,11 +53,11 @@ class UserAccountsController < ApplicationController
   def change_password
     if @user.change_the_password(change_password_params)
       flash[:success] = I18n.t('controllers.users.change_password.flash.success')
-      redirect_to account_url
     else
       flash[:error] = I18n.t('controllers.users.change_password.flash.error')
-      redirect_to account_url
     end
+
+    redirect_to account_url
   end
 
   def subscription_invoice
@@ -72,17 +71,16 @@ class UserAccountsController < ApplicationController
   end
 
   def allowed_params
-    params.require(:user).permit(:email, :first_name, :last_name, :address, :date_of_birth,
-                                 :unsubscribed_from_emails, exam_body_user_details_attributes: [
-                                                                              :id,
-                                                                              :exam_body_id,
-                                                                              :student_number]
-    )
+    params.require(:user).permit(:email, :first_name, :last_name,
+                                 :address, :date_of_birth,
+                                 :unsubscribed_from_emails,
+                                 exam_body_user_details_attributes: [:id,
+                                                                     :exam_body_id,
+                                                                     :student_number])
   end
 
   def get_variables
     @user = current_user
     seo_title_maker('Account Details', '', true)
   end
-
 end

--- a/app/controllers/user_groups_controller.rb
+++ b/app/controllers/user_groups_controller.rb
@@ -1,31 +1,9 @@
-# == Schema Information
-#
-# Table name: user_groups
-#
-#  id                           :integer          not null, primary key
-#  name                         :string
-#  description                  :text
-#  tutor                        :boolean          default(FALSE), not null
-#  site_admin                   :boolean          default(FALSE), not null
-#  created_at                   :datetime
-#  updated_at                   :datetime
-#  system_requirements_access   :boolean          default(FALSE)
-#  content_management_access    :boolean          default(FALSE)
-#  stripe_management_access     :boolean          default(FALSE)
-#  user_management_access       :boolean          default(FALSE)
-#  developer_access             :boolean          default(FALSE)
-#  user_group_management_access :boolean          default(FALSE)
-#  student_user                 :boolean          default(FALSE)
-#  trial_or_sub_required        :boolean          default(FALSE)
-#  blocked_user                 :boolean          default(FALSE)
-#  marketing_resources_access   :boolean          default(FALSE)
-#
+# frozen_string_literal: true
 
 class UserGroupsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_group_management_access))
+    ensure_user_has_access_rights(%w[user_group_management_access])
   end
   before_action :get_variables
 
@@ -33,18 +11,17 @@ class UserGroupsController < ApplicationController
     @user_groups = UserGroup.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @user_group = UserGroup.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @user_group = UserGroup.new(allowed_params)
+
     if @user_group.save
       flash[:success] = I18n.t('controllers.user_groups.create.flash.success')
       redirect_to user_groups_url
@@ -68,15 +45,14 @@ class UserGroupsController < ApplicationController
     else
       flash[:error] = I18n.t('controllers.user_groups.destroy.flash.error')
     end
+
     redirect_to user_groups_url
   end
 
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @user_group = UserGroup.where(id: params[:id]).first
-    end
+    @user_group = UserGroup.find_by(id: params[:id]) if params[:id].to_i.positive?
     seo_title_maker(@user_group.try(:name) || 'User groups', '', true)
     @layout = 'management'
   end
@@ -89,5 +65,4 @@ class UserGroupsController < ApplicationController
                                        :student_user, :trial_or_sub_required, :blocked_user,
                                        :tutor, :exercise_corrections_access)
   end
-
 end

--- a/app/controllers/user_passwords_controller.rb
+++ b/app/controllers/user_passwords_controller.rb
@@ -1,5 +1,6 @@
-class UserPasswordsController < ApplicationController
+# frozen_string_literal: true
 
+class UserPasswordsController < ApplicationController
   before_action :logged_out_required, except: [:manager_resend_email]
   before_action :get_variables
 
@@ -23,7 +24,7 @@ class UserPasswordsController < ApplicationController
 
   def edit
     seo_title_maker('Reset Your Password | LearnSignal',
-                    "Enter a new password for your learnsignal subscription account here to access your online learning materials and start studying today.",
+                    'Enter a new password for your learnsignal subscription account here to access your online learning materials and start studying today.',
                     nil)
 
     if params[:id].to_s.length == 20
@@ -56,12 +57,12 @@ class UserPasswordsController < ApplicationController
         @user.update_attribute(:password_change_required, nil)
         redirect_back_or_default root_url
       else
-        #TODO need to improve if/else statements here.
-        #If @user can't be found then pw reset process needs to start again with
+        # TODO, need to improve if/else statements here.
+        # If @user can't be found then pw reset process needs to start again with
         # new email submission and email with reset link. But currently could not
         # work due to account being set to active after first part of reset process.
 
-        @user = User.find_by_password_reset_token(params[:id])
+        @user = User.find_by(password_reset_token: params[:id])
         if @user
           flash[:error] = I18n.t('controllers.user_passwords.update.flash.error')
           render :edit
@@ -71,7 +72,7 @@ class UserPasswordsController < ApplicationController
         end
       end
     else
-      @user = User.find_by_password_reset_token(params[:id])
+      @user = User.find_by(password_reset_token: params[:id])
       if @user
         flash[:error] = I18n.t('controllers.user_passwords.update.flash.password_and_confirmation_do_not_match')
         render :edit
@@ -84,7 +85,8 @@ class UserPasswordsController < ApplicationController
 
   def set_password
     if params[:id].to_s.length == 20
-      @user = User.where(password_reset_token: params[:id].to_s).first
+      @user = User.find_by(password_reset_token: params[:id].to_s)
+
       if @user
         render :set_password
       else
@@ -99,7 +101,8 @@ class UserPasswordsController < ApplicationController
   end
 
   def create_password
-    time_now = params[:hidden][:communication_approval] ? Proc.new{Time.now}.call : nil
+    time_now = params[:hidden][:communication_approval] ? Proc.new{ Time.now }.call : nil
+
     if params[:password] == params[:password_confirmation]
       # in the params, params[:id] holds the reset_token.
       @user = User.finish_password_reset_process(params[:id], params[:password], params[:password_confirmation])
@@ -112,7 +115,7 @@ class UserPasswordsController < ApplicationController
                                 communication_approval_datetime: time_now)
         redirect_back_or_default library_url
       else
-        @user = User.find_by_password_reset_token(params[:id])
+        @user = User.find_by(password_reset_token: params[:id])
         flash[:error] = I18n.t('controllers.user_passwords.update.flash.error')
         if @user
           render :set_password
@@ -121,7 +124,7 @@ class UserPasswordsController < ApplicationController
         end
       end
     else
-      @user = User.find_by_password_reset_token(params[:id])
+      @user = User.find_by(password_reset_token: params[:id])
       flash[:error] = I18n.t('controllers.user_passwords.update.flash.password_and_confirmation_do_not_match')
       if @user
         render :edit
@@ -130,7 +133,6 @@ class UserPasswordsController < ApplicationController
       end
     end
   end
-
 
   protected
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,83 +1,22 @@
 # frozen_string_literal: true
 
-# == Schema Information
-#
-# Table name: users
-#
-#  id                              :integer          not null, primary key
-#  email                           :string
-#  first_name                      :string
-#  last_name                       :string
-#  address                         :text
-#  country_id                      :integer
-#  crypted_password                :string(128)      default(""), not null
-#  password_salt                   :string(128)      default(""), not null
-#  persistence_token               :string
-#  perishable_token                :string(128)
-#  single_access_token             :string
-#  login_count                     :integer          default(0)
-#  failed_login_count              :integer          default(0)
-#  last_request_at                 :datetime
-#  current_login_at                :datetime
-#  last_login_at                   :datetime
-#  current_login_ip                :string
-#  last_login_ip                   :string
-#  account_activation_code         :string
-#  account_activated_at            :datetime
-#  active                          :boolean          default(FALSE), not null
-#  user_group_id                   :integer
-#  password_reset_requested_at     :datetime
-#  password_reset_token            :string
-#  password_reset_at               :datetime
-#  stripe_customer_id              :string
-#  created_at                      :datetime
-#  updated_at                      :datetime
-#  locale                          :string
-#  guid                            :string
-#  subscription_plan_category_id   :integer
-#  password_change_required        :boolean
-#  session_key                     :string
-#  name_url                        :string
-#  profile_image_file_name         :string
-#  profile_image_content_type      :string
-#  profile_image_file_size         :integer
-#  profile_image_updated_at        :datetime
-#  email_verification_code         :string
-#  email_verified_at               :datetime
-#  email_verified                  :boolean          default(FALSE), not null
-#  stripe_account_balance          :integer          default(0)
-#  free_trial                      :boolean          default(FALSE)
-#  terms_and_conditions            :boolean          default(FALSE)
-#  date_of_birth                   :date
-#  description                     :text
-#  analytics_guid                  :string
-#  student_number                  :string
-#  unsubscribed_from_emails        :boolean          default(FALSE)
-#  communication_approval          :boolean          default(FALSE)
-#  communication_approval_datetime :datetime
-#
-
 class UsersController < ApplicationController
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_management_access))
+    ensure_user_has_access_rights(%w[user_management_access])
   end
   before_action :layout_variables
-  before_action :get_variables, except: [:user_personal_details, :user_subscription_status,
-                                         :user_activity_details, :user_purchases_details,
-                                         :user_courses_status, :user_referral_details]
-  before_action :get_user_variables, only: [:user_personal_details, :user_subscription_status,
-                                            :user_activity_details, :user_purchases_details,
-                                            :user_courses_status, :user_referral_details]
-
+  before_action :get_variables, except: %i[user_personal_details user_subscription_status
+                                           user_activity_details user_purchases_details
+                                           user_courses_status user_referral_details]
+  before_action :get_user_variables, only: %i[user_personal_details user_subscription_status
+                                              user_activity_details user_purchases_details
+                                              user_courses_status user_referral_details]
 
   def index
-    @users =
-      if params[:search_term].to_s.blank?
-        User.sort_by_most_recent.paginate(per_page: 50, page: params[:page])
-      else
-        User.sort_by_most_recent.search_for(params[:search_term].to_s).paginate(per_page: 50, page: params[:page])
-      end
+    @users = User.page(params[:page]).
+               search(params[:search_term]).
+               sort_by_most_recent
   end
 
   def show
@@ -140,9 +79,20 @@ class UsersController < ApplicationController
     redirect_to users_url
   end
 
+  def search
+    @users = User.page(params[:page]).
+               search(params[:search_term]).
+               sort_by_most_recent
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def preview_csv_upload
     @user_groups = UserGroup.all_in_order
-    if params[:upload] && params[:upload].respond_to?(:read)
+
+    if params[:upload]&.respond_to?(:read)
       @csv_data, @has_errors = User.parse_csv(params[:upload].read)
     else
       flash[:error] = t('controllers.dashboard.preview_csv.flash.error')
@@ -197,12 +147,7 @@ class UsersController < ApplicationController
 
   def update_courses
     @user = User.find(params[:user_id]) rescue nil
-
-    if params[:user]
-      @user.subject_course_ids = params[:user][:subject_course_ids]
-    else
-      @user.subject_course_ids = []
-    end
+    @user.subject_course_ids = params[:user] ? params[:user][:subject_course_ids] : []
 
     flash[:success] = I18n.t('controllers.users.update_subjects.flash.success')
     redirect_to users_url
@@ -213,13 +158,11 @@ class UsersController < ApplicationController
   def allowed_params
     params.require(:user).permit(:email, :first_name, :last_name, :user_group_id, :address, :country_id,
                                  :profile_image, :date_of_birth, :description, :student_number, :name_url,
-                                 :stripe_account_balance, student_access_attributes: [:id, :account_type]
-    )
+                                 :stripe_account_balance, student_access_attributes: [:id, :account_type])
   end
 
-
   def get_variables
-    @user        = User.where(id: params[:id]).first
+    @user        = User.find_by(id: params[:id])
     @user_groups = UserGroup.all_not_admin
     @countries   = Country.all_in_order
 
@@ -231,7 +174,7 @@ class UsersController < ApplicationController
   end
 
   def get_user_variables
-    @user = User.where(id: params[:user_id]).first
+    @user = User.find_by(id: params[:user_id])
 
     seo_title_maker("#{@user.full_name} - Details", '', true)
   end

--- a/app/controllers/vat_codes_controller.rb
+++ b/app/controllers/vat_codes_controller.rb
@@ -1,21 +1,9 @@
-# == Schema Information
-#
-# Table name: vat_codes
-#
-#  id         :integer          not null, primary key
-#  country_id :integer
-#  name       :string
-#  label      :string
-#  wiki_url   :string
-#  created_at :datetime
-#  updated_at :datetime
-#
+# frozen_string_literal: true
 
 class VatCodesController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(system_requirements_access stripe_management_access))
+    ensure_user_has_access_rights(%w[system_requirements_access stripe_management_access])
   end
   before_action :get_variables
 
@@ -23,19 +11,18 @@ class VatCodesController < ApplicationController
     @vat_codes = VatCode.paginate(per_page: 50, page: params[:page]).all_in_order
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @vat_code = VatCode.new
     @vat_code.vat_rates.build
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @vat_code = VatCode.new(allowed_params)
+
     if @vat_code.save
       flash[:success] = I18n.t('controllers.vat_codes.create.flash.success')
       redirect_to vat_codes_url
@@ -53,7 +40,6 @@ class VatCodesController < ApplicationController
     end
   end
 
-
   def destroy
     if @vat_code.destroy
       flash[:success] = I18n.t('controllers.vat_codes.destroy.flash.success')
@@ -66,9 +52,7 @@ class VatCodesController < ApplicationController
   protected
 
   def get_variables
-    if params[:id].to_i > 0
-      @vat_code = VatCode.where(id: params[:id]).first
-    end
+    @vat_code = VatCode.find_by(id: params[:id]) if params[:id].to_i.positive?
     @countries = Country.all_in_order
     seo_title_maker(@vat_code.try(:name) || 'VAT Codes', '', true)
     @layout = 'management'

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -1,40 +1,9 @@
-# == Schema Information
-#
-# Table name: visits
-#
-#  id               :uuid             not null, primary key
-#  visitor_id       :uuid
-#  ip               :string
-#  user_agent       :text
-#  referrer         :text
-#  landing_page     :text
-#  user_id          :integer
-#  referring_domain :string
-#  search_keyword   :string
-#  browser          :string
-#  os               :string
-#  device_type      :string
-#  screen_height    :integer
-#  screen_width     :integer
-#  country          :string
-#  region           :string
-#  city             :string
-#  postal_code      :string
-#  latitude         :decimal(, )
-#  longitude        :decimal(, )
-#  utm_source       :string
-#  utm_medium       :string
-#  utm_term         :string
-#  utm_content      :string
-#  utm_campaign     :string
-#  started_at       :datetime
-#
+# frozen_string_literal: true
 
 class VisitsController < ApplicationController
-
   before_action :logged_in_required
   before_action do
-    ensure_user_has_access_rights(%w(user_management_access))
+    ensure_user_has_access_rights(%w[user_management_access])
   end
   before_action :get_variables
 
@@ -44,15 +13,16 @@ class VisitsController < ApplicationController
   end
 
   def all_index
-    @visits = params[:search_term].to_s.blank? ?
-        @visits = Visit.order(started_at: :desc).paginate(per_page: 50, page: params[:page]) :
-        @visits = Visit.search_for(params[:search_term].to_s).
-            paginate(per_page: 50, page: params[:page])
-
+    @visits =
+      if params[:search_term].to_s.blank?
+        Visit.order(started_at: :desc).paginate(per_page: 50, page: params[:page])
+      else
+        Visit.search_for(params[:search_term].to_s).paginate(per_page: 50, page: params[:page])
+      end
   end
 
   def show
-    @user = User.find(params[:user_id])
+    @user  = User.find(params[:user_id])
     @visit = Visit.find(params[:id])
   end
 
@@ -66,5 +36,4 @@ class VisitsController < ApplicationController
     seo_title_maker('User Visits', nil, false)
     @layout = 'management'
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,9 +12,8 @@ module ApplicationHelper
             "<span style='color: #ffffff;' class='glyphicon glyphicon-flag'></span>".html_safe
   end
 
-  def number_in_local_currency(amount, currency_id)
-    ccy = Currency.find(currency_id)
-    number_to_currency(amount, unit: ccy.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.decimal_separator'), precision: 2)
+  def number_in_local_currency(amount, currency)
+    number_to_currency(amount, unit: currency.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.decimal_separator'), precision: 2)
   end
 
   def number_in_local_currency_no_precision(amount, currency_id)

--- a/app/helpers/remote_link_pagination_helper.rb
+++ b/app/helpers/remote_link_pagination_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module RemoteLinkPaginationHelper
+  class LinkRenderer < WillPaginate::ActionView::LinkRenderer
+    def link(text, target, attributes = {})
+      attributes['data-remote'] = true
+      super
+    end
+  end
+end

--- a/app/models/invoice_line_item.rb
+++ b/app/models/invoice_line_item.rb
@@ -29,8 +29,7 @@ class InvoiceLineItem < ApplicationRecord
 
   # validation
   validates :invoice_id, :amount, :currency_id, presence: true
-  validates :subscription_id, :subscription_plan_id, :period_start_at,
-            :period_end_at, presence: true, if: :subscription_invoice?
+  validates :subscription_id, :subscription_plan_id, presence: true, if: :subscription_invoice?
 
   # callbacks
   before_destroy :check_dependencies

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -23,7 +23,7 @@
 
 class Product < ApplicationRecord
   include ActionView::Helpers::NumberHelper
-  include LearnSignalModelExtras
+
   enum product_type: { mock_exam: 0, correction_pack: 1 }
 
   # Constants
@@ -31,84 +31,78 @@ class Product < ApplicationRecord
   # relationships
   belongs_to :currency
   belongs_to :mock_exam
-  has_many :orders
-  has_many :exercises
+  has_many :orders, dependent: :restrict_with_error
+  has_many :exercises, dependent: :restrict_with_error
 
   # validation
   validates :name, presence: true
-  validates :mock_exam_id, presence: true,
-            numericality: { only_integer: true, greater_than: 0 }
+  validates :mock_exam_id, presence: true, numericality: { only_integer: true,
+                                                           greater_than: 0 }
   validates :currency_id, presence: true
   validates :price, presence: true
   validates :stripe_guid, presence: true, uniqueness: true, on: :update
   validates :stripe_sku_guid, presence: true, uniqueness: true, on: :update
-  validates :correction_pack_count,
-              presence: true,
-              numericality: {
-                only_integer: true, greater_than: 0
-              }, if: Proc.new { |prod| prod.correction_pack? }
+  validates :correction_pack_count, presence: true,
+                                    numericality: { only_integer: true,
+                                                    greater_than: 0 }, if: proc { |prod| prod.correction_pack? }
 
   # callbacks
   after_create :create_on_stripe
   after_update :update_on_stripe
-  before_destroy :check_dependencies
 
   # scopes
   scope :all_in_order, -> { order(:sorting_order, :name) }
-  scope :all_active, -> { where(active: true).includes(mock_exam: :subject_course) }
-  scope :in_currency, lambda { |ccy_id| where(currency_id: ccy_id) }
-
-  # class methods
+  scope :all_active,   -> { where(active: true).includes(mock_exam: :subject_course) }
+  scope :in_currency,  ->(ccy_id) { where(currency_id: ccy_id) }
 
   # instance methods
   def destroyable?
-    self.orders.empty?
+    orders.empty?
   end
 
+  # class methods
   def self.search(search)
-    return where('name ILIKE ?', "%#{search}%") if search.present?
+    search.present? ? where('name ILIKE ?', "%#{search}%") : all
+  end
 
-    Product.all_active.all_in_order
+  def self.filter_by_state(state)
+    case state
+    when 'Inactive'
+      where(active: false)
+    when 'All'
+      all
+    else
+      where(active: true)
+    end
   end
 
   ## Creates product object on stripe and updates attributes here with response data ##
   def create_on_stripe
-    unless Rails.env.test?
-      stripe_product = Stripe::Product.create(name: self.name,
-                                              shippable: false,
-                                              active: self.active)
-      self.live_mode = stripe_product.livemode
-      self.stripe_guid = stripe_product.id
+    return if Rails.env.test?
 
-      stripe_sku = Stripe::SKU.create(product: stripe_product.id,
-                                      currency: self.currency.iso_code,
-                                      price: (self.price.to_f * 100).to_i,
-                                      active: true,
-                                      inventory: { type: 'infinite' })
-      self.stripe_sku_guid = stripe_sku.id
-      self.save!
-    end
+    stripe_product   = Stripe::Product.create(name: name, shippable: false, active: active)
+    self.live_mode   = stripe_product.livemode
+    self.stripe_guid = stripe_product.id
+
+    stripe_sku = Stripe::SKU.create(product: stripe_product.id,
+                                    currency: currency.iso_code,
+                                    price: (price.to_f * 100).to_i,
+                                    active: true,
+                                    inventory: { type: 'infinite' })
+    self.stripe_sku_guid = stripe_sku.id
+    save!
   end
 
   ## Updates stripe product object ##
   def update_on_stripe
     unless Rails.env.test?
-      stripe_product = Stripe::Product.retrieve(id: self.stripe_guid)
-      stripe_product.name = self.name
-      stripe_product.active = self.active
+      stripe_product = Stripe::Product.retrieve(id: stripe_guid)
+      stripe_product.name = name
+      stripe_product.active = active
       stripe_product.save
     end
   rescue => e
     errors.add(:stripe, e.message)
     false
-  end
-
-  protected
-  def check_dependencies
-    unless self.destroyable?
-      errors.add(:base, I18n.t('models.general.dependencies_exist'))
-      false
-      throw :abort
-    end
   end
 end

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -107,12 +107,16 @@ class SubscriptionPlan < ApplicationRecord
 
   end
 
+  def self.by_exam_body(exam_body_id)
+    exam_body_id ? where(exam_body_id: exam_body_id) : all
+  end
+
   def self.search(search)
     if search
       where('name ILIKE ? OR stripe_guid ILIKE ? OR paypal_guid ILIKE ? OR guid ILIKE ?',
             "%#{search}%", "%#{search}%", "%#{search}%", "%#{search}%")
     else
-      SubscriptionPlan.all_active.all_in_order
+      all
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,7 +131,6 @@ class User < ApplicationRecord
 
   # scopes
   scope :all_in_order, -> { order(:user_group_id, :last_name, :first_name, :email) }
-  scope :search_for, lambda { |search_term| where("email ILIKE :t OR first_name ILIKE :t OR last_name ILIKE :t OR stripe_customer_id ILIKE :t OR textcat(first_name, textcat(text(' '), last_name)) ILIKE :t", t: '%' + search_term + '%') }
   scope :sort_by_email, -> { order(:email) }
   scope :sort_by_name, -> { order(:last_name, :first_name) }
   scope :sort_by_most_recent, -> { order(created_at: :desc) }
@@ -141,8 +140,11 @@ class User < ApplicationRecord
   scope :active_this_week, -> { where(last_request_at: Time.now.beginning_of_week..Time.now.end_of_week) }
   scope :with_course_tutor_details, -> { joins(:course_tutor_details) }
 
-
   ### class methods
+  def self.search(term)
+    where("email ILIKE :t OR first_name ILIKE :t OR last_name ILIKE :t OR stripe_customer_id ILIKE :t OR textcat(first_name, textcat(text(' '), last_name)) ILIKE :t", t: "%#{term}%")
+  end
+
   def self.all_students
     includes(:user_group).references(:user_groups).where('user_groups.student_user = ?', true)
   end

--- a/app/views/admin/exercises/index.html.haml
+++ b/app/views/admin/exercises/index.html.haml
@@ -8,7 +8,7 @@
     .row
       .col-sm-12
         .box-item.table-box
-          .row            
+          .row
             .col-sm
               .search-container.mb-3.float-right
                 =form_tag(admin_search_exercises_url, role: 'form', class: 'form-inline') do

--- a/app/views/courses/_cme_nav.html.haml
+++ b/app/views/courses/_cme_nav.html.haml
@@ -1,9 +1,9 @@
 .d-flex.flex-wrap.flex-sm-nowrap.justify-content-between
   .mw-0
-    =link_to course_special_link(cme, @course.group.exam_body_id, @subject_course_user_log), class: 'btn btn-secondary btn-sm mb-3 mb-sm-0' do
+    =link_to course_special_link(cme, @subject_course_user_log), class: 'btn btn-secondary btn-sm mb-3 mb-sm-0' do
       =t('views.course_module_elements.show.retake_quiz')
 
   .mw-0
-    =link_to course_special_link(cme.next_element, @course.group.exam_body_id, @subject_course_user_log) do
+    =link_to course_special_link(cme.next_element, @subject_course_user_log) do
       .btn.btn-primary.btn-sm.btn-sm-arrow-right
         =t('views.course_module_elements.show.next_step')

--- a/app/views/courses/_constructed_response.html.haml
+++ b/app/views/courses/_constructed_response.html.haml
@@ -33,7 +33,7 @@
 
           &#124;
           %li
-            =link_to course_special_link(@course_module_element, @group.exam_body_id, @subject_course_user_log), class: 'cr-nav-link' do
+            =link_to course_special_link(@course_module_element, @subject_course_user_log), class: 'cr-nav-link' do
               -# Add 'Confirm' Modal
               ='Exit'
 

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -9,7 +9,7 @@
 
           -if @course_module_element && @course_module_element.is_video?
             .mw-0
-              =link_to course_special_link(@course_module_element.next_element, @group.exam_body_id, @subject_course_user_log) do
+              =link_to course_special_link(@course_module_element.next_element, @subject_course_user_log) do
                 .btn.btn-primary.btn-sm.btn-sm-arrow-right
                   =t('views.course_module_elements.show.next_step')
 

--- a/app/views/footer_pages/media_library.html.haml
+++ b/app/views/footer_pages/media_library.html.haml
@@ -42,7 +42,7 @@
                         .pt-2
                           %i.budicon-files-tick{"aria-label" => "", :role => "img"}
                         %p.h6.text-ellipsis.pt-4
-                          =number_in_local_currency(product.price, product.currency_id)
+                          =number_in_local_currency(product.price, product.currency)
                         .pt-2
                           %span.btn.btn-secondary.btn-sm.btn-sm-arrow-right Buy Now
 
@@ -61,7 +61,7 @@
                       .pt-2
                         %i.budicon-files-tick{"aria-label" => "", :role => "img"}
                       %p.h6.text-ellipsis.pt-4
-                        =number_in_local_currency(question.price, question.currency_id)
+                        =number_in_local_currency(question.price, question.currency)
                       .pt-2
                         %span.btn.btn-secondary.btn-sm.btn-sm-arrow-right Buy Now
 

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -26,7 +26,7 @@
                           %tr
                             %td=invoice.id
                             %td=humanize_datetime(invoice.issued_at)
-                            %td=number_in_local_currency(invoice.total, invoice.currency_id)
+                            %td=number_in_local_currency(invoice.total, invoice.currency)
                             %td=invoice_type(invoice)
                             %td
                               %span{class: invoice.status == 'Paid' ? 'text-success' : 'text-danger'}

--- a/app/views/library/course_show.html.haml
+++ b/app/views/library/course_show.html.haml
@@ -108,7 +108,7 @@
 
                               - if current_user #Logged In User
                                 -if @valid_subscription
-                                  =link_to course_special_link(cme, @group.exam_body_id, @subject_course_user_log), class: 'btn btn-text py-3 w-100 text-left' do
+                                  =link_to course_special_link(cme, @subject_course_user_log), class: 'btn btn-text py-3 w-100 text-left' do
                                     .lesson-item.lesson-item-inner.w-100{class: @cmeuls && @cmeuls_ids.include?(cme.id) ? (@completed_cmeuls_cme_ids.include?(cme.id) ? 'completed' : 'failed') : ''}
                                       %i.material-icons.icon-bg-round{"aria-label" => "failed", :role => "img"}
                                         =cme.icon_label
@@ -136,7 +136,7 @@
 
                                   - if permission[:view]
 
-                                    =link_to course_special_link(cme, @group.exam_body_id, @subject_course_user_log), class: 'btn btn-text py-3 w-100 text-left' do
+                                    =link_to course_special_link(cme, @subject_course_user_log), class: 'btn btn-text py-3 w-100 text-left' do
                                       .lesson-item.lesson-item-inner.w-100{class: @cmeuls && @cmeuls_ids.include?(cme.id) ? (@completed_cmeuls_cme_ids.include?(cme.id) ? 'completed' : 'failed') : ''}
                                         %i.material-icons.icon-bg-round{"aria-label" => "failed", :role => "img"}
                                           =cme.icon_label

--- a/app/views/orders/_order_card_form.html.haml
+++ b/app/views/orders/_order_card_form.html.haml
@@ -10,7 +10,7 @@
       %h4.m-0.pt-2
         Total:
         %span.value
-          =number_in_local_currency(@product.price, @product.currency_id)
+          =number_in_local_currency(@product.price, @product.currency)
 
     .col-sm-6.mb-2.mt-sm-4
       = f.button :submit, class: 'btn btn-primary w-100 mb-2', id: 'card_submit' do

--- a/app/views/orders/_paypal_form.html.haml
+++ b/app/views/orders/_paypal_form.html.haml
@@ -4,7 +4,7 @@
       %h4.m-0
         Total:
         %span.value#paypal-total-value
-          =number_in_local_currency(@product.price, @product.currency_id)
+          =number_in_local_currency(@product.price, @product.currency)
 
     .col-sm-6.mb-2.mt-sm-4.text-center
       = f.button :submit, class: 'btn btn-img mb-4', id: 'paypal_submit' do

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -36,7 +36,7 @@
                             .h6.text-ellipsis
                               Total:
                               %span
-                                =number_in_local_currency(@product.price, @product.currency_id)
+                                =number_in_local_currency(@product.price, @product.currency)
                   .px-4
                     %p.text-left
                       -if @product.mock_exam?

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -15,12 +15,12 @@
               =link_to 'Mock Exams', mock_exams_url, class: 'btn btn-secondary btn-xs', title: t('views.general.new_tooltip')
 
             .col-sm
-              .search-container
+              .search-container.mb-3.float-right
                 =form_tag(products_url, method: :get, role: 'form', class: 'form-inline') do
+                  =select_tag :state, options_for_select(['Active', 'Inactive', 'All'], params[:state] || 'Active'), class: 'form-control custom-select filter mr-3'
                   =text_field_tag :search, params[:search], class: 'form-control', placeholder: t('views.general.search')
-                  %button{type: "submit"}
+                  %button{type: "submit", class: 'ml-3'}
                     %i{:role => "img", class: 'budicon-search-list'}
-
 
           .table-responsive.pt-4
             Please sort in blocks of the 3 currencies for each product
@@ -33,7 +33,7 @@
                   %th
                   %th
               %tbody
-                -@products.all_in_order.each do |product|
+                -@products.each do |product|
                   %tr{id: product.id}
                     %td
                       =product.name
@@ -41,7 +41,7 @@
                         -if product.mock_exam
                           =product.mock_exam.name
                     %td=tick_or_cross(product.active)
-                    %td=number_in_local_currency(product.price, product.currency_id)
+                    %td=number_in_local_currency(product.price, product.currency)
                     %td
                       =link_to 'Edit', edit_product_url(product), class: 'btn btn-primary btn-xs'
                       -if product.mock_exam

--- a/app/views/student_sign_ups/_default.html.haml
+++ b/app/views/student_sign_ups/_default.html.haml
@@ -92,7 +92,7 @@
                     %p.h2.mb-0
                       =@preferred_plan.currency.format_number(@preferred_plan.price)
                     .mt-auto
-                      =link_to subscription_checkout_special_link(@group.exam_body_id, @preferred_plan.guid), class: 'btn btn-secondary btn-sm', onclick: "addToCart('#{@preferred_plan.currency.iso_code}', '#{@preferred_plan.name}', '#{@preferred_plan.id}', '#{number_in_local_currency(@preferred_plan.price, @preferred_plan.currency_id)}', '#{@preferred_plan.exam_body.name}');" do
+                      =link_to subscription_checkout_special_link(@group.exam_body_id, @preferred_plan.guid), class: 'btn btn-secondary btn-sm', onclick: "addToCart('#{@preferred_plan.currency.iso_code}', '#{@preferred_plan.name}', '#{@preferred_plan.id}', '#{number_in_local_currency(@preferred_plan.price, @preferred_plan.currency)}', '#{@preferred_plan.exam_body.name}');" do
                         Choose this plan
 
 

--- a/app/views/student_sign_ups/sign_in_or_register.html.haml
+++ b/app/views/student_sign_ups/sign_in_or_register.html.haml
@@ -59,7 +59,7 @@
                     %p.h4.mb-3.text-torquoise
                       Total:
                       %span
-                        =number_in_local_currency(@product.price, @product.currency_id)
+                        =number_in_local_currency(@product.price, @product.currency)
                   .pt-4.pt-md-5
                     %i.material-icons.icon-bg-round.text-mint.bg-mint-light{"aria-label" => "selected", :role => "img"} check
 

--- a/app/views/subscription_management/_invoices.html.haml
+++ b/app/views/subscription_management/_invoices.html.haml
@@ -15,7 +15,7 @@
           -if invoice.issued_at
             =humanize_datetime(invoice.issued_at)
         %td
-          =number_in_local_currency(invoice.total, invoice.currency_id)
+          =number_in_local_currency(invoice.total, invoice.currency)
         %td
           =invoice.status
         %td

--- a/app/views/subscription_plans/show.html.haml
+++ b/app/views/subscription_plans/show.html.haml
@@ -23,7 +23,7 @@
                   %td.col-sm-8=link_to @subscription_plan.currency.name, @subscription_plan.currency
                 %tr
                   %td.col-sm-4=t('views.subscription_plans.form.price')
-                  %td.col-sm-8=number_in_local_currency(@subscription_plan.price, @subscription_plan.currency_id)
+                  %td.col-sm-8=number_in_local_currency(@subscription_plan.price, @subscription_plan.currency)
                 %tr
                   %td.col-sm-4=t('views.subscription_plans.form.available_from')
                   %td.col-sm-8=@subscription_plan.available_from.to_s(:standard)

--- a/app/views/subscriptions/_invoices_index.html.haml
+++ b/app/views/subscriptions/_invoices_index.html.haml
@@ -14,7 +14,7 @@
           -if invoice.issued_at
             =humanize_datetime(invoice.issued_at)
         %td
-          =number_in_local_currency(invoice.total, invoice.currency_id)
+          =number_in_local_currency(invoice.total, invoice.currency)
         %td
           =invoice.status
         %td

--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -59,7 +59,7 @@
                           %tr
                             %td=invoice.id
                             %td=humanize_datetime(invoice.issued_at)
-                            %td=number_in_local_currency(invoice.total, invoice.currency_id)
+                            %td=number_in_local_currency(invoice.total, invoice.currency)
                             %td
                               %span{class: invoice.status == 'Paid' ? 'text-success' : 'text-danger'}
                                 =invoice.status

--- a/app/views/user_accounts/_orders_info.html.haml
+++ b/app/views/user_accounts/_orders_info.html.haml
@@ -18,7 +18,7 @@
                 -if order.product && order.product.mock_exam
                   =order.product.mock_exam.name.to_s.truncate(20)
               %td=order.stripe_status.to_s.capitalize
-              %td=number_in_local_currency(order.product.price, order.product.currency_id)
+              %td=number_in_local_currency(order.product.price, order.product.currency)
               %td
                 -if order.product && order.product.mock_exam
                   =link_to pdf_invoice_path(order.invoice.id, format: 'pdf'), target: '_blank' do

--- a/app/views/users/_users_list.html.haml
+++ b/app/views/users/_users_list.html.haml
@@ -1,0 +1,22 @@
+%table.table{style: 'font-size: 18px;'}
+  %thead
+    %tr
+      %th=t('views.users.form.full_name')
+      %th=t('views.users.form.email')
+      %th=t('views.users.form.email_verified')
+      %th
+      %th
+  %tbody
+    -@users.each do |user|
+      %tr
+        %td=user.full_name
+        %td=user.email
+        %td=tick_or_cross(user.email_verified)
+        %td
+          =link_to t('views.general.view'), user_url(user), class: 'btn btn-secondary btn-xs'
+        %td
+          =link_to t('views.general.edit'), edit_user_url(user), class: 'btn btn-primary btn-xs'
+
+  .col-sm-10.user-pagination
+    =will_paginate @users, renderer: RemoteLinkPaginationHelper::LinkRenderer,
+                      params: { controller: :users, search_term: params[:search_term] }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -17,34 +17,13 @@
               =link_to 'Invite New user', new_user_url, class: 'btn btn-primary btn-sm'
             .col-sm
               .search-container
-                =form_tag(search_users_url, role: 'form', class: 'form-inline') do
+                =form_tag(search_users_url, method: :get, role: 'form', class: 'form-inline', remote: true) do
                   =text_field_tag :search_term, params[:search_term], class: 'form-control', placeholder: t('views.general.search')
                   %button{type: "submit"}
                     %i{:role => "img", class: 'budicon-search-list'}
 
-
-          .table-responsive.pt-5
-            %table.table{style: 'font-size: 18px;'}
-              %thead
-                %tr
-                  %th=t('views.users.form.full_name')
-                  %th=t('views.users.form.email')
-                  %th=t('views.users.form.email_verified')
-                  %th
-                  %th
-              %tbody
-                -@users.each do |user|
-                  %tr
-                    %td=user.full_name
-                    %td=user.email
-                    %td=tick_or_cross(user.email_verified)
-                    %td
-                      =link_to t('views.general.view'), user_url(user), class: 'btn btn-secondary btn-xs'
-                    %td
-                      =link_to t('views.general.edit'), edit_user_url(user), class: 'btn btn-primary btn-xs'
-
-            .col-sm-10.user-pagination
-              =will_paginate @users, renderer: BootstrapPagination::Rails
+          .table-responsive.pt-5{ id: :users_list }
+            =render partial: 'users/users_list'
 
 
 =render partial: 'users/csv_import_modal'

--- a/app/views/users/search.js.erb
+++ b/app/views/users/search.js.erb
@@ -1,0 +1,1 @@
+$('#users_list').html("<%= j (render partial: 'users/users_list') %>")

--- a/app/views/users/user_purchases_details.html.haml
+++ b/app/views/users/user_purchases_details.html.haml
@@ -37,7 +37,7 @@
                   %td
                     =order.stripe? ? 'Stripe' : 'PayPal'
                   %td
-                    =number_in_local_currency(order.product.price, order.product.currency_id)
+                    =number_in_local_currency(order.product.price, order.product.currency)
                   %td
                     -if order.product && order.product.mock_exam
                       =link_to order.product.mock_exam.file.url, target: '_blank' do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,9 +82,14 @@ Rails.application.configure do
       s3_region: 'eu-west-1'
     }
   }
-  #Enable bullet in your application
-  Bullet.enable = true
-  Bullet.rails_logger = true
+
+  # Bullet configuration
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,9 +28,6 @@ Rails.application.routes.draw do
     get '500' => redirect('500-page')
 
     # users and authentication
-    resources :users do
-      resources :visits, only: [:index, :show]
-    end
 
     get 'new_subscription', to: 'subscriptions#new', as: :new_subscription
     post 'create_subscription/:user_id', to: 'subscriptions#create', as: :create_subscription
@@ -80,8 +77,10 @@ Rails.application.routes.draw do
       get  '/orders', action: :user_purchases_details, as: :orders
       get  '/referrals', action: :user_referral_details, as: :referrals
       patch '/update_courses', action: :update_courses, as: :update_courses
+      get 'search', on: :collection
       resources :exercises, only: [:index, :show, :edit, :update], shallow: true
       resources :invoices, only: :index, shallow: true
+      resources :visits, only: [:index, :show]
     end
     resources :invoices, only: :show do
       get '/pdf', action: :pdf, on: :member
@@ -230,9 +229,6 @@ Rails.application.routes.draw do
     get 'terms_and_conditions', to: 'footer_pages#terms_and_conditions'
     get 'tutor/:name_url', to: 'footer_pages#profile', as: :profile
     get 'tutors', to: 'footer_pages#profile_index', as: :tutors
-
-    resources :users, only: [:new, :create]
-    post 'search_users', to: 'users#index', as: :search_users
 
     post :preview_csv_upload, to: 'users#preview_csv_upload'
     post :import_csv_upload, to: 'users#import_csv_upload'

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -197,17 +197,18 @@ RSpec.describe CoursesController, type: :controller do
     end
 
     describe 'Get submit_constructed_response_user_log with CMEUL data for CR for final submit' do
-
       it 'should respond ok and redirect to ' do
         get :submit_constructed_response_user_log, params: { cmeul_id: cr_cmeul.id }
+        course_url = course_url(cr_cmeul.course_module_element.course_module.course_section.subject_course.name_url,
+                                cr_cmeul.course_module_element.course_module.course_section.name_url,
+                                cr_cmeul.course_module_element.course_module.name_url,
+                                cr_cmeul.course_module_element.name_url)
+
         expect(flash[:success]).to be_nil
         expect(flash[:error]).to be_nil
         expect(response.status).to eq(302)
-        expect(response).to redirect_to(course_url(cr_cmeul.course_module_element.course_module.course_section.subject_course.name_url, cr_cmeul.course_module_element.course_module.course_section.name_url, cr_cmeul.course_module_element.course_module.name_url, cr_cmeul.course_module_element.name_url))
+        expect(response).to redirect_to(course_url)
       end
-
     end
-
   end
-
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -21,14 +21,21 @@
 
 FactoryBot.define do
   factory :product do
-    sequence(:name)                  { |n| "Product-00#{n}" }
-    mock_exam
-    active { true }
-    sequence(:stripe_guid)           { |n| "stripe-guid-#{n}" }
-    live_mode { false }
-    price { '999' }
+    sequence(:name)            { |n| "Product-00#{n}" }
+    active                     { true }
+    sequence(:stripe_guid)     { |n| "stripe-guid-#{n}" }
+    live_mode                  { false }
+    price                      { '999' }
+    sequence(:stripe_sku_guid) { |n| "stripe-sku-guid-#{n}" }
     currency
-    sequence(:stripe_sku_guid)           { |n| "stripe-sku-guid-#{n}" }
+    mock_exam
   end
 
+  trait :inactive do
+    active { false }
+  end
+
+  trait :with_order do
+    orders { build_list :order, 2 }
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
-
 RSpec.describe ApplicationHelper, type: :helper do
-
   describe '#humanize_stripe_date_full' do
     context 'with a date passed in' do
       it 'returns the correctly formatted date' do

--- a/spec/models/invoice_line_item_spec.rb
+++ b/spec/models/invoice_line_item_spec.rb
@@ -32,8 +32,6 @@ describe InvoiceLineItem do
   it { should validate_presence_of(:currency_id) }
   ## validation of subscription invoice
   before { allow(subject).to receive(:subscription_invoice?).and_return(true) }
-  it { should validate_presence_of(:period_start_at) }
-  it { should validate_presence_of(:period_end_at) }
   it { should validate_presence_of(:subscription_id) }
   it { should validate_presence_of(:subscription_plan_id) }
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -22,10 +22,14 @@
 require 'rails_helper'
 
 describe Product do
+  let(:order_product)    { create(:product, :with_order) }
+  let(:active_product)   { create(:product) }
+  let(:inactive_product) { create(:product, :inactive) }
 
   # relationships
   it { should belong_to(:currency) }
   it { should belong_to(:mock_exam) }
+  it { should have_many(:exercises) }
   it { should have_many(:orders) }
 
   # validation
@@ -42,7 +46,6 @@ describe Product do
   it { should validate_presence_of(:stripe_sku_guid).on(:update) }
 
   # callbacks
-  it { should callback(:check_dependencies).before(:destroy) }
   it { should callback(:create_on_stripe).after(:create) }
   it { should callback(:update_on_stripe).after(:update) }
 
@@ -53,11 +56,72 @@ describe Product do
 
   # class methods
   it { expect(Product).to respond_to(:search) }
+  it { expect(Product).to respond_to(:filter_by_state) }
 
   # instance methods
   it { should respond_to(:create_on_stripe) }
-  it { should respond_to(:destroyable?) }
   it { should respond_to(:update_on_stripe) }
 
+  describe 'Methods' do
+    before do
+      @first_term  = active_product.name
+      @second_term = inactive_product.name
+    end
 
+    context '#destroyable?' do
+      it 'without orders' do
+        expect(active_product.destroyable?).to be_truthy
+      end
+
+      it 'without orders' do
+        expect(order_product.destroyable?).to be_falsey
+      end
+    end
+
+    context '.search' do
+      it 'complete term' do
+        result = Product.search(@first_term)
+
+        expect(result).to     include(active_product)
+        expect(result).not_to include(inactive_product)
+      end
+
+      it 'partial term' do
+        result = Product.search(@second_term[0, 4])
+
+        expect(result).to include(active_product)
+        expect(result).to include(inactive_product)
+      end
+    end
+
+    context '.filter_by_state' do
+      it 'default' do
+        result = Product.filter_by_state(nil)
+
+        expect(result).to     include(active_product)
+        expect(result).not_to include(inactive_product)
+      end
+
+      it 'active' do
+        result = Product.filter_by_state('Active')
+
+        expect(result).to     include(active_product)
+        expect(result).not_to include(inactive_product)
+      end
+
+      it 'inactive' do
+        result = Product.filter_by_state('Inactive')
+
+        expect(result).not_to include(active_product)
+        expect(result).to     include(inactive_product)
+      end
+
+      it 'all' do
+        result = Product.filter_by_state('All')
+
+        expect(result).to include(active_product)
+        expect(result).to include(inactive_product)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,7 +60,6 @@
 require 'rails_helper'
 
 describe User do
-
   it 'should have a valid factory' do
     expect(build(:user)).to be_valid
   end
@@ -95,6 +94,7 @@ describe User do
   it { should have_one(:student_access) }
   it { should have_one(:referred_signup) }
   it { should belong_to(:subscription_plan_category) }
+  it { should belong_to(:currency) }
 
   # validation
   context 'test uniqueness validation' do
@@ -144,7 +144,6 @@ describe User do
 
   # scopes
   it { expect(User).to respond_to(:all_in_order) }
-  it { expect(User).to respond_to(:search_for) }
   it { expect(User).to respond_to(:sort_by_email) }
   it { expect(User).to respond_to(:sort_by_name) }
   it { expect(User).to respond_to(:sort_by_most_recent) }
@@ -155,6 +154,7 @@ describe User do
   it { expect(User).to respond_to(:with_course_tutor_details) }
 
   # class methods
+  it { expect(User).to respond_to(:search) }
   it { expect(User).to respond_to(:all_students) }
   it { expect(User).to respond_to(:all_trial_or_sub_students) }
   it { expect(User).to respond_to(:all_tutors) }


### PR DESCRIPTION
Add filter_by_state in product list, products page now list just actives products as default.
User still can user filter to list Active, Inactive and all products.

Clean up controllers files:
* remove annotated comment in start of every controller file;
* add frozen_string_literal;
* use guard clause: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GuardClause
* syntax improves
* change some callbacks to use in specific methods instead every method
* update dynamic finders in favour of non-dynamic. IE. `find_by(name: 'bla')` instead `find_by_name('bla)`

Improves in search/filter:
* remove the conditional checks from controller and let model methods handle it
* Products, SubscriptionPlans, Users and EnrollmentManagementController controllers
* Product, SubscriptionPlan, User and Enrollment models

Users list - Search/Paginate
* Change user to use a ajax request in search and pagination
* Clean up users resources in routes

Change search to work with paginate:
* Products

Special attention in ApplicationController methods:
* course_module_special_link
* content_activation_special_link
* library_special_link
* course_enrollment_special_link
* navigation_special_link
* course_special_link
* user_course_correct_url