### PR TITLE
UPDATE: What happens when a plan-change fails 3DS

### DIFF
--- a/app/controllers/subscriptions/cancellations_controller.rb
+++ b/app/controllers/subscriptions/cancellations_controller.rb
@@ -1,37 +1,39 @@
-class Subscriptions::CancellationsController < ApplicationController
+# frozen_string_literal: true
 
-  before_action :logged_in_required
-  before_action do
-    ensure_user_has_access_rights(%w(student_user))
-  end
-  before_action :get_subscription
-
-  def new
-  end
-
-  def create
-    @subscription.cancelling_subscription = true
-    if @subscription.update(subscription_params) && @subscription.cancel_by_user
-      flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
-      flash[:datalayer_cancel] = @subscription.user_readable_name
-
-      redirect_to account_url(anchor: 'account-info')
-    else
-      Rails.logger.warn "WARN: Subscription#delete failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
-      flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
-      @subscription.errors.add(:cancellation_reason, 'please select an option')
-
-      redirect_to new_subscriptions_cancellation_path(id: @subscription.id)
+module Subscriptions
+  class CancellationsController < ApplicationController
+    before_action :logged_in_required
+    before_action do
+      ensure_user_has_access_rights(%w[student_user])
     end
-  end
+    before_action :set_subscription
 
-  private
+    def new; end
 
-  def subscription_params
-    params.require(:subscription).permit(:cancellation_reason, :cancellation_note)
-  end
+    def create
+      @subscription.cancelling_subscription = true
+      if @subscription.update(subscription_params) && @subscription.cancel_by_user
+        flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
+        flash[:datalayer_cancel] = @subscription.user_readable_name
 
-  def get_subscription
-    @subscription = Subscription.find_by_id(params[:id])
+        redirect_to account_url(anchor: 'account-info')
+      else
+        Rails.logger.warn "WARN: Subscription#delete failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
+        flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
+        @subscription.errors.add(:cancellation_reason, 'please select an option')
+
+        redirect_to new_subscriptions_cancellation_path(id: @subscription.id)
+      end
+    end
+
+    private
+
+    def set_subscription
+      @subscription = Subscription.find_by(id: params[:subscription_id])
+    end
+
+    def subscription_params
+      params.require(:subscription).permit(:cancellation_reason, :cancellation_note)
+    end
   end
 end

--- a/app/controllers/subscriptions/plan_changes_controller.rb
+++ b/app/controllers/subscriptions/plan_changes_controller.rb
@@ -6,7 +6,7 @@ module Subscriptions
     before_action do
       ensure_user_has_access_rights(%w(student_user))
     end
-    before_action :get_subscription
+    before_action :set_subscription
 
     def show
       Rails.logger.info "DataLayer Event: PlanChanges#show - Subscription: #{@subscription.id}, Revenue: #{@subscription.subscription_plan.price}, PlanName: #{@subscription.subscription_plan.name}, Brand: #{@subscription.subscription_plan.exam_body.name}" if @subscription
@@ -36,10 +36,6 @@ module Subscriptions
 
     private
 
-    def get_subscription
-      @subscription = Subscription.find_by_id(params[:id])
-    end
-
     def change_stripe_subscription(subscription, plan_id)
       @subscription, data = StripeSubscriptionService.new(subscription).
                               change_plan(plan_id)
@@ -61,6 +57,10 @@ module Subscriptions
 
     def plan_change_params
       params.require(:subscription).permit(:subscription_plan_id)
+    end
+
+    def set_subscription
+      @subscription = Subscription.find_by(id: params[:subscription_id])
     end
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -32,7 +32,7 @@ class Subscription < ApplicationRecord
 
   serialize :stripe_customer_data, Hash
   attr_accessor :use_paypal, :paypal_approval_url, :cancelling_subscription,
-                :payment_intent, :client_secret
+                :payment_intent_status, :client_secret
 
   delegate :currency, to: :subscription_plan
 
@@ -47,6 +47,7 @@ class Subscription < ApplicationRecord
   belongs_to :coupon, optional: true
   belongs_to :changed_from, class_name: 'Subscription', foreign_key: :changed_from_id, optional: true
 
+  has_one :changed_to, class_name: 'Subscription', foreign_key: 'changed_from_id', inverse_of: :changed_from
   has_one :student_access
   has_one :exam_body, through: :subscription_plan
 
