### PR TITLE
FOR MASTER: Daily summary for mock exam and correction pack purchases

### DIFF
--- a/app/controllers/admin/exercises_controller.rb
+++ b/app/controllers/admin/exercises_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action do
       ensure_user_has_access_rights(%w[exercise_corrections_access])
     end
-    before_action :set_exercise, except: :index
+    before_action :set_exercise, except: %i[index generate_daily_summary]
 
     layout 'management'
 
@@ -46,6 +46,11 @@ module Admin
       else
         render action: :edit
       end
+    end
+
+    def generate_daily_summary
+      Order.send_daily_orders_update
+      redirect_to admin_exercises_path, notice: 'Daily summary sent to Slack'
     end
 
     private

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -1,14 +1,27 @@
 class SlackService
 
-  def notify_channel(channel, attachments)
+  def notify_channel(channel, attachments, **options)
     message = {
       channel: "##{channel}",
       as_user: false,
-      icon_emoji: ":female-student:",
-      username: "learnsignal bot",
+      icon_emoji: options.fetch(:icon_emoji, ':female-student:'),
+      username: options.fetch(:username, 'learnsignal bot'),
       attachments: attachments
     }
     send_notification(message)
+  end
+
+  def order_summary_attachment(orders)
+    [{ fallback: 'Daily Orders Summary (Last 24hrs)',
+       title: 'Daily Orders Summary (Last 24hrs)',
+       color: '#7CD197',
+       fields: [
+         { title: 'Mock Exams', value: orders.product_type_count('mock_exam'),
+           short: true },
+         { title: 'General Corrections',
+           value: orders.product_type_count('correction_pack'),
+           short: true }
+       ] }]
   end
 
   private

--- a/app/views/admin/exercises/index.html.haml
+++ b/app/views/admin/exercises/index.html.haml
@@ -49,4 +49,7 @@
                         %span= "Claimed By (#{exercise.corrector.name})"
                       -else
                         =link_to 'Claim', admin_exercise_path(exercise, exercise: { corrector_id: current_user.id }), method: :patch, class: 'btn btn-secondary btn-xs'
-
+          .row
+            .col-sm
+              .search-container
+                =link_to 'Generate Daily Summary', generate_daily_summary_admin_exercises_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :exercises, only: [:index, :show, :edit, :update]
+    resources :exercises, only: [:index, :show, :edit, :update] do
+      get 'generate_daily_summary', on: :collection
+    end
     post 'search_exercises', to: 'exercises#index', as: :search_exercises
   end
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -31,6 +31,15 @@ FactoryBot.define do
     mock_exam
   end
 
+  trait :for_mock do
+    product_type 'mock_exam'
+  end
+
+  trait :for_corrections do
+    product_type 'correction_pack'
+    correction_pack_count 1
+  end
+
   trait :inactive do
     active { false }
   end


### PR DESCRIPTION
This is the `cherry-pick` of the PR over on `staging`.

* Slack messaging code
* Specs for orders count method.
* Specs for orders daily summary.
* Codeclimate fixes.
* Added updates for manually triggering the summary.