### PR TITLE
FIX: Geocoding rake task to handle updating IP records

### DIFF
--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -26,6 +26,7 @@
 #  revision                   :boolean          default(FALSE)
 #  course_section_id          :integer
 #  constructed_response_count :integer          default(0)
+#  temporary_label            :string
 #
 
 class CourseModule < ApplicationRecord

--- a/app/models/course_module_element_video.rb
+++ b/app/models/course_module_element_video.rb
@@ -12,6 +12,7 @@
 #  video_id                 :string
 #  duration                 :float
 #  vimeo_guid               :string
+#  voo_player_id            :string
 #
 
 class CourseModuleElementVideo < ApplicationRecord

--- a/app/models/ip_address.rb
+++ b/app/models/ip_address.rb
@@ -2,14 +2,15 @@
 #
 # Table name: ip_addresses
 #
-#  id          :integer          not null, primary key
-#  ip_address  :string
-#  latitude    :float
-#  longitude   :float
-#  country_id  :integer
-#  alert_level :integer
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id           :integer          not null, primary key
+#  ip_address   :string
+#  latitude     :float
+#  longitude    :float
+#  country_id   :integer
+#  alert_level  :integer
+#  created_at   :datetime
+#  updated_at   :datetime
+#  rechecked_on :datetime
 #
 
 class IpAddress < ApplicationRecord

--- a/db/migrate/20190711114424_add_rechecked_on_to_ip_addresses.rb
+++ b/db/migrate/20190711114424_add_rechecked_on_to_ip_addresses.rb
@@ -1,0 +1,5 @@
+class AddRecheckedOnToIpAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ip_addresses, :rechecked_on, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -651,6 +651,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_093157) do
     t.integer "alert_level"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "rechecked_on"
   end
 
   create_table "mock_exams", id: :serial, force: :cascade do |t|

--- a/lib/tasks/ip_address_country_cleanup.rake
+++ b/lib/tasks/ip_address_country_cleanup.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+desc 'Cleaning up the badly geocoded IP Addresses'
+task ip_address_cleanup: :environment do
+  Rails.logger = Logger.new(Rails.root.join('log', 'tasks.log'))
+  Rails.logger.info 'Running command to clean up ip_address records...'
+
+  total_time = Benchmark.measure do
+    IpAddress.where(rechecked_on: nil).find_in_batches(batch_size: 1000) do |ip_addresses|
+      IpAddress.transaction do
+        Rails.logger.info "======= #{ip_addresses.count} IP ADDRESSES ========="
+        bench_time = Benchmark.measure do
+          ip_addresses.each do |ip|
+            if ip.update(latitude: nil, longitude: nil)
+              run_ip_update(ip)
+            else
+              Rails.logger.error "#{ip.id} was not updated"
+            end
+          end
+        end
+        Rails.logger.info "=========== Bench time #{bench_time.real} =========="
+      end
+    end
+  end
+  Rails.logger.info "============= Total time #{total_time.real} =============="
+  Rails.logger.info '=========================================================='
+end
+
+def run_ip_update(ip)
+  ip.reverse_geocode
+  if ip.latitude.nil?
+    Rails.logger.error("Geocoder error for IP Address #{ip.id}")
+  else
+    ip.update(rechecked_on: Time.zone.now)
+  end
+end

--- a/spec/factories/course_module_element_videos.rb
+++ b/spec/factories/course_module_element_videos.rb
@@ -10,6 +10,7 @@
 #  video_id                 :string
 #  duration                 :float
 #  vimeo_guid               :string
+#  voo_player_id            :string
 #
 
 FactoryBot.define do

--- a/spec/factories/course_modules.rb
+++ b/spec/factories/course_modules.rb
@@ -26,6 +26,7 @@
 #  revision                   :boolean          default(FALSE)
 #  course_section_id          :integer
 #  constructed_response_count :integer          default(0)
+#  temporary_label            :string
 #
 
 FactoryBot.define do

--- a/spec/factories/ip_addresses.rb
+++ b/spec/factories/ip_addresses.rb
@@ -2,14 +2,15 @@
 #
 # Table name: ip_addresses
 #
-#  id          :integer          not null, primary key
-#  ip_address  :string
-#  latitude    :float
-#  longitude   :float
-#  country_id  :integer
-#  alert_level :integer
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id           :integer          not null, primary key
+#  ip_address   :string
+#  latitude     :float
+#  longitude    :float
+#  country_id   :integer
+#  alert_level  :integer
+#  created_at   :datetime
+#  updated_at   :datetime
+#  rechecked_on :datetime
 #
 
 FactoryBot.define do

--- a/spec/models/course_module_element_video_spec.rb
+++ b/spec/models/course_module_element_video_spec.rb
@@ -10,6 +10,7 @@
 #  video_id                 :string
 #  duration                 :float
 #  vimeo_guid               :string
+#  voo_player_id            :string
 #
 
 require 'rails_helper'

--- a/spec/models/course_module_spec.rb
+++ b/spec/models/course_module_spec.rb
@@ -26,6 +26,7 @@
 #  revision                   :boolean          default(FALSE)
 #  course_section_id          :integer
 #  constructed_response_count :integer          default(0)
+#  temporary_label            :string
 #
 
 require 'rails_helper'

--- a/spec/models/ip_address_spec.rb
+++ b/spec/models/ip_address_spec.rb
@@ -2,14 +2,15 @@
 #
 # Table name: ip_addresses
 #
-#  id          :integer          not null, primary key
-#  ip_address  :string
-#  latitude    :float
-#  longitude   :float
-#  country_id  :integer
-#  alert_level :integer
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id           :integer          not null, primary key
+#  ip_address   :string
+#  latitude     :float
+#  longitude    :float
+#  country_id   :integer
+#  alert_level  :integer
+#  created_at   :datetime
+#  updated_at   :datetime
+#  rechecked_on :datetime
 #
 
 require 'rails_helper'


### PR DESCRIPTION
Google Geocoding API gives us unlimited requests per day with a limit of 5000 per 100 seconds. 

I looked at measuring the execution time and adding a pause in the execution if we're approaching the request rate limit but running that code alone was taking greater than 20 milliseconds (100 / 5,000). So I'm pretty happy that we won't exceed the rate limit. In any case, if we exceed the limit, the records won't have their `rechecked_on` timestamp updated.

https://learnsignal-team.monday.com/boards/224818924/pulses/262345669