@@ -160,6 +161,15 @@ class Subscription < ApplicationRecord
   # CLASS METHODS ==============================================================
 
   # INSTANCE METHODS ===========================================================
+
+  def take_appropriate_action(status)
+    case status
+    when 'active'
+      start
+    when 'past_due'
+      mark_payment_action_required
+    end
+  end
 
   def cancel_by_user
     if stripe_customer_id && stripe_guid
@@ -311,6 +321,10 @@ class Subscription < ApplicationRecord
     self.record_error
   end
 
+  def pending_3ds_invoice
+    invoices.find_by(requires_3d_secure: true)
+  end
+
   def reactivation_options
     SubscriptionPlan
       .where(
@@ -429,7 +443,7 @@ class Subscription < ApplicationRecord
   def update_subscription_status
     if stripe_status == 'active'
       start
-    elsif payment_intent == 'requires_action'
+    elsif payment_intent_status == 'requires_action'
       mark_payment_action_required
     end
   end

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -23,7 +23,7 @@
                           %th PDF
                       %tbody
                         -@invoices.each do |invoice|
-                          - unless invoice.status == 'Pending'
+                          - unless invoice.status == 'Pending' && !invoice.requires_3d_secure
                             %tr
                               %td=invoice.id
                               %td=humanize_datetime(invoice.issued_at)

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -335,8 +335,12 @@
             window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
           }
         },
-        error: function(data, status, error){
-          resetForm(data.responseJSON.error);
+        error: function(request, status, error){
+          if (request.status === 500) {
+            resetForm('Something went wrong. Please try again.');
+          } else {
+            resetForm(request.responseJSON.error);
+          }
         }
       });
     }
@@ -345,27 +349,27 @@
       let statusArray = ['active', 'succeeded'];
       let intentStatus = '';
       stripe.handleCardPayment(client_secret, cardElement).then(function(result) {
-          if (result.error) {
-            resetForm(result.error.message);
-            intentStatus = 'pending';
-          } else {
-            intentStatus = result['paymentIntent']['status'];
-          }
+        if (result.error) {
+          resetForm(result.error.message);
+          intentStatus = 'pending';
+        } else {
+          intentStatus = result['paymentIntent']['status'];
+        }
 
-          $.ajax({
-            type: 'post',
-            url: "#{subscriptions_status_from_stripe_path}",
-            data: { status: intentStatus, id: subscription_id },
-            dataType: 'json',
-            success: function(data,status,xhr){
-              if( $.inArray(intentStatus, statusArray) !== -1){
-                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
-              }
-            },
-            error: function(xhr,status,error){
-              resetForm(error);
+        $.ajax({
+          type: 'post',
+          url: "/subscriptions/" + subscription_id + "/status_from_stripe",
+          data: { status: intentStatus },
+          dataType: 'json',
+          success: function(data,status,xhr){
+            if( $.inArray(intentStatus, statusArray) !== -1){
+              window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
             }
-          });
+          },
+          error: function(xhr,status,error){
+            resetForm(error);
+          }
+        });
       });
     }
 

--- a/app/views/subscriptions/plan_changes/_update_card_modal.haml
+++ b/app/views/subscriptions/plan_changes/_update_card_modal.haml
@@ -1,0 +1,42 @@
+#update-card-modal.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "update-card-modal", :role => "dialog", :tabindex => "-1"}
+  .modal-dialog{:role => "document"}
+    .modal-content
+      %button.btn.btn-text.modal-close.p-0{"data-dismiss" => "modal"}
+        %i.material-icons{"aria-hidden" => "true"} close
+      %div
+        %h3#add-card-modal.text-gray2.mb-5 Update Card
+        %p Your payment details have failed authentication. Please update your card details below.
+      .modal-body
+        =form_for(SubscriptionPaymentCard.new, method: :post, html: {class: 'py-2', role: 'form', id: 'new-subscription-payment-card-form'}, name: 'add_card_form') do |f|
+          =f.hidden_field :user_id, value: current_user.id
+          =f.hidden_field :stripe_token
+
+          .row
+            .col-sm-12
+              .payment-errors
+                .payment-errors
+                  .form-group.cc
+                    %label
+                      Credit or Debit card
+                    .clearfix
+                      #card-element
+                      #card-errors{role: 'alert', class: 'invalid-details'}
+
+          .pt-2.d-flex.flex-wrap.flex-sm-nowrap.justify-content-between
+            %div
+              = f.button :submit, class: 'btn btn-primary float-left mb-2', id: 'card_submit' do
+                Submit Card Details
+
+              .sk-circle{style: 'margin-right: 50px; margin-left: 50px;'}
+                .sk-circle1.sk-child
+                .sk-circle2.sk-child
+                .sk-circle3.sk-child
+                .sk-circle4.sk-child
+                .sk-circle5.sk-child
+                .sk-circle6.sk-child
+                .sk-circle7.sk-child
+                .sk-circle8.sk-child
+                .sk-circle9.sk-child
+                .sk-circle10.sk-child
+                .sk-circle11.sk-child
+                .sk-circle12.sk-child

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -11,7 +11,7 @@
         %section.pb-md-6.pb-5
           -if flash[:success] || flash[:error] || flash[:warning]
             =render partial: 'layouts/flash_messages'
