### PR TITLE
UPDATE: SCA handling for subscription plan changes.

### DIFF
--- a/app/controllers/subscriptions/plan_changes_controller.rb
+++ b/app/controllers/subscriptions/plan_changes_controller.rb
@@ -1,43 +1,66 @@
-class Subscriptions::PlanChangesController < ApplicationController
-  before_action :logged_in_required
-  before_action do
-    ensure_user_has_access_rights(%w(student_user))
-  end
-  before_action :get_subscription
+# frozen_string_literal: true
 
-  def show
-    Rails.logger.info "DataLayer Event: PlanChanges#show - Subscription: #{@subscription.id}, Revenue: #{@subscription.subscription_plan.price}, PlanName: #{@subscription.subscription_plan.name}, Brand: #{@subscription.subscription_plan.exam_body.name}" if @subscription
-  end
-
-  def new
-  end
-
-  def create
-    subscription_object = SubscriptionService.new(@subscription)
-    if @subscription = subscription_object.change_plan(plan_change_params[:subscription_plan_id].to_i)
-      if subscription_object.stripe?
-        @subscription.start
-        subscription_object.validate_referral
-        redirect_to subscriptions_plan_change_url(@subscription), notice: 'Your new plan is confirmed!'
-      elsif subscription_object.paypal?
-        redirect_to @subscription.paypal_approval_url
-      end
-    else
-      Rails.logger.error "ERROR: SubscriptionsController#update - something went wrong."
-      flash[:error] = I18n.t('controllers.subscriptions.update.flash.error')
+module Subscriptions
+  class PlanChangesController < ApplicationController
+    before_action :logged_in_required
+    before_action do
+      ensure_user_has_access_rights(%w(student_user))
     end
-  rescue Learnsignal::SubscriptionError => e
-    flash[:error] = e.message
-    redirect_to account_url(anchor: 'account-info')
-  end
+    before_action :get_subscription
 
-  private
+    def show
+      Rails.logger.info "DataLayer Event: PlanChanges#show - Subscription: #{@subscription.id}, Revenue: #{@subscription.subscription_plan.price}, PlanName: #{@subscription.subscription_plan.name}, Brand: #{@subscription.subscription_plan.exam_body.name}" if @subscription
+    end
 
-  def get_subscription
-    @subscription = Subscription.find_by_id(params[:id])
-  end
+    def new; end
 
-  def plan_change_params
-    params.require(:subscription).permit(:subscription_plan_id)
+    def create
+      send("change_#{@subscription.subscription_type}_subscription",
+           @subscription, plan_change_params[:subscription_plan_id].to_i)
+    rescue Learnsignal::SubscriptionError => e
+      if request.xhr?
+        render json: { subscription_id: @subscription&.id,
+                       error: e.message }, status: :bad_request
+      else
+        flash[:error] = e.message
+        redirect_to account_url(anchor: 'account-info')
+      end
+    end
+
+    def status_from_stripe
+      case params[:status]
+      when 'active', 'succeeded'
+        @subscription.start
+      end
+    end
+
+    private
+
+    def get_subscription
+      @subscription = Subscription.find_by_id(params[:id])
+    end
+
+    def change_stripe_subscription(subscription, plan_id)
+      @subscription, data = StripeSubscriptionService.new(subscription).
+                              change_plan(plan_id)
+
+      if data[:status] == :ok
+        render 'subscriptions/create'
+      else
+        render json: { subscription_id: @subscription.id,
+                       error: data[:error_message] }, status: data[:status]
+      end
+    end
+
+    def change_paypal_subscription(subscription, _params)
+      @subscription =
+        PaypalSubscriptionsService.new(subscription).change_plan(plan_id)
+
+      redirect_to @subscription.paypal_approval_url
+    end
+
+    def plan_change_params
+      params.require(:subscription).permit(:subscription_plan_id)
+    end
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -33,8 +33,8 @@ class SubscriptionsController < ApplicationController
          @subscription, subscription_service, params)
   rescue Learnsignal::SubscriptionError => e
     if request.xhr?
-      render json: { subscription_id: @subscription.id,
-                     error: e.message }, status: :error
+      render json: { subscription_id: @subscription&.id,
+                     error: e.message }, status: :bad_request
     else
       flash[:error] = e.message
       redirect_to new_subscription_url(subscription_plan_id: params[:subscription][:subscription_plan_id])
@@ -129,10 +129,7 @@ class SubscriptionsController < ApplicationController
 
     if @subscription.save
       if data[:status] == :ok
