### PR TITLE
FEATURE: Student view for spreadsheet editor

### DIFF
--- a/app/controllers/api/v1/cbes/users_log_controller.rb
+++ b/app/controllers/api/v1/cbes/users_log_controller.rb
@@ -28,18 +28,11 @@ module Api
 
         def permitted_params
           params.require(:cbe_user_log).permit(
-            :status,
-            :score,
-            :created_at,
-            :updated_at,
-            :cbe_id,
-            :user_id,
+            :status, :score, :created_at, :updated_at, :cbe_id, :user_id,
             answers_attributes: [
-              :cbe_question_id,
-              :cbe_answer_id,
+              :cbe_question_id, :cbe_answer_id,
               content: [
-                :text,
-                :correct
+                :text, :correct, data: %i[value row col colBinding style]
               ]
             ]
           )

--- a/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
+++ b/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
@@ -227,21 +227,17 @@
           flex.selectedSheetIndex = 0;
           setTimeout(() => this._updateSelection(flex, flex.selection), 100);
         });
-
         flex.selectionChanged.addHandler((sender, args) => {
           this._updateSelection(flex, args.range);
         });
-
-        flex.cellEditEnded.addHandler((sender, args) => {
+        flex.lostFocus.addHandler((sender, args) => {
           this.commitUpdatedData(flex);
         })
-
-        // set the height of rows in the scrollable area
         flex.rows.defaultSize = 22;
         flex.rowHeaders.defaultSize = 100;
         flex.columns.defaultSize = 75;
-        // set the height of rows in the column header area
         flex.columnHeaders.rows.defaultSize = 22;
+        this.commitUpdatedData(flex);
 
         this.flex = flex;
       },

--- a/app/javascript/components/cbe/Home.vue
+++ b/app/javascript/components/cbe/Home.vue
@@ -25,40 +25,37 @@
 </template>
 
 <script>
-import axios from "axios";
-import NavBar from "./NavBar";
-import NavPagination from "./NavPagination";
-import { mapGetters } from "vuex";
+import axios from 'axios';
+import { mapGetters } from 'vuex';
+import NavBar from './NavBar.vue';
+import NavPagination from './NavPagination.vue';
 
 export default {
   components: {
     NavBar,
-    NavPagination
+    NavPagination,
   },
   data() {
     return {
       cbeId: this.$parent.cbe_id,
-      userId: this.$parent.user_id
+      userId: this.$parent.user_id,
     };
   },
-  mounted() {
-    this.$store.dispatch("cbe/getCbe", this.cbeId);
-  },
   computed: {
-    ...mapGetters("cbe", {
-      cbe_data: "cbe_data"
+    ...mapGetters('cbe', {
+      cbe_data: 'cbe_data',
     }),
-    ...mapGetters("user_cbe", {
-      user_cbe_data: "user_cbe_data"
-    })
+    ...mapGetters('user_cbe', {
+      user_cbe_data: 'user_cbe_data',
+    }),
   },
   watch: {
     cbe_data: {
       handler() {
-        this.$store.dispatch("userCbe/startUserCbeData", {
+        this.$store.dispatch('user_cbe/startUserCbeData', {
           cbe_id: this.cbeId,
           user_id: this.userId,
-          cbe_data: this.cbe_data
+          cbe_data: this.cbe_data,
         });
       }
     },
@@ -69,6 +66,9 @@ export default {
         }
       },
     }
+  },
+  mounted() {
+    this.$store.dispatch('cbe/getCbe', this.cbeId);
   },
   methods: {
     submitExam: function() {
@@ -106,6 +106,6 @@ export default {
         }
       });
     }
-  }
+  },
 };
 </script>

--- a/app/javascript/components/cbe/QuestionAnswers.vue
+++ b/app/javascript/components/cbe/QuestionAnswers.vue
@@ -1,41 +1,45 @@
 <template>
   <section>
     <DropdownList
+      v-if="question_kind === 'dropdown_list'"
       :answers="answers"
       :question_id="question_id"
-      v-if="question_kind == 'dropdown_list'"
     />
     <!-- passing just the first answer in fill the blank cause is just one text value -->
     <FillTheBlank
+      v-if="question_kind === 'fill_in_the_blank'"
       :answer="answers[0]"
       :question_id="question_id"
-      v-if="question_kind == 'fill_in_the_blank'"
     />
     <MultipleChoice
