### PR TITLE
Update nokogiri to solve a possible vulnerability in this gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'paperclip', '~> 6.1.0' # for uploading files (works with RemotiPart)
 gem 'mailchimp-api', '~> 2.0.4'
 gem 'momentjs-rails', '>= 2.9.0'
 gem 'modernizr-rails'
+gem "nokogiri", ">= 1.10.4"
 gem 'bootstrap3-datetimepicker-rails', '~> 4.14.30'
 gem 'multipart-post' #To allow uploading wistia api
 gem 'pg' # PostgreSQL database engine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       connection_pool (~> 2.2)
     newrelic_rpm (5.7.0.350)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -595,6 +595,7 @@ DEPENDENCIES
   momentjs-rails (>= 2.9.0)
   multipart-post
   newrelic_rpm
+  nokogiri (>= 1.10.4)
   paperclip (~> 6.1.0)
   paypal-sdk-rest
   pg


### PR DESCRIPTION

![Screenshot 2019-08-22 at 08 22 36](https://user-images.githubusercontent.com/136358/63494717-3394ea00-c4b6-11e9-8b4b-4b548cc9ba0c.png)

https://github.com/SignalEducation/version1/network/alert/Gemfile.lock/nokogiri/open