### PR TITLE
Production - 6 July 2019

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -545,6 +545,11 @@ class User < ApplicationRecord
     ) unless Rails.env.test?
   end
 
+  def send_custom_verification_email
+    url = UrlHelper.instance.user_verification_url(email_verification_code: email_verification_code)
+    MandrillWorker.perform_async(id, 'send_custom_verification_email', url)
+  end
+
   def create_stripe_customer
     StripeCustomerCreationWorker.perform_async(id)
   end

--- a/lib/mandrill_client.rb
+++ b/lib/mandrill_client.rb
@@ -12,6 +12,12 @@ class MandrillClient
     send_template('email-verification-190429', msg)
   end
 
+  def send_custom_verification_email(verification_url)
+    msg = message_stub.merge({"subject" => "Please Verify your email"})
+    msg["global_merge_vars"] << { "name" => "VERIFICATIONURL", "content" => verification_url }
+    send_template('email-verification-reminder-190705', msg)
+  end
+
   def admin_invite(verification_url)
     msg = message_stub.merge({"subject" => "Welcome to LearnSignal"})
     msg["global_merge_vars"] << { "name" => "VERIFICATIONURL", "content" => verification_url }


### PR DESCRIPTION
This is a quick addition of a custom email template with a user method to call it. I will be triggering this directly from the console on production in order to resend the verification emails to a users in the last month who have not clicked the verification link. Philip requested a custom template to be used. This can all be removed once it has been triggered.