+      v-if="question_kind === 'multiple_choice'"
       :answers="answers"
       :question_id="question_id"
-      v-if="question_kind == 'multiple_choice'"
     />
     <MultipleResponse
+      v-if="question_kind === 'multiple_response'"
       :answers="answers"
       :question_id="question_id"
-      v-if="question_kind == 'multiple_response'"
     />
     <OpenAnswer
+      v-if="question_kind === 'open'"
       :question_id="question_id"
-      v-if="question_kind == 'open'"
+    />
+    <SpreadsheetAnswer
+      v-if="question_kind === 'spreadsheet'"
+      :question-id="question_id"
+      :answer-data="answers[0]"
     />
   </section>
 </template>
 
 <script>
-import DropdownList from "./answers/DropdownList";
-import FillTheBlank from "./answers/FillTheBlank";
-import MultipleChoice from "./answers/MultipleChoice";
-import MultipleResponse from "./answers/MultipleResponse";
-import OpenAnswer from "./answers/OpenAnswer";
-
-
+import DropdownList from './answers/DropdownList.vue';
+import FillTheBlank from './answers/FillTheBlank.vue';
+import MultipleChoice from './answers/MultipleChoice.vue';
+import MultipleResponse from './answers/MultipleResponse.vue';
+import OpenAnswer from './answers/OpenAnswer.vue';
+import SpreadsheetAnswer from './answers/SpreadsheetAnswer.vue';
 
 export default {
   components: {
@@ -43,13 +47,13 @@ export default {
     FillTheBlank,
     MultipleChoice,
     MultipleResponse,
-    OpenAnswer
+    OpenAnswer,
+    SpreadsheetAnswer,
   },
   props: {
     answers: {},
     question_id: Number,
-    question_kind: String
-  }
+    question_kind: String,
+  },
 };
 </script>
-

--- a/app/javascript/components/cbe/admin/Edit.vue
+++ b/app/javascript/components/cbe/admin/Edit.vue
@@ -409,37 +409,37 @@ export default {
       this.$store.commit('setCbeId', this.cbeId);
       this.$store.dispatch('cbe/getEditCbe', this.cbeId);
     },