-        render json: { subscription_id: @subscription.id,
-                       status: @subscription.stripe_status,
-                       completion_guid: @subscription.completion_guid,
-                       client_secret: data[:client_secret] }, status: data[:status]
+        render :create
       else
         render json: { subscription_id: @subscription.id,
                        error: data[:error_message] }, status: data[:status]

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -64,8 +64,9 @@ class Subscription < ApplicationRecord
   validates :paypal_status, inclusion: { in: PAYPAL_STATUSES }, allow_blank: true
   validates :cancellation_reason, presence: true, if: proc { |sub| sub.cancelling_subscription }
   validates :stripe_guid, :stripe_customer_id, length: { maximum: 255 }, allow_blank: true
-  validate :plan_change_currencies, :plan_change_active, :subscription_change_allowable,
-           :user_has_default_card, :user_is_student, if: proc { |sub| sub.changed_from.present? }
+  validate :plan_change_currencies, :plan_change_active,
+           :subscription_change_allowable, :user_has_default_card,
+           :user_is_student, if: proc { |sub| sub.changed_from.present? }, on: :create
 
   # callbacks
   after_create :create_subscription_payment_card, if: :stripe_token # If new card details
@@ -408,6 +409,12 @@ class Subscription < ApplicationRecord
 
   def stripe?
     stripe_guid.present?
+  end
+
+  def subscription_type
+    return 'stripe' if stripe?
+    return 'paypal' if paypal?
+    'unknown'
   end
 
   protected

--- a/app/views/subscriptions/create.json.jbuilder
+++ b/app/views/subscriptions/create.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.subscription_id @subscription.id
+json.status @subscription.stripe_status
+json.completion_guid @subscription.completion_guid
+json.client_secret @subscription.client_secret

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -233,7 +233,6 @@
 
     $('#pay-with-card').click(); // To open the stripe card section on page load
 
-
     $('#all-plans').collapse({
       toggle: false
     });
@@ -332,7 +331,7 @@
         success: function(data, status, xhr){
           if(data.status == 'incomplete'){
             handlePayment(data.client_secret, data.subscription_id)
-          }else if(data.status == 'active'){
+          } else if(data.status == 'active'){
             window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
           }
         },

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -13,6 +13,7 @@
             =render partial: 'layouts/flash_messages'
           =form_for(@subscription, url: subscriptions_plan_changes_path(id: @subscription.id), method: :post, html: {class: 'form-horizontal', role: 'form', id: 'upgrade-subscription-form'}) do |f|
             =f.hidden_field :subscription_plan_id
+            =f.hidden_field :use_paypal, value: @subscription.paypal?
             .row.row-md
               -@subscription.upgrade_options.each do |plan|
                 .col-lg
@@ -67,6 +68,7 @@
                       ='Selecting this Plan will result in an immediate charge and start a new billing period from this date.'
                     %p
                       ='Any remaining time paid for on your current billing will be credited to your account, and used for this payment and any future payments until all credit is used.'
+                    %div.invalid-details
                 .row
                   .col-sm-6.offset-1
                     .d-flex.justify-content-between.align-items-center.pt-3
@@ -122,6 +124,10 @@
   }
 
   $(document).on('ready', function() {
+    var displayError = $('.invalid-details');
+    displayError.text('');
+    var stripe = Stripe('#{ENV['LEARNSIGNAL_V3_STRIPE_PUBLIC_KEY']}');
+
     $(".sk-circle").hide();
     choosePlan($('.plan-option')[0]);
     $('.option').bind('click', function(event) {
@@ -133,12 +139,78 @@
       event.preventDefault();
       choosePlan(this);
     });
-  });
 
