### PR TITLE
Plan Changes Updates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,7 +138,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
   .margin-top {
-    margin-top: 80px;
+    margin-top: 85px;
   }
   .margin-top-lg {
     margin-top: 127px;
@@ -698,6 +698,12 @@ textarea.form-control {
   width: 100%;
   margin-top: .25rem;
   font-size: .75rem;
+  color: #dc3545
+}
+.text-alert {
+  color: #f0ca28
+}
+.text-error {
   color: #dc3545
 }
 .invalid-tooltip {
@@ -1694,7 +1700,7 @@ textarea.form-control {
 }
 .alert-warning {
   color: #7d6915;
-  background-color: #fcf4d4;
+  background-color: #fff3cd;
   border-color: #fbf0c3
 }
 .alert-warning hr {
@@ -6022,7 +6028,7 @@ input[type="radio"] {
   background-color: rgba(119,94,173,.1)
 }
 .badge-warning {
-  background-color: rgba(240,202,40,.1)
+  background-color: #fff3cd
 }
 .badge-danger {
   background-color: rgba(253,92,99,.1)

--- a/app/assets/stylesheets/components/buttons/_standard_buttons.scss
+++ b/app/assets/stylesheets/components/buttons/_standard_buttons.scss
@@ -31,7 +31,7 @@
 }
 @media (min-width:576px) {
   .btn {
-    padding: .4rem 1rem;
+    //padding: .4rem 1rem;
     padding-top: -webkit-calc(.65rem + .1rem);
     padding-top: calc(.65rem + .1rem);
     font-size: 1rem
@@ -493,4 +493,8 @@
   font-size: .875rem;
   line-height: 1.5;
   border-radius: 0;
+}
+
+.btn.full-width {
+  width: 100%;
 }

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -30,7 +30,7 @@ class LibraryController < ApplicationController
       if country && @currency_id
         @subscription_plans =
           SubscriptionPlan.where(subscription_plan_category_id: nil, exam_body_id: @group.exam_body_id).
-                           includes(:currency).in_currency(@currency_id).all_active.all_in_order.limit(3)
+                           includes(:currency).in_currency(@currency_id).all_active.all_in_display_order.limit(3)
       end
     else
       redirect_to root_url

--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -142,7 +142,7 @@ class StudentSignUpsController < ApplicationController
       elsif flash[:product_id]
         UserSession.create(@user)
         set_current_visit
-        redirect_to new_order_url(product_id: flash[:product_id], registered: true)
+        redirect_to new_product_order_url(product_id: flash[:product_id], registered: true)
       else
         flash[:datalayer_id] = @user.id
         flash[:datalayer_body] = @user.try(:preferred_exam_body).try(:name)

--- a/app/controllers/subscriptions/plan_changes_controller.rb
+++ b/app/controllers/subscriptions/plan_changes_controller.rb
@@ -12,7 +12,9 @@ module Subscriptions
       Rails.logger.info "DataLayer Event: PlanChanges#show - Subscription: #{@subscription.id}, Revenue: #{@subscription.subscription_plan.price}, PlanName: #{@subscription.subscription_plan.name}, Brand: #{@subscription.subscription_plan.exam_body.name}" if @subscription
     end
 
-    def new; end
+    def new
+      @card = default_payment_card(@subscription.user_id)
+    end
 
     def create
       send("change_#{@subscription.subscription_type}_subscription",
@@ -53,6 +55,11 @@ module Subscriptions
         PaypalSubscriptionsService.new(subscription).change_plan(plan_id)
 
       redirect_to @subscription.paypal_approval_url
+    end
+
+    def default_payment_card(user_id)
+      @subscription_payment_cards = SubscriptionPaymentCard.where(user_id: user_id).all_in_order
+      @default_payment_card       = @subscription_payment_cards.all_default_cards.first
     end
 
     def plan_change_params

--- a/app/controllers/user_accounts_controller.rb
+++ b/app/controllers/user_accounts_controller.rb
@@ -73,7 +73,9 @@ class UserAccountsController < ApplicationController
   end
 
   def show_invoice
-    @invoice       = Invoice.find_by(sca_verification_guid: params['guid'])
+    @invoice = Invoice.find_by(sca_verification_guid: params['guid'])
+    redirect_to account_url if @invoice.payment_closed
+
     @subscription  = @invoice.subscription
     @card          = default_payment_card(@invoice.user_id)
     @client_secret = stripe_client_secret(@invoice)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -79,7 +79,7 @@ class Subscription < ApplicationRecord
   # scopes
   scope :all_in_order,             -> { order(:user_id, :id) }
   scope :in_created_order,         -> { order(:created_at) }
-  scope :in_reverse_created_order, -> { order(:created_at).reverse_order }
+  scope :in_reverse_created_order, -> { order(created_at: :desc) }
   scope :all_of_status,            ->(status) { where(stripe_status: status) }
   scope :all_active,               -> { with_states(:active, :paused, :errored, :pending_cancellation) }
   scope :all_valid,                -> { where(state: VALID_STATES) }
@@ -123,6 +123,9 @@ class Subscription < ApplicationRecord
     end
 
     event :mark_payment_action_required do
+      # This event can also be triggered when non-3D-secure plan_changes fails to charge the first payment
+      # So subscriptions that are not SCA required can be in pending_3d_secure state as action is required
+      # in order to charge an outstanding invoice (A new card)
       transition all => :pending_3d_secure
     end
 
@@ -347,7 +350,7 @@ class Subscription < ApplicationRecord
       where(subscription_plan_category_id: nil).
       for_exam_body(subscription_plan.exam_body_id).
       in_currency(subscription_plan.currency_id).
-      all_active.all_in_order
+      all_active.all_in_display_order
   end
 
   def update_from_stripe
@@ -475,7 +478,7 @@ class Subscription < ApplicationRecord
   def update_hub_spot_data
     return if Rails.env.test?
 
-    HubSpotContactWorker.perform_async(id)
+    HubSpotContactWorker.perform_async(user_id)
   end
 
   def subscription_change_allowable

--- a/app/models/subscription_payment_card.rb
+++ b/app/models/subscription_payment_card.rb
@@ -193,8 +193,8 @@ class SubscriptionPaymentCard < ApplicationRecord
   end
 
   def destroyable?
-    # don't alow destroy if user have a current valid subscription
-    !user.current_subscription?
+    # don't allow destroy if it is the default card or if user has a current valid subscription
+    !is_default_card || !user.current_subscription?
   end
 
   def status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -470,6 +470,14 @@ class User < ApplicationRecord
     active_subscriptions_for_exam_body(exam_body_id).all_valid.any?
   end
 
+  def subscription_action_required?
+    viewable_subscriptions.map(&:state).include?('pending_3d_secure')
+  end
+
+  def actionable_invoice
+    invoices.where(payment_attempted: true).where.not(next_payment_attempt_at: nil).last
+  end
+
   def analytics_exam_body_plan_data
     user_plans = ''
     plans_type = ''

--- a/app/pdfs/invoice_document.rb
+++ b/app/pdfs/invoice_document.rb
@@ -86,8 +86,8 @@ class InvoiceDocument < Prawn::Document
 
     summary_details = [
       ['Subtotal', invoice.currency.format_number(invoice.sub_total)],
-      ['Discount', invoice.currency.format_number((invoice.sub_total - invoice.total))],
-      ['Total',    invoice.currency.format_number(invoice.total)]
+      ['Discount', invoice.currency.format_number((invoice.sub_total - invoice.amount_due))],
+      ['Total',    invoice.currency.format_number(invoice.amount_due)]
     ]
 
     table(summary_details, column_widths: [480, 60], header: true,

--- a/app/services/stripe_subscription_service.rb
+++ b/app/services/stripe_subscription_service.rb
@@ -101,8 +101,8 @@ class StripeSubscriptionService < StripeService
       stripe_status: stripe_sub.status, stripe_customer_id: customer.id,
       next_renewal_date: renewal_date(stripe_sub), stripe_guid: stripe_sub.id,
       stripe_customer_data: customer.to_hash.deep_dup,
-      payment_intent_status: stripe_sub.latest_invoice[:payment_intent][:status],
-      client_secret: stripe_sub.latest_invoice[:payment_intent][:client_secret]
+      payment_intent_status: stripe_sub.latest_invoice&.payment_intent&.status,
+      client_secret: stripe_sub.latest_invoice&.payment_intent&.client_secret
     )
     @subscription
   end

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -27,16 +27,16 @@
                             %tr
                               %td=invoice.id
                               %td=humanize_datetime(invoice.issued_at)
-                              %td=number_in_local_currency(invoice.total, invoice.currency)
+                              %td=number_in_local_currency(invoice.amount_due, invoice.currency)
                               %td=invoice_type(invoice)
                               %td
                                 %span{class: invoice.status == 'Paid' ? 'text-success' : 'text-danger'}
                                   =invoice.status
                               %td
-                                -if invoice.requires_3d_secure
+                                -if (subscription.pending_3d_secure? && invoice.requires_3d_secure) || invoice.status == 'Past Due'
                                   =link_to show_invoice_url(invoice.sca_verification_guid) do
                                     .btn.btn-primary.btn-xs
-                                      Authenticate
+                                      =invoice.requires_3d_secure ? 'Authenticate' : 'Confirm Payment'
                                 -else
                                   =link_to subscription_invoices_url(invoice.id, format: 'pdf'), target: '_blank' do
                                     .btn.btn-link.btn-xs

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -92,6 +92,13 @@
         -unless controller_name == 'subscriptions' || controller_name == 'orders' || controller_name == 'footer_pages' || controller_name == 'student_sign_ups' || controller_name == 'user_accounts'
           -if flash[:success] || flash[:error] || flash[:warning]
             =render partial: 'layouts/flash_messages'
+        -if current_user&.subscription_action_required? && !(controller_name == 'user_accounts' || controller_name == 'subscriptions' || controller_name == 'student_sign_ups')
+          .alert.alert-warning.text-center
+            There is an problem with your subscription.
+            -if current_user.actionable_invoice
+              =link_to 'Resolve Issue!', show_invoice_url(current_user.actionable_invoice.sca_verification_guid)
+            -else
+              =link_to 'Resolve Issue!', account_url(anchor: 'account-info')
 
         =yield
 

--- a/app/views/library/_course_module.html.haml
+++ b/app/views/library/_course_module.html.haml
@@ -55,7 +55,7 @@
                                 -else
                                   =cme.number_of_questions.to_s + ' ' +  'Question'
 
-              -else
+              - else
                 - permission = cme.available_to_user(current_user, @group.exam_body_id, @subject_course_user_log)
 
                 - if permission[:view]

--- a/app/views/library/_subscription_restriction_modal.html.haml
+++ b/app/views/library/_subscription_restriction_modal.html.haml
@@ -11,8 +11,14 @@
       .modal-body
         %p.mb-4
           A valid account is required to access that content. Subscribe to a payment plan to access all course materials. Cancel anytime.
-        %p.mb-4
-          ="Get unlimited access to all #{@group.name} courses."
+
+        - if current_user&.subscription_action_required?
+          %h5.text-warning
+            ='There seems to be problem with your existing subscription. You should resolve this issue first or you may be double charged.'
+            =link_to 'Resolve Issue!', account_url(anchor: 'account-info')
+        - else
+          %p.mb-4
+            ="Get unlimited access to all #{@group.name} courses."
 
       .modal-footer
         =link_to 'Subscribe Now', subscription_checkout_special_link(@group.exam_body_id), class: 'btn btn-primary', title: 'Get Unlimited Access'

--- a/app/views/subscriptions/plan_changes/_update_card_modal.haml
+++ b/app/views/subscriptions/plan_changes/_update_card_modal.haml
@@ -4,9 +4,10 @@
       %button.btn.btn-text.modal-close.p-0{"data-dismiss" => "modal"}
         %i.material-icons{"aria-hidden" => "true"} close
       %div
-        %h3#add-card-modal.text-gray2.mb-5 Update Card
-        %p Your payment details have failed authentication. Please update your card details below.
-      .modal-body
+        %h3#add-card-modal.text-gray2.mb-2 Payment Card Authentication
+        %p.text-error Your payment details have failed authentication. Please re-enter your card details or try a different card.
+        %p If we cannot authenticate your payment details and process the outstanding charge your subscription will be cancelled.
+      .modal-body.mt-3
         =form_for(SubscriptionPaymentCard.new, method: :post, html: {class: 'py-2', role: 'form', id: 'new-subscription-payment-card-form'}, name: 'add_card_form') do |f|
           =f.hidden_field :user_id, value: current_user.id
           =f.hidden_field :stripe_token

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -6,88 +6,104 @@
           %h1.h2-hero.mb-2
             Change Plan
           %p.p-hero.px-lg-6
-            Simply select your new plan
-          -#TODO Proration Details explained here!
+            Select your preferred payment plan
         %section.pb-md-6.pb-5
           -if flash[:success] || flash[:error] || flash[:warning]
             =render partial: 'layouts/flash_messages'
           =form_for(@subscription, url: subscription_plan_changes_path(@subscription), method: :post, html: {class: 'form-horizontal', role: 'form', id: 'upgrade-subscription-form'}) do |f|
             =f.hidden_field :subscription_plan_id
             =f.hidden_field :use_paypal, value: @subscription.paypal?
-            .row.row-md
-              -@subscription.upgrade_options.each do |plan|
-                .col-lg
-                  %article.card.card-primary.card-primary-alt.medium-gap{id: "sub-#{plan.currency.iso_code}-#{plan.payment_frequency_in_months}", data: {plan_id: plan.id, :price => plan.price, :currency => plan.currency.iso_code, :name => plan.name, :body => plan.exam_body.name}}
-                    -if plan.most_popular
-                      .card-banner.bg-mint
-                        %large.text-white
-                          Most popular payment plan
-                    .card-body.text-center.py-4.py-sm-5
-                      %h2.card-title
-                        =t("views.general.payment_frequency_in_months.a#{plan.payment_frequency_in_months}")
+            .row
+              .col-12.col-lg-8
+                .row.row-md.justify-content-center
+                  -@subscription.upgrade_options.each do |plan|
+                    .col
+                      %article.card.card-primary.card-primary-alt{id: "sub-#{plan.currency.iso_code}-#{plan.payment_frequency_in_months}", data: {plan_id: plan.id, :price => plan.price, :currency => plan.currency.iso_code, :name => plan.name, :body => plan.exam_body.name}}
+                        -if plan.most_popular
+                          .card-banner.bg-mint
+                            %large.text-white
+                              Most popular payment plan
+                        .card-body.text-center.py-4.py-sm-5
+                          %h2.card-title
+                            =t("views.general.payment_frequency_in_months.a#{plan.payment_frequency_in_months}")
 
-                      %ul.list-centered
-                        -if plan.bullet_points_list && !plan.bullet_points_list.empty?
-                          - plan.bullet_points_list.split(/, ?/).each do |bullet|
-                            %li=bullet
-                        -else
-                          %li="Access all #{plan.exam_body.group.name} courses"
-                          %li="Topic-by-topic lectures"
-                          %li="24/7 tutor support"
+                          %ul.list-centered
+                            -if plan.bullet_points_list && !plan.bullet_points_list.empty?
+                              - plan.bullet_points_list.split(/, ?/).each do |bullet|
+                                %li=bullet
+                            -else
+                              %li="Access all #{plan.exam_body.group.name} courses"
+                              %li="Topic-by-topic lectures"
+                              %li="24/7 tutor support"
 
-                        -unless plan.exam_body.name == "CPD"
-                          %li{style: 'font-style: italic;'}
-                            Cancel anytime
+                            -unless plan.exam_body.name == "CPD"
+                              %li{style: 'font-style: italic;'}
+                                Cancel anytime
 
-                      %p.h2.mb-0
-                        =plan.currency.format_number(plan.price)
+                          %p.h2.mb-0
+                            =plan.currency.format_number(plan.price)
 
-                      -if plan.monthly_percentage_off
-                        %p.h5.text-gray2{style: 'margin-bottom: 0;'}
-                          Save over
-                          =plan.monthly_percentage_off
-                          ='%'
+                          -if plan.monthly_percentage_off
+                            %p.h5.text-gray2{style: 'margin-bottom: 0;'}
+                              Save over
+                              =plan.monthly_percentage_off
+                              ='%'
 
-                      .pt-4.pt-md-5
-                        %fieldset
-                          %legend.sr-only Select this plan
-                          .custom-control.custom-radio.plan-option
-                            %input{id: 'chk-plan-' + plan.id.to_s, type: 'radio', class: 'custom-control-input style-radio option'}
-                            %label{class: "custom-control-label ", for: 'chk-plan-' + plan.id.to_s}
-                              %span.custom-label-info
-                                %span Select this plan
-                              %span.custom-check
+                          .pt-4.pt-md-5
+                            %fieldset
+                              %legend.sr-only Select this plan
+                              .custom-control.custom-radio.plan-option
+                                %input{id: 'chk-plan-' + plan.id.to_s, type: 'radio', class: 'custom-control-input style-radio option'}
+                                %label{class: "custom-control-label ", for: 'chk-plan-' + plan.id.to_s}
+                                  %span.custom-label-info
+                                    %span Select this plan
+                                  %span.custom-check
 
 
 
-            %section#simply
-              .container
-                .row
-                  .col-sm-10.offset-1
-                    %h3
-                      ='Selecting this Plan will result in an immediate charge and start a new billing period from this date.'
-                    %p
-                      ='Any remaining time paid for on your current billing will be credited to your account, and used for this payment and any future payments until all credit is used.'
-                    %div.invalid-details
-                .row
-                  .col-sm-6.offset-1
-                    .d-flex.justify-content-between.align-items-center.pt-3
-                      =f.submit 'Change Plan', class: 'btn btn-primary btn-sm', id: 'changePlan'
-                      .sk-circle
-                        .sk-circle1.sk-child
-                        .sk-circle2.sk-child
-                        .sk-circle3.sk-child
-                        .sk-circle4.sk-child
-                        .sk-circle5.sk-child
-                        .sk-circle6.sk-child
-                        .sk-circle7.sk-child
-                        .sk-circle8.sk-child
-                        .sk-circle9.sk-child
-                        .sk-circle10.sk-child
-                        .sk-circle11.sk-child
-                        .sk-circle12.sk-child
+              .col-12.col-lg-4
+                %section#simply
+                  .container.pt-lg-6
+                    .row
+                      - if @subscription.stripe? && !@card
+                        .col-sm-10.offset-1
+                          %h5.text-alert
+                            ='You must have a default payment method in order to change plans. Please visit the card details section in your account.'
+                      - else
+                        .col-sm-10.offset-1
+                          %h5.pt-4
+                            ='This action will result in an immediate charge and start a new billing period from this date.'
 
-                      =link_to t('views.general.cancel'), account_url(anchor: 'account-info'), class: 'btn btn-secondary btn-sm '
+                          - if @subscription.stripe? && @card
+                            .invoice-payment-details-wrap
+                              %span.payment-content
+                                =image_tag('ico-card.svg', alt: 'Credit Card Icon', class: 'logo-icon mr-2 mr-sm-3')
+                                =@card.brand
+                                &#8226;
+                                &#8226;
+                                &#8226;
+                                =@card.last_4
+
+                          %p.py-4
+                            ='Any remaining time on your current billing period will be credited to your account, and used for this and any future payments until all credit is used.'
+                          %div.invalid-details
+
+                        .col-sm-10.offset-1.text-center
+                          =f.submit 'Change Plan Now', class: 'btn btn-primary full-width', id: 'changePlan'
+                          .sk-circle
+                            .sk-circle1.sk-child
+                            .sk-circle2.sk-child
+                            .sk-circle3.sk-child
+                            .sk-circle4.sk-child
+                            .sk-circle5.sk-child
+                            .sk-circle6.sk-child
+                            .sk-circle7.sk-child
+                            .sk-circle8.sk-child
+                            .sk-circle9.sk-child
+                            .sk-circle10.sk-child
+                            .sk-circle11.sk-child
+                            .sk-circle12.sk-child
+
 
 =render partial: 'update_card_modal'
 

--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -13,7 +13,7 @@
                     =subscription.user_readable_name
 
                   %span.badge.badge-warning.align-middle
-                    =subscription.pending_3d_secure? ? 'Payment Error' : subscription.state.capitalize
+                    =subscription.pending_3d_secure? ? 'Action Required' : subscription.state.capitalize
 
                 %p.mb-1
                   Subscription created on
@@ -65,15 +65,15 @@
                             %tr
                               %td=invoice.id
                               %td=humanize_datetime(invoice.issued_at)
-                              %td=number_in_local_currency(invoice.total, invoice.currency)
+                              %td=number_in_local_currency(invoice.amount_due, invoice.currency)
                               %td
                                 %span{class: invoice.status == 'Paid' ? 'text-success' : 'text-danger'}
                                   =invoice.status
                               %td
-                                -if invoice.requires_3d_secure
+                                -if (subscription.pending_3d_secure? && invoice.requires_3d_secure) || invoice.status == 'Past Due'
                                   =link_to show_invoice_url(invoice.sca_verification_guid) do
                                     .btn.btn-primary.btn-xs
-                                      Authenticate
+                                      =invoice.requires_3d_secure ? 'Authenticate' : 'Confirm Payment'
                                 -else
                                   =link_to subscription_invoices_url(invoice.id, format: 'pdf'), target: '_blank' do
                                     .btn.btn-link.btn-xs

--- a/app/views/user_accounts/account_show.html.haml
+++ b/app/views/user_accounts/account_show.html.haml
@@ -27,6 +27,10 @@
               %li.nav-item
                 %a#account-info-tab.nav-link{"aria-controls" => "account-info", "aria-selected" => "false", "data-toggle" => "tab", :href => "#account-info", :role => "tab"}
                   Account Info
+                  -if current_user&.subscription_action_required?
+                    %span.badge.badge-warning.align-middle
+                      ='Action Required'
+
               %li.nav-item
                 %a#payment-details-tab.nav-link{"aria-controls" => "payment-details", "aria-selected" => "false", "data-toggle" => "tab", :href => "#payment-details", :role => "tab"}
                   Card Details

--- a/app/views/user_accounts/show_invoice.html.haml
+++ b/app/views/user_accounts/show_invoice.html.haml
@@ -4,8 +4,10 @@
       %header.hero-section
         %h1.h2-hero.mb-2
           Confirm payment
-        %p
-          ="You'll be asked to verify your identity with your bank."
+        -if @invoice.requires_3d_secure
+          %p="You'll be asked to verify your identity with your bank."
+        -else
+          %p='Invoice payment is outstanding, please add a new payment card.'
 
 
       %section.pb-md-6.pb-5
@@ -30,6 +32,10 @@
                         Amount due:
                         %span
                           =number_in_local_currency(@invoice.total, @invoice.currency)
+                      %p.mb-1
+                        Status:
+                        %span.text-alert
+                          =@invoice.status
 
                   .col-12.col-md-6.mb-4
                     .invoice-payment-details
@@ -45,15 +51,19 @@
 
                       -if @invoice.status == 'Pending'
                         %p
-                          Invoice pending, please add a new payment card.
+                          The last charge attempt failed with this card.
+                        %p.invalid-details
+                          Your subscription will be cancelled if this invoice is not paid.
 
-                        .col-md-4.text-md-right
-                          %a{data: {target: '#add-card-modal', toggle: 'modal'}, href: '#', class: 'btn btn-primary btn-sm add-card'}
+                        .col-10.offset-1
+                          %a{data: {target: '#add-card-modal', toggle: 'modal'}, href: '#', class: 'btn btn-primary full-width add-card'}
                             =t('views.users.show.new_card')
 
                       -else
-                        .mt-5.text-center
-                          .btn.btn-primary.btn-sm#triggerAuth{onclick: 'ReAuth(); return false;'}
+                        %p.invalid-details
+                          Your subscription will be cancelled if this invoice is not paid.
+                        .col-10.offset-1.mt-5
+                          .btn.btn-primary.full-width#triggerAuth{onclick: 'ReAuth(); return false;'}
                             ='Confirm Payment'
                           .spinner
                             .bounce1
@@ -135,7 +145,6 @@
       if (result.error) {
         console.log(result)
       } else {
-        console.log(result)
         $.ajax({
           type: 'patch',
           url: "#{invoice_path(@invoice.id)}",
@@ -176,5 +185,3 @@
     console.log(error);
     // Display error message & feedback to user
   }
-
-  //window.onload = ReAuth;

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -215,6 +215,9 @@ describe User do
   it { should respond_to(:next_enrollment) }
   it { should respond_to(:next_exam_date) }
 
+  it { should respond_to(:subscription_action_required?) }
+  it { should respond_to(:actionable_invoice) }
+
   it { should respond_to(:completed_course_module_element) }
   it { should respond_to(:started_course_module_element) }
 


### PR DESCRIPTION
* Cleaned up the plan_changes form.
* Reduced the processing delays on stripe event workers. Replaced find_by on Subscriptions to where with order because subscriptions can exist with the same stripe_guid after changing plans
* Updated the invoices show 3d_secure authentication processes to work with standard subs and invoices created with pending payments resulting from when plan_changes fails
* Fixed old url for order new during registration
* Fixed issue with card removal block
* Fixed issue with wrong id sent to HubSpotContactWorker in subscription model