### PR TITLE
FIX: Airbrake invalid subscription on Stripe when cancelling sub.

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -198,6 +198,8 @@ class Subscription < ApplicationRecord
       Rails.logger.error "ERROR: Subscription#cancel failed because it didn't have a stripe_customer_id OR a stripe_guid. Subscription:#{self}."
       false
     end
+  rescue Stripe::InvalidRequestError
+    raise Learnsignal::SubscriptionError, I18n.t('controllers.subscriptions.destroy.flash.error')
   end
 
   def immediate_cancel


### PR DESCRIPTION
[Stripe::InvalidRequestError: No such subscription: sub_DuZPoyjtmYNxMT](https://learnsignal.airbrake.io/projects/107826/groups/2571171550125566774?tab=notice-detail)