### PR TITLE
UPDATE: Moving orders back to pending after a failed 3DS authentication.

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -69,6 +69,10 @@ class Order < ApplicationRecord
       transition %i[pending errored] => :completed
     end
 
+    event :mark_pending do
+      transition all => :pending
+    end
+
     event :mark_payment_action_required do
       transition all => :pending_3d_secure
     end
@@ -102,7 +106,6 @@ class Order < ApplicationRecord
 
   def confirm_payment_intent
     StripeService.new.confirm_purchase(self)
-    confirm_3d_secure
   end
 
   def destroyable?
@@ -126,8 +129,7 @@ class Order < ApplicationRecord
   end
 
   def stripe?
-    stripe_client_secret.present? || stripe_payment_intent_id.present? ||
-      stripe_payment_method_id.present?
+    stripe_payment_intent_id.present? || stripe_payment_method_id.present?
   end
 
   def generate_invoice

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -256,24 +256,30 @@
     };
 
     function handlePayment(client_secret, order_id){
+      let orderStatus = '';
       stripe.handleCardAction(client_secret, card).then(function(result) {
-          if (result.error) {
-            resetForm(result.error);
-          } else {
-            $.ajax({
-              type: 'PATCH',
-              url: '/orders/' + order_id,
-              data: { stripe_payment_intent_id: result.paymentIntent.id, id: order_id },
-              dataType: 'json',
-              success: function(data,status,xhr){
-                console.log(data);
-                window.location.replace("#{user_exercises_path(current_user)}");
-              },
-              error: function(xhr,status,error){
-                resetForm(xhr.responseJSON.error);
-              }
-          });
+        if (result.error) {
+          resetForm(result.error);
+          orderStatus = 'pending';
+        } else {
+          orderStatus = result['paymentIntent']['status'];
         }
+          $.ajax({
+            type: 'PATCH',
+            url: '/orders/' + order_id,
+            data: { status: orderStatus },
+            dataType: 'json',
+            success: function(data,status,xhr){
+              if (data.status == 'completed') {
+                window.location.replace("#{user_exercises_path(current_user)}");
+              } else {
+                resetForm(data);
+              }
+            },
+            error: function(xhr,status,error){
+              resetForm(xhr.responseJSON.error);
+            }
+        });
       });
     };
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -217,15 +217,5 @@ describe Order do
 
       order.confirm_payment_intent
     end
-
-    it 'calls transition[confirm_3d_secure] if the intent is succeeded' do
-      intent = double(status: 'succeeded')
-      allow_any_instance_of(StripeService).to(
-        receive(:confirm_purchase).with(order).and_return(intent)
-      )
-      expect(order).to receive(:confirm_3d_secure)
-
-      order.confirm_payment_intent
-    end
   end
 end


### PR DESCRIPTION
- [x] Clean up orders controller and post purchase update.
- [x] Move order back to pending if 3DS has a failure.