-  $("#upgrade-subscription-form").submit(function(ev) {
-    ev.preventDefault();
-    $(".sk-circle").show();
-    $("#changePlan").hide();
-    this.submit();
+    $("#upgrade-subscription-form").submit(function(ev) {
+      ev.preventDefault();
+      $(".sk-circle").show();
+      displayError.text('');
+      $("#changePlan").hide();
+
+      if ($('#subscription_use_paypal').val() === 'true') {
+        this.submit();
+      } else {
+        upgradeStripeSubscription();
+      }
+    });
+
+    function upgradeStripeSubscription(){
+      var form = $('#upgrade-subscription-form');
+
+      $.ajax({
+        type: $(form).attr('method'),
+        url: $(form).attr('action'),
+        data: $(form).serialize(),
+        dataType: 'json',
+        success: function(data, status, xhr){
+          if($.inArray(data.status, [ 'incomplete', 'past_due'])){
+            handleStripeAction(data.client_secret, data.subscription_id)
+          } else if(data.status == 'active'){
+            window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+          }
+        },
+        error: function(request, status, error){
+          if (request.status === 500) {
+            resetForm('Something went wrong. Please try again.');
+          } else {
+            resetForm(request.responseJSON.error);
+          }
+        }
+      });
+    }
+
+    function handleStripeAction(client_secret, subscription_id){
+      let statusArray = ['active', 'succeeded'];
+      let intentStatus = '';
+      stripe.handleCardPayment(client_secret).then(function(result) {
+        if (result.error) {
+          resetForm(result.error.message);
+          intentStatus = 'pending';
+        } else {
+          intentStatus = result['paymentIntent']['status'];
+        }
+
+        $.ajax({
+          type: 'post',
+          url: "/subscriptions/plan_changes/" + subscription_id + "/status_from_stripe",
+          data: { status: intentStatus, id: subscription_id },
+          dataType: 'json',
+          success: function(data,status,xhr){
+            if( $.inArray(intentStatus, statusArray) !== -1){
+              window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+            }
+          },
+          error: function(xhr,status,error){
+            resetForm(error);
+          }
+        });
+      });
+    }
+
+    function resetForm(error){
+      $(".sk-circle").hide();
+      $("#changePlan").show();
+      displayError.text(error);
+      $("#changePlan").attr("disabled", false);
+    }
   });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,9 @@ Rails.application.routes.draw do
 
     namespace :subscriptions do
       resources :cancellations, only: [:new, :create]
-      resources :plan_changes, only: [:show, :new, :create]
+      resources :plan_changes, only: [:show, :new, :create] do
+        post :status_from_stripe, on: :member
+      end
       post 'status_from_stripe'
     end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -29,6 +29,7 @@
 require 'rails_helper'
 
 describe SubscriptionsController, type: :controller do
+  render_views
   before :each do
     allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
   end
@@ -114,6 +115,7 @@ describe SubscriptionsController, type: :controller do
     let(:data) { { client_secret: Faker::Alphanumeric.alphanumeric, status: :ok } }
 
     before(:each) do
+      valid_subscription.client_secret = data[:client_secret]
       activate_authlogic
       UserSession.create!(basic_student)
       valid_subscription.start
@@ -166,8 +168,9 @@ describe SubscriptionsController, type: :controller do
         }
         stub_subscription_post_request(post_url, post_request_body, post_response_body)
 
-        post :create, params: { subscription: upgrade_params.merge(subscription_plan_id: subscription_plan_gbp_m.id, user_id: basic_student.id),
+        post :create, format: 'json', params: { subscription: upgrade_params.merge(subscription_plan_id: subscription_plan_gbp_m.id, user_id: basic_student.id),
                                 "payment-options": 'stripe' }
+
         body = JSON.parse(response.body)
 
         expect(flash[:success]).to be_nil
@@ -180,7 +183,7 @@ describe SubscriptionsController, type: :controller do
       end
 
       it 'should respond with Error Your request was declined. T&Cs false' do
-        post :create, params: { subscription: invalid_upgrade_params_1, user_id: basic_student.id, "payment-options": 'stripe' }
+        post :create, format: 'json', params: { subscription: invalid_upgrade_params_1, user_id: basic_student.id, "payment-options": 'stripe' }
         expect(flash[:success]).to be_nil
         expect(flash[:error]).to eq('Sorry! The data entered is not valid. Please contact us for assistance.')
         expect(response.status).to eq(302)
@@ -189,7 +192,7 @@ describe SubscriptionsController, type: :controller do
       end
 
       it 'should respond with Error Your request was declined. With Bad params' do
-        post :create, params: { subscription: invalid_upgrade_params_2, user_id: basic_student.id, "payment-options": 'stripe'  }
+        post :create, format: 'json', params: { subscription: invalid_upgrade_params_2, user_id: basic_student.id, "payment-options": 'stripe'  }
         expect(flash[:success]).to be_nil
         expect(flash[:error]).to eq('Sorry! The data entered is not valid. Please contact us for assistance.')
         expect(response.status).to eq(302)
@@ -228,7 +231,7 @@ describe SubscriptionsController, type: :controller do
         }
         stub_subscription_post_request(post_url, post_request_body, post_response_body)
 
-        post :create, params: { subscription: upgrade_params, "payment-options": 'stripe' }
+        post :create, format: 'json', params: { subscription: upgrade_params, "payment-options": 'stripe' }
         body = JSON.parse(response.body)
         expect(flash[:success]).to be_nil
         expect(flash[:error]).to be_nil