-    toggleCbeDetails: () => {
+    toggleCbeDetails() {
       this.showCbeDetails = !this.showCbeDetails;
       if (this.showCbeDetails && (this.showIntroPages || this.showResources)) {
         this.showIntroPages = false;
         this.showResources = false;
       }
     },
-    toggleIntroPages: () => {
+    toggleIntroPages() {
       this.showIntroPages = !this.showIntroPages;
       if (this.showIntroPages && (this.showCbeDetails || this.showResources)) {
         this.showCbeDetails = false;
         this.showResources = false;
       }
     },
-    toggleResources: () => {
+    toggleResources() {
       this.showResources = !this.showResources;
       if (this.showResources && (this.showCbeDetails || this.showIntroPages)) {
         this.showCbeDetails = false;
         this.showIntroPages = false;
       }
     },
-    updateSections: (data) => {
+    updateSections(data) {
       this.edit_cbe_data.sections.push(data);
     },
-    updatePages: (data) => {
+    updatePages(data) {
       this.edit_cbe_data.introPages.push(data);
     },
     updateResources: (data) => {
       this.edit_cbe_data.resources.push(data);
     },
-    updateScenarios: (data) => {
+    updateScenarios(data) {
       let sectionIndex = 0;
       this.edit_cbe_data.sections.forEach((s, i) => {
         if (s.id === data.cbe_section_id) {
@@ -456,7 +456,7 @@ export default {
       }
       currentSection.scenarios.push(data);
     },
-    updateQuestions: (data) => {
+    updateQuestions(data) {
       let sectionIndex = 0;
       this.edit_cbe_data.sections.forEach((s, i) => {
         if (s.id === data.cbe_section_id) {
@@ -464,16 +464,14 @@ export default {
         }
       });
       const currentSection = this.edit_cbe_data.sections[sectionIndex];
-      if (currentSection.hasOwnProperty('questions')) {
-        console.log(currentSection);
-      } else {
+      if (!('questions' in currentSection)) {
         // This $set syntax is required by Vue to ensure the section.questions array is reactive
         // It is inside the conditional to ensure section.questions is not reset to empty
         this.$set(currentSection, 'questions', []);
       }
       currentSection.questions.push(data);
     },
-    updateScenarioQuestions: (data) => {
+    updateScenarioQuestions(data) {
       let scenarioIndex = 0;
       let sectionIndex = 0;
 
@@ -490,9 +488,7 @@ export default {
         }
       });
       const currentScenario = currentSection.scenarios[scenarioIndex];
-      if (currentScenario.hasOwnProperty('questions')) {
-        console.log(currentScenario);
-      } else {
+      if (!('questions' in currentScenario)) {
         // This $set syntax is required by Vue to ensure the section.questions array is reactive
         // It is inside the conditional to ensure section.questions is not reset to empty
         this.$set(currentScenario, 'questions', []);

--- a/app/javascript/components/cbe/admin/Home.vue
+++ b/app/javascript/components/cbe/admin/Home.vue
@@ -464,9 +464,7 @@ export default {
         }
       });
       const currentSection = this.sections[sectionIndex];
-      if (currentSection.hasOwnProperty('questions')) {
-        console.log(currentSection);
-      } else {
+      if (!('questions' in currentSection)) {
         // This $set syntax is required by Vue to ensure the section.questions array is reactive
         // It is inside the conditional to ensure section.questions is not reset to empty
         this.$set(currentSection, 'questions', []);
@@ -490,9 +488,7 @@ export default {
         }
       });
       const currentScenario = currentSection.scenarios[scenarioIndex];
-      if (currentScenario.hasOwnProperty('questions')) {
-        console.log(currentScenario);
-      } else {
+      if (!('questions' in currentScenario)) {
         // This $set syntax is required by Vue to ensure the section.questions array is reactive
         // It is inside the conditional to ensure section.questions is not reset to empty
         this.$set(currentScenario, 'questions', []);

--- a/app/javascript/components/cbe/admin/Question.vue
+++ b/app/javascript/components/cbe/admin/Question.vue
@@ -33,7 +33,7 @@
         <div class="input-group input-group-lg" id="questionScore">
           <input
             id="questionScore"
-            v-model="questionScore"
+            v-model.number="questionScore"
             placeholder="Score"
             :class="'form-control ' + {error: shouldAppendErrorClass($v.questionScore), valid: shouldAppendValidClass($v.questionScore)}"
             @blur="$v.questionScore.$touch()"
@@ -125,16 +125,34 @@ import AdminAnswers from './QuestionAnswers.vue';
 
 export default {
   props: {
-    sectionId: Number,
-    scenarioId: Number,
+    sectionId: {
+      type: Number,
+      default: null,
+    },
+    scenarioId: {
+      type: Number,
+      default: null,
+    },
     id: {
       type: Number,
-      default: 0
+      default: null,
     },
-    initialScore: Number,
-    initialContent: String,
-    initialKind: String,
-    initialAnswers: Array
+    initialScore: {
+      type: Number,
+      default: null,
+    },
+    initialContent: {
+      type: String,
+      default: '',
+    },
+    initialKind: {
+      type: String,
+      default: '',
+    },
+    initialAnswers: {
+      type: Array,
+      default: () => [],
+    },
   },
   components: {
     TinyEditor,
@@ -201,14 +219,14 @@ export default {
           .then(response => {
             this.createdQuestion = response.data;
             this.questionDetails.id = this.createdQuestion.id;
-            this.$emit("add-question", this.questionDetails);
-            this.$emit("update-content", this.TinyEditor);
+            this.$emit('add-question', this.questionDetails);
+            this.$emit('update-content', this.TinyEditor);
             this.questionDetails = {};
             this.questionKind = null;
             this.questionContent = null;
             this.questionScore = null;
             this.questionAnswers = [];
-            this.submitStatus = "OK";
+            this.submitStatus = 'OK';
             this.$v.$reset();
           })
           .catch(error => {

--- a/app/javascript/components/cbe/answers/DropdownList.vue
+++ b/app/javascript/components/cbe/answers/DropdownList.vue
@@ -32,7 +32,7 @@ export default {
   },
   watch: {
     question(newValue, oldValue) {
-      this.$store.dispatch("userCbe/recordAnswer", newValue);
+      this.$store.dispatch("user_cbe/recordAnswer", newValue);
     }
   },
   methods: {

--- a/app/javascript/components/cbe/answers/FillTheBlank.vue
+++ b/app/javascript/components/cbe/answers/FillTheBlank.vue
@@ -20,7 +20,7 @@ export default {
     question(newValue, oldValue) {
       let check = this.compareValues(newValue);
 
-      this.$store.dispatch("userCbe/recordAnswer", {
+      this.$store.dispatch("user_cbe/recordAnswer", {
         id: this.question_id,
         answers: {
           cbe_answer_id: this.answer.id,

--- a/app/javascript/components/cbe/answers/MultipleChoice.vue
+++ b/app/javascript/components/cbe/answers/MultipleChoice.vue
@@ -26,7 +26,7 @@ export default {
   },
   watch: {
     question(newValue, oldValue) {
-      this.$store.dispatch("userCbe/recordAnswer", newValue);
+      this.$store.dispatch("user_cbe/recordAnswer", newValue);
     }
   },
   methods: {

--- a/app/javascript/components/cbe/answers/MultipleResponse.vue
+++ b/app/javascript/components/cbe/answers/MultipleResponse.vue
@@ -26,7 +26,7 @@ export default {
   },
   watch: {
     question(newValue, oldValue) {
-      this.$store.dispatch("userCbe/recordAnswer", this.getQuestionFormated(newValue));
+      this.$store.dispatch("user_cbe/recordAnswer", this.getQuestionFormated(newValue));
     }
   },
   methods: {

--- a/app/javascript/components/cbe/answers/OpenAnswer.vue
+++ b/app/javascript/components/cbe/answers/OpenAnswer.vue
@@ -21,12 +21,12 @@ export default {
   },
   data() {
     return {
-      question: this.getPickedValue()
+      question: this.getPickedValue(),
     };
   },
   watch: {
     question(newValue, oldValue) {
-      this.$store.dispatch("userCbe/recordAnswer", {
+      this.$store.dispatch("user_cbe/recordAnswer", {
         id: this.question_id,
         answers: {
           content: {

--- a/app/javascript/components/cbe/answers/SpreadsheetAnswer.vue
+++ b/app/javascript/components/cbe/answers/SpreadsheetAnswer.vue
@@ -1,0 +1,52 @@
+<template>
+  <section>
+    <div class="answer">
+      <SpreadsheetEditor
+        :initial-data="answer"
+        @spreadsheet-updated="syncSpreadsheetData"
+      />
+    </div>
+  </section>
+</template>
+
+<script>
+import SpreadsheetEditor from '../../SpreadsheetEditor/SpreadsheetEditor.vue';
+
+export default {
+  components: {
+    SpreadsheetEditor,
+  },
+  props: {
+    questionId: {
+      type: Number,
+      default: 0,
+    },
+    answerData: {
+      type: Object,
+      default: () => ({ content: { data: [] } }),
+    },
+  },
+  data() {
+    return {
+      answer: this.getPrepopulatedAnswer(),
+    };
+  },
+  methods: {
+    syncSpreadsheetData(jsonData) {
+      this.$store.dispatch('user_cbe/recordAnswer', {
+        id: this.questionId,
+        answers: {
+          content: {
+            data: jsonData,
+          },
+          cbe_question_id: this.questionId,
+        },
+      });
+    },
+    getPrepopulatedAnswer() {
+      const initialValue = this.$store.state.user_cbe.user_cbe_data.questions[this.questionId];
+      return initialValue ? initialValue.answers : this.answerData;
+    },
+  },
+};
+</script>

--- a/app/javascript/packs/cbe_main.js
+++ b/app/javascript/packs/cbe_main.js
@@ -19,12 +19,12 @@ import CbeHome from '../components/cbe/Home.vue';
 
 Vue.use(BootstrapVue);
 
-const mountCbeElement = (element, component) =>
+const mountCbeElement = (element, theComponent) =>
   new Vue({
     store,
     el: element,
-    components: { component },
-    render: h => h(component)
+    components: { theComponent },
+    render: h => h(theComponent)
   });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/store/modules/user_cbe.js
+++ b/app/javascript/store/modules/user_cbe.js
@@ -11,14 +11,14 @@ const state = {
       description: null,
       type: null,
       page: null,
-      param: null,
+      param: null
     },
-    scratch_pad: null,
-  },
+    scratch_pad: null
+  }
 };
 
 const getters = {
-  user_cbe_data: state => state.user_cbe_data,
+  user_cbe_data: state => state.user_cbe_data
 };
 
 const actions = {
@@ -40,7 +40,7 @@ const mutations = {
   },
   setAnswerData(state, question) {
     state.user_cbe_data.questions[question.id] = question;
-  },
+  }
 };
 
 const functions = {
@@ -58,7 +58,7 @@ const functions = {
 
       section.questions.filter(question => {
         page += 1;
-        exam_pages.push(this.exam_pagesData(question, 'questions', page));
+        exam_pages.push(this.exam_pagesData(question, "questions", page));
       });
     });
 
@@ -67,14 +67,14 @@ const functions = {
 
   exam_pagesData(data, type, index) {
     return {
-      state: 'Unseen',
+      state: "Unseen",
       flagged: false,
       description: `Question ${index}`,
       type: type,
       page: index,
-      param: data.id,
+      param: data.id
     };
-  },
+  }
 };
 
 export default {
@@ -82,5 +82,5 @@ export default {
   state,
   getters,
   actions,
-  mutations,
+  mutations
 };

--- a/app/javascript/views/cbes/Agreement.vue
+++ b/app/javascript/views/cbes/Agreement.vue
@@ -5,14 +5,13 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters } from 'vuex';
 
 export default {
   computed: {
     ...mapGetters('cbe', {
-      cbe_data: 'cbeData'
-    })
-  }
-}
+      cbe_data: 'cbe_data',
+    }),
+  },
+};
 </script>
-

--- a/app/javascript/views/cbes/Cbe.vue
+++ b/app/javascript/views/cbes/Cbe.vue
@@ -10,9 +10,8 @@ import { mapGetters } from 'vuex'
 export default {
   computed: {
     ...mapGetters('cbe', {
-      cbe_data: 'cbeData'
-    })
-  }
-}
+      cbe_data: 'cbe_data',
+    }),
+  },
+};
 </script>
-

--- a/app/javascript/views/cbes/Introduction.vue
+++ b/app/javascript/views/cbes/Introduction.vue
@@ -23,9 +23,8 @@ export default {
   },
   computed: {
     ...mapGetters('cbe', {
-      cbe_data: 'cbeData'
-    })
-  }
-}
+      cbe_data: 'cbe_data',
+    }),
+  },
+};
 </script>
-

--- a/app/javascript/views/cbes/Questions.vue
+++ b/app/javascript/views/cbes/Questions.vue
@@ -46,8 +46,8 @@ export default {
   },
   computed: {
     ...mapGetters("cbe", {
-      cbe_data: "cbeData"
-    })
+      cbe_data: 'cbe_data',
+    }),
   },
   methods: {
     handleResize: function() {

--- a/app/javascript/views/cbes/Review.vue
+++ b/app/javascript/views/cbes/Review.vue
@@ -28,7 +28,7 @@
 
 <script>
 import { mapGetters } from "vuex";
-import CbeFlagToReview from "../../components/CbeFlagToReview"
+import CbeFlagToReview from "../../components/CbeFlagToReview.vue"
 
 export default {
   components: {
@@ -44,11 +44,11 @@ export default {
         { key: 'state', label: 'Status' },
         { key: 'flagged', label: 'Flagged - Review' },
       ],
-    }
+    };
   },
   computed: {
-    ...mapGetters("userCbe", {
-      user_cbe_data: "userCbeData"
+    ...mapGetters('user_cbe', {
+      user_cbe_data: 'user_cbe_data',
     }),
   },
 };

--- a/app/javascript/views/cbes/Sections.vue
+++ b/app/javascript/views/cbes/Sections.vue
@@ -15,17 +15,16 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters } from 'vuex';
 
 export default {
   props: {
-    id: Number
+    id: Number,
   },
   computed: {
-    ...mapGetters("cbe", {
-      cbe_data: "cbeData"
-    })
-  }
+    ...mapGetters('cbe', {
+      cbe_data: 'cbe_data',
+    }),
+  },
 };
 </script>
-


### PR DESCRIPTION
I think this is generally good to go - definitely for `staging` and demo purposes. Included is:

1. Fix for some of the errors when adding questions in **edit** mode.
2. New spreadsheet component to the student side of the CBE.
3. Pre-populate the student spreadsheet with any admin specified data.
4. Persist the user's response as they navigate between questions.
5. Allow submission of the data at the end of the CBE and saving the spreadsheet data.


Some Notes:
- Some of the buttons on the SpreadsheetEditor still need to be updated. This is minor in comparison to the other elements.
- **NB** I may have broken some of the other components that rely on the store. There were a ton of issues that cropped up when I was switching stuff to camel case so I switched everything back to _snake-case_ temporarily. I think we might have some broken components as a result.