### PR TITLE
Fix cancellation redirect after error.

### DIFF
--- a/app/controllers/subscriptions/cancellations_controller.rb
+++ b/app/controllers/subscriptions/cancellations_controller.rb
@@ -14,12 +14,14 @@ class Subscriptions::CancellationsController < ApplicationController
     if @subscription.update(subscription_params) && @subscription.cancel_by_user
       flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
       flash[:datalayer_cancel] = @subscription.user_readable_name
+
       redirect_to account_url(anchor: 'subscriptions')
     else
       Rails.logger.warn "WARN: Subscription#delete failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
       flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
       @subscription.errors.add(:cancellation_reason, 'please select an option')
-      render :new
+
+      redirect_to new_subscriptions_cancellation_path(id: @subscription.id)
     end
   end
 


### PR DESCRIPTION
Use render after an error in post method will keep post url in browser, I changed it to a redirect action.
[Airbrake link ](https://learnsignal.airbrake.io/projects/107826/groups/2468370268269256908?dur=90d%2F1d&last_n=90&tab=overview)

![Screenshot 2019-07-12 at 12 11 39](https://user-images.githubusercontent.com/136358/61124377-a9ad3680-a49e-11e9-9d44-57056f0d3776.png)