-          =form_for(@subscription, url: subscriptions_plan_changes_path(id: @subscription.id), method: :post, html: {class: 'form-horizontal', role: 'form', id: 'upgrade-subscription-form'}) do |f|
+          =form_for(@subscription, url: subscription_plan_changes_path(@subscription), method: :post, html: {class: 'form-horizontal', role: 'form', id: 'upgrade-subscription-form'}) do |f|
             =f.hidden_field :subscription_plan_id
             =f.hidden_field :use_paypal, value: @subscription.paypal?
             .row.row-md
@@ -89,6 +89,8 @@
 
                       =link_to t('views.general.cancel'), account_url(anchor: 'account-info'), class: 'btn btn-secondary btn-sm '
 
+=render partial: 'update_card_modal'
+
 
 
 :javascript
@@ -123,10 +125,35 @@
     addToCart(theThing);
   }
 
+  var style = {
+    base: {
+      color: '#32325d',
+      lineHeight: '18px',
+      fontFamily: '"OakesGrotesk", "Helvetica Neue", Helvetica, sans-serif',
+      fontSmoothing: 'antialiased',
+      fontSize: '16px',
+      '::placeholder': {
+        color: '#aab7c4'
+      }
+    },
+    invalid: {
+      color: '#fa755a',
+      iconColor: '#fa755a'
+    }
+  };
+
   $(document).on('ready', function() {
     var displayError = $('.invalid-details');
+    var displayCardError = $('#card-errors');
+    let clientSecret, subscriptionId;
+    let statusArray = ['active', 'succeeded'];
     displayError.text('');
+    displayCardError.text('');
     var stripe = Stripe('#{ENV['LEARNSIGNAL_V3_STRIPE_PUBLIC_KEY']}');
+    var elements = stripe.elements();
+
+    var cardElement = elements.create('card', {hidePostalCode: true, style: style});
+    cardElement.mount('#card-element');
 
     $(".sk-circle").hide();
     choosePlan($('.plan-option')[0]);
@@ -162,7 +189,7 @@
         data: $(form).serialize(),
         dataType: 'json',
         success: function(data, status, xhr){
-          if($.inArray(data.status, [ 'incomplete', 'past_due'])){
+          if($.inArray(data.status, ['incomplete', 'past_due'])){
             handleStripeAction(data.client_secret, data.subscription_id)
           } else if(data.status == 'active'){
             window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
@@ -179,38 +206,92 @@
     }
 
     function handleStripeAction(client_secret, subscription_id){
-      let statusArray = ['active', 'succeeded'];
       let intentStatus = '';
       stripe.handleCardPayment(client_secret).then(function(result) {
         if (result.error) {
           resetForm(result.error.message);
           intentStatus = 'pending';
+          let failureStatusArray = ['requires_payment_method', 'requires_source']
+          if ($.inArray(result.error.payment_intent.status, failureStatusArray) !== -1 ) {
+            launchPaymentMethodForm(client_secret, subscription_id);
+          }
         } else {
           intentStatus = result['paymentIntent']['status'];
-        }
-
-        $.ajax({
-          type: 'post',
-          url: "/subscriptions/plan_changes/" + subscription_id + "/status_from_stripe",
-          data: { status: intentStatus, id: subscription_id },
-          dataType: 'json',
-          success: function(data,status,xhr){
-            if( $.inArray(intentStatus, statusArray) !== -1){
-              window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+          $.ajax({
+            type: 'post',
+            url: "/subscriptions/" + subscription_id + "plan_changes/status_from_stripe",
+            data: { status: intentStatus, id: subscription_id },
+            dataType: 'json',
+            success: function(data,status,xhr){
+              if( $.inArray(intentStatus, statusArray) !== -1){
+                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+              }
+            },
+            error: function(xhr,status,error){
+              resetForm(error);
             }
-          },
-          error: function(xhr,status,error){
-            resetForm(error);
-          }
-        });
+          });
+        }
       });
     }
+
+    function launchPaymentMethodForm(client_secret, subscription_id) {
+      $('#update-card-modal').modal('show');
+      clientSecret = client_secret;
+      subscriptionId = subscription_id;
+    }
+
+    cardElement.addEventListener('change', function(event) {
+      if (event.error) {
+        resetCardForm(event.error.message);
+      } else {
+        displayCardError.text('');
+      }
+    });
+
+    var cardButton = document.getElementById('card_submit');
+
+    cardButton.addEventListener('click', function(ev) {
+      ev.preventDefault();
+      $('#card_submit').hide();
+      $(".sk-circle").show();
+
+      stripe.handleCardPayment(clientSecret, cardElement).then(function(result) {
+        if (result.error) {
+          resetCardForm(result.error.message);
+          intentStatus = 'pending';
+        } else {
+          intentStatus = result['paymentIntent']['status'];
+          $.ajax({
+            type: 'post',
+            url: "/subscriptions/" + subscriptionId + "plan_changes/status_from_stripe",
+            data: { status: intentStatus },
+            dataType: 'json',
+            success: function(data,status,xhr){
+              if( $.inArray(intentStatus, statusArray) !== -1){
+                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+              }
+            },
+            error: function(xhr,status,error){
+              resetCardForm(error);
+            }
+          });
+        }
+      })
+    });
 
     function resetForm(error){
       $(".sk-circle").hide();
       $("#changePlan").show();
       displayError.text(error);
       $("#changePlan").attr("disabled", false);
+    }
+
+    function resetCardForm(error){
+      $(".sk-circle").hide();
+      $("#card_submit").show();
+      displayCardError.text(error);
+      $("#card_submit").attr("disabled", false);
     }
   });
 

--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -13,7 +13,7 @@
                     =subscription.user_readable_name
 
                   %span.badge.badge-warning.align-middle
-                    =subscription.state.capitalize
+                    =subscription.pending_3d_secure? ? 'Payment Error' : subscription.state.capitalize
 
                 %p.mb-1
                   Subscription created on
@@ -24,7 +24,12 @@
                     =subscription.stripe? ? 'Credit card' : "PayPal"
 
               .col-md-4.text-md-right
-                %button.btn.btn-secondary.btn-sm.js-show-hide-details.collapsed.sub-details{"aria-controls" => "#sub-#{subscription.id}", "aria-expanded" => "false", "data-target" => "#sub-#{subscription.id}", "data-toggle" => "collapse"}
+                -if subscription.pending_3d_secure? && subscription.pending_3ds_invoice
+                  =link_to show_invoice_url(subscription.pending_3ds_invoice&.sca_verification_guid) do
+                    .btn.btn-secondary
+                      Authenticate
+                -else
+                  %button.btn.btn-secondary.btn-sm.js-show-hide-details.collapsed.sub-details{"aria-controls" => "#sub-#{subscription.id}", "aria-expanded" => "false", "data-target" => "#sub-#{subscription.id}", "data-toggle" => "collapse"}
 
             .collapse{id: "sub-#{subscription.id}"}
               .pt-5.pb-4
@@ -56,7 +61,7 @@
                           %th PDF
                       %tbody
                         -subscription.invoices.each do |invoice|
-                          - unless invoice.status == 'Pending'
+                          - unless invoice.status == 'Pending' && !invoice.requires_3d_secure
                             %tr
                               %td=invoice.id
                               %td=humanize_datetime(invoice.issued_at)
@@ -74,16 +79,15 @@
                                     .btn.btn-link.btn-xs
                                       View
 
-
                 %div.mr-3.mb-4
                   =link_to 'View All Invoices', user_invoices_path(current_user)
                 %div
                   -if subscription.can_change_plan?
-                    =link_to 'Change Subscription Plan', new_subscriptions_plan_change_path(id: subscription.id), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
+                    =link_to 'Change Subscription Plan', new_subscription_plan_changes_path(subscription), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
                   -if subscription.paused?
                     =link_to 'Reactivate Subscription', subscriptions_suspension_path(id: subscription.id), method: :delete, class: 'btn btn-secondary btn-xs', style: 'vertical-align: top;'
                   -if !subscription.cancelled?
-                    =link_to 'Cancel Subscription', new_subscriptions_cancellation_path(id: subscription.id), class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
+                    =link_to 'Cancel Subscription', new_subscription_cancellation_path(subscription), class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
                   -else
                     =link_to 'Renew Subscription', subscription_checkout_special_link(subscription.subscription_plan.exam_body_id), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,15 +39,14 @@ Rails.application.routes.draw do
         put 'un_cancel'
         get 'execute'
         get 'unapproved'
+        post 'status_from_stripe'
       end
-    end
-
-    namespace :subscriptions do
-      resources :cancellations, only: [:new, :create]
-      resources :plan_changes, only: [:show, :new, :create] do
-        post :status_from_stripe, on: :member
+      scope module: 'subscriptions' do
+        resources :cancellations, only: [:new, :create]
+        resource :plan_changes, only: [:show, :new, :create] do
+          post :status_from_stripe, on: :member
+        end
       end
-      post 'status_from_stripe'
     end
 
     resources :subscription_management do

--- a/spec/services/stripe_subscription_service_spec.rb
+++ b/spec/services/stripe_subscription_service_spec.rb
@@ -28,16 +28,16 @@ describe StripeSubscriptionService, type: :service do
       )
     }
 
