### PR TITLE
Fixed issue with filtered plans for inactive plan guid param

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -329,11 +329,11 @@ class Subscription < ApplicationRecord
   end
 
   def reactivation_options
-    SubscriptionPlan
-      .where(
-        currency_id: self.subscription_plan.currency_id
-      )
-      .where('price > 0.0').generally_available.all_active.all_in_order
+    SubscriptionPlan.
+      where(
+        currency_id: subscription_plan.currency_id
+      ).
+      where('price > 0.0').generally_available.all_active.all_in_order
   end
 
   def schedule_paypal_cancellation
@@ -342,7 +342,12 @@ class Subscription < ApplicationRecord
   end
 
   def upgrade_options
-    SubscriptionPlan.includes(:currency).where.not(id: subscription_plan.id).where(subscription_plan_category_id: nil).for_exam_body(subscription_plan.exam_body_id).in_currency(subscription_plan.currency_id).all_active.all_in_order
+    SubscriptionPlan.includes(:currency).
+      where.not(payment_frequency_in_months: subscription_plan.payment_frequency_in_months).
+      where(subscription_plan_category_id: nil).
+      for_exam_body(subscription_plan.exam_body_id).
+      in_currency(subscription_plan.currency_id).
+      all_active.all_in_order
   end
 
   def update_from_stripe

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -93,8 +93,9 @@ class SubscriptionPlan < ApplicationRecord
 
   def self.get_individual_related_plan(plan_guid, currency)
     plan = SubscriptionPlan.find_by(guid: plan_guid)
-    return plan unless plan && plan.currency_id != currency.id
-    raise Learnsignal::SubscriptionError, 'The specified plan is not available in your currency! Please choose another.'
+    return plan unless (plan && plan.currency_id != currency.id) || (plan && !plan.active?)
+
+    raise Learnsignal::SubscriptionError, 'The specified plan is not available! Please choose another.'
   end
 
   def self.get_related_plans(user, currency, exam_body_id, plan_guid)

--- a/spec/models/subscription_plan_spec.rb
+++ b/spec/models/subscription_plan_spec.rb
@@ -140,7 +140,7 @@ describe SubscriptionPlan, type: :model do
 
       describe 'when neither the exam_body or preferred_exam_body exist' do
         let(:new_user) { build_stubbed(:user, preferred_exam_body_id: nil) }
-        
+
         it 'returns the original plans' do
           expect(SubscriptionPlan.scope_exam_body_plans(new_user, nil, plans)).to(
             eq plans
@@ -161,8 +161,15 @@ describe SubscriptionPlan, type: :model do
       end
 
       it 'raises an error if there is a currency miss-match' do
-        expect{ SubscriptionPlan.get_individual_related_plan(plan.guid, currency) }.to(
-          raise_error(Learnsignal::SubscriptionError, 'The specified plan is not available in your currency! Please choose another.')
+        expect { SubscriptionPlan.get_individual_related_plan(plan.guid, currency) }.to(
+          raise_error(Learnsignal::SubscriptionError, 'The specified plan is not available! Please choose another.')
+        )
+      end
+
+      it 'raises an error if the plan is not active' do
+        plan.update_column(:available_to, 1.days.ago)
+        expect { SubscriptionPlan.get_individual_related_plan(plan.guid, currency) }.to(
+          raise_error(Learnsignal::SubscriptionError, 'The specified plan is not available! Please choose another.')
         )
       end
     end


### PR DESCRIPTION
Changed upgrade_options condition to stop changing plan to a plan with the same payment interval