--- a/spec/services/stripe_subscription_service_spec.rb
+++ b/spec/services/stripe_subscription_service_spec.rb
@@ -21,16 +21,24 @@ describe StripeSubscriptionService, type: :service do
   describe '#change_plan' do
     let(:sub_plan) { create(:subscription_plan) }
     let(:new_sub) { create(:subscription, subscription_plan_id: sub_plan.id) }
+    let(:stripe_sub) { 
+      double(
+        latest_invoice: { payment_intent: { client_secret: 'cs_123456' }},
+        status: 'active'
+      )
+    }
 
     it 'calls #create_new_subscription' do
       allow(subject).to receive(:update_old_subscription)
-      expect(subject).to receive(:create_new_subscription).and_return(new_sub)
+      expect(subject).to receive(:create_new_subscription).
+                           and_return([new_sub, stripe_sub])
 
       subject.change_plan(sub_plan.id)
     end
 
     it 'starts the new subscription' do
-      allow(subject).to receive(:create_new_subscription).and_return(new_sub)
+      allow(subject).to receive(:create_new_subscription).
+                          and_return([new_sub, stripe_sub])
       allow(subject).to receive(:update_old_subscription)
       expect_any_instance_of(Subscription).to receive(:start)
 
@@ -38,17 +46,37 @@ describe StripeSubscriptionService, type: :service do
     end
 
     it 'calls #update_old_subscription' do
-      allow(subject).to receive(:create_new_subscription).and_return(new_sub)
+      allow(subject).to receive(:create_new_subscription).
+                          and_return([new_sub, stripe_sub])
       expect(subject).to receive(:update_old_subscription)
 
       subject.change_plan(sub_plan.id)
     end
 
-    it 'returns a subscription object' do
-      allow(subject).to receive(:create_new_subscription).and_return(new_sub)
+    it 'returns a subscription and stripe object' do
+      allow(subject).to receive(:create_new_subscription).
+                          and_return([new_sub, stripe_sub])
       allow(subject).to receive(:update_old_subscription)
 
-      expect(subject.change_plan(sub_plan.id)).to be_kind_of Subscription
+      expect(subject.change_plan(sub_plan.id)).to be_kind_of Array
+    end
+
+    describe 'for payments failing 3DS' do
+      let(:stripe_sub_3ds) { 
+        double(
+          latest_invoice: { payment_intent: { client_secret: 'cs_123456' }},
+          status: 'past_due'
+        )
+      }
+      
+      it 'calls #mark_payment_action_required on the subscription' do
+        allow(subject).to receive(:create_new_subscription).
+                          and_return([new_sub, stripe_sub_3ds])
+        allow(subject).to receive(:update_old_subscription)
+        expect_any_instance_of(Subscription).to receive(:mark_payment_action_required)
+
+        subject.change_plan(sub_plan.id)
+      end
     end
   end
 
@@ -95,8 +123,7 @@ describe StripeSubscriptionService, type: :service do
       expect(subject.create_and_return_subscription('sk_test_token', nil)).to(
         include(
           a_kind_of(Subscription),
-          { client_secret: stripe_sub.latest_invoice.payment_intent
-                            .client_secret, status: :ok }
+          { status: :ok }
         )
       )
     end
@@ -207,7 +234,7 @@ describe StripeSubscriptionService, type: :service do
     let(:stripe_sub) {
       JSON.parse(
         File.read(
-          Rails.root.join('spec/fixtures/stripe/create_subscription_response.json')
+          Rails.root.join('spec/fixtures/stripe/create_sub_with_payment_intent.json')
         ), object_class: OpenStruct
       )
     }
@@ -282,7 +309,7 @@ describe StripeSubscriptionService, type: :service do
     it 'assigns attributes to the subscription' do
       expect(test_sub).to receive(:assign_attributes)
 
-      subject.send(:merge_subscription_data, stripe_sub, customer, nil)
+      subject.send(:merge_subscription_data, stripe_sub, customer)
     end
   end
 


### PR DESCRIPTION
- [x] Handle plan changes that happen without requiring SCA.
- [x] Load SCA modal for plan changes that don't succeed with SCA error.
- [x] Roll back subscriptions until SCA is approved.
  - Can roll back this properly in our DB but wondering what we can do on Stripe. The subscription has already been updated and is now in a failed state. What I'm working towards here is to put the new subscription in a failed state (like we do when we get a webhook for a recurring payment).