### PR TITLE
FIX: Airbrake new_order_url route updated for student signups.

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -26,7 +26,7 @@ class UserSessionsController < ApplicationController
       if flash[:plan_guid]
         redirect_to new_subscription_url(plan_guid: flash[:plan_guid], exam_body_id: flash[:exam_body], login: true)
       elsif flash[:product_id]
-        redirect_to new_order_url(product_id: flash[:product_id], login: true)
+        redirect_to new_product_order_url(product_id: flash[:product_id], login: true)
       elsif session[:return_to]
         redirect_back_or_default(student_dashboard_url)
       elsif params[:subject_course_id]


### PR DESCRIPTION
This fixes two airbrakes.
- StudentSignUps [here](https://learnsignal.airbrake.io/projects/107826/groups/2570573885729876768?tab=notice-detail)
- UserSessions [here](https://learnsignal.airbrake.io/projects/107826/groups/2570574191964400419?tab=overview)