-    it 'calls #create_new_subscription' do
+    it 'calls #create_subscription' do
       allow(subject).to receive(:update_old_subscription)
-      expect(subject).to receive(:create_new_subscription).
+      expect(subject).to receive(:create_subscription).
                            and_return([new_sub, stripe_sub])
 
       subject.change_plan(sub_plan.id)
     end
 
     it 'starts the new subscription' do
-      allow(subject).to receive(:create_new_subscription).
+      allow(subject).to receive(:create_subscription).
                           and_return([new_sub, stripe_sub])
       allow(subject).to receive(:update_old_subscription)
       expect_any_instance_of(Subscription).to receive(:start)
@@ -46,7 +46,7 @@ describe StripeSubscriptionService, type: :service do
     end
 
     it 'calls #update_old_subscription' do
-      allow(subject).to receive(:create_new_subscription).
+      allow(subject).to receive(:create_subscription).
                           and_return([new_sub, stripe_sub])
       expect(subject).to receive(:update_old_subscription)
 
@@ -54,7 +54,7 @@ describe StripeSubscriptionService, type: :service do
     end
 
     it 'returns a subscription and stripe object' do
-      allow(subject).to receive(:create_new_subscription).
+      allow(subject).to receive(:create_subscription).
                           and_return([new_sub, stripe_sub])
       allow(subject).to receive(:update_old_subscription)
 
@@ -70,7 +70,7 @@ describe StripeSubscriptionService, type: :service do
       }
       
       it 'calls #mark_payment_action_required on the subscription' do
-        allow(subject).to receive(:create_new_subscription).
+        allow(subject).to receive(:create_subscription).
                           and_return([new_sub, stripe_sub_3ds])
         allow(subject).to receive(:update_old_subscription)
         expect_any_instance_of(Subscription).to receive(:mark_payment_action_required)
@@ -227,7 +227,7 @@ describe StripeSubscriptionService, type: :service do
     end
   end
 
-  describe '#create_new_subscription' do
+  describe '#create_subscription' do
     let(:user) { create(:student_user) }
     let(:test_sub) { create(:stripe_subscription, user: user, state: 'active') }
     let(:sub_plan) { create(:subscription_plan, currency: test_sub.currency) }
@@ -248,13 +248,13 @@ describe StripeSubscriptionService, type: :service do
     it 'calls #get_updated_stripe_subscription' do
       expect(subject).to receive(:get_updated_stripe_subscription).and_return(stripe_sub)
 
-      subject.send(:create_new_subscription, sub_plan)
+      subject.send(:create_subscription, sub_plan)
     end
 
     it 'creates a new Subscription record' do
       allow(subject).to receive(:get_updated_stripe_subscription).and_return(stripe_sub)
 
-      expect{ subject.send(:create_new_subscription, sub_plan) }.to(
+      expect{ subject.send(:create_subscription, sub_plan) }.to(
         change { Subscription.count }.from(1).to(2)
       )
     end


### PR DESCRIPTION
- [x] Update the account_info tab with details of the failed payment and an ability to authenticate the payment.
- [x] How do we handle the delay between the failed `plan-change` action and the creation of the invoice that needs 3DS authentication?