### PR TITLE
(HOTIFIX) Stripe update plans.

### DIFF
--- a/app/services/stripe_subscription_service.rb
+++ b/app/services/stripe_subscription_service.rb
@@ -59,13 +59,14 @@ class StripeSubscriptionService < StripeService
 
   def create_subscription(new_plan)
     stripe_sub = get_updated_stripe_subscription(new_plan)
+
     [Subscription.create!(
       user_id: @subscription.user_id, subscription_plan_id: new_plan.id,
       complimentary: false, livemode: stripe_sub.plan[:livemode],
       stripe_status: stripe_sub.status, changed_from: @subscription,
       stripe_guid: stripe_sub.id, next_renewal_date: renewal_date(stripe_sub),
       stripe_customer_id: @subscription.stripe_customer_id,
-      client_secret: stripe_sub.latest_invoice[:payment_intent][:client_secret]
+      client_secret: stripe_sub.latest_invoice.to_h.dig(:payment_intent, :client_secret)
     ), stripe_sub]
   end
 
@@ -83,6 +84,7 @@ class StripeSubscriptionService < StripeService
 
   def get_updated_stripe_subscription(new_sub_plan)
     stripe_sub = retrieve_subscription
+
     Stripe::Subscription.update(
       @subscription.stripe_guid,
       items: [{ id: stripe_sub&.items&.first&.id, plan: new_sub_plan.stripe_guid }],

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -189,14 +189,14 @@
         data: $(form).serialize(),
         dataType: 'json',
         success: function(data, status, xhr){
-          if($.inArray(data.status, ['incomplete', 'past_due'])){
+          if (['incomplete', 'past_due'].includes(data.status)) {
             handleStripeAction(data.client_secret, data.subscription_id)
-          } else if(data.status == 'active'){
+          } else if(data.status == 'active') {
             window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
           }
         },
         error: function(request, status, error){
-          if (request.status === 500) {
+          if (request.status === 500 || request.responseJSON === undefined) {
             resetForm('Something went wrong. Please try again.');
           } else {
             resetForm(request.responseJSON.error);
@@ -212,7 +212,7 @@
           resetForm(result.error.message);
           intentStatus = 'pending';
           let failureStatusArray = ['requires_payment_method', 'requires_source']
-          if ($.inArray(result.error.payment_intent.status, failureStatusArray) !== -1 ) {
+          if ($.inArray(result.error.payment_intent.status, failureStatusArray) !== -1) {
             launchPaymentMethodForm(client_secret, subscription_id);
           }
         } else {
@@ -223,7 +223,7 @@
             data: { status: intentStatus, id: subscription_id },
             dataType: 'json',
             success: function(data,status,xhr){
-              if( $.inArray(intentStatus, statusArray) !== -1){
+              if ($.inArray(intentStatus, statusArray) !== -1){
                 window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
               }
             },


### PR DESCRIPTION
Using `.dig` method to get data from subscription hash if exist, avoiding trigger a error;
Using includes in status check in javascript to do the correct checking.
* This javascript fix will do to users avoid to update the same subscription for not receive any error message before;

Should cover airbrake tickets:

- [`NoMethodError: undefined method '[]' for nil:NilClass`](https://learnsignal.airbrake.io/projects/107826/groups/2570168143868799755?tab=overview)
- [`ActiveRecord::RecordInvalid: Validation failed: Can't switch from a subscription in this current status`](https://learnsignal.airbrake.io/projects/107826/groups/2570112601628551938?tab=overview)
- [`ActiveRecord::RecordInvalid: Validation failed: You cannot upgrade to that plan. Please choose a different plan.`](https://learnsignal.airbrake.io/projects/107826/groups/2570389202136148761?tab=overview)