### PR TITLE
FIX: Airbrake error for stripe card missing from a charge.

### DIFF
--- a/app/views/subscription_management/charge.html.haml
+++ b/app/views/subscription_management/charge.html.haml
@@ -56,7 +56,7 @@
                   .h3
                     Stripe Card ID
                   .h6
-                    =@charge.subscription_payment_card.stripe_card_guid
+                    =@charge.subscription_payment_card&.stripe_card_guid || '-'
 
                 .col-sm-6
                   .h3


### PR DESCRIPTION
https://learnsignal-team.monday.com/boards/224818924/pulses/273475709