### PR TITLE
FIX: Various Airbrake fixes

### DIFF
--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -155,6 +155,9 @@ class StudentSignUpsController < ApplicationController
     else
       redirect_to root_url
     end
+  rescue ActionController::InvalidAuthenticityToken
+    flash[:error] = 'Sorry. Your sign up attempt failed. Please try again'
+    redirect_to root_url
   end
 
   def show

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -41,6 +41,9 @@ class UserSessionsController < ApplicationController
     else
       render action: :new
     end
+  rescue ActionController::InvalidAuthenticityToken
+    flash[:error] = 'Sorry. Your login attempt failed. Please try again'
+    redirect_to sign_in_url
   end
 
   def destroy

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -85,7 +85,7 @@ class Product < ApplicationRecord
   end
 
   def name_by_type
-    cbe? ? cbe.name : mock_exam.name
+    cbe? ? cbe.name : (mock_exam&.name || name)
   end
 
   private

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -37,7 +37,7 @@
                                   =link_to pdf_invoice_path(invoice.id, format: 'pdf'), target: '_blank' do
                                     .btn.btn-link.btn-xs
                                       View
-                                -elsif (invoice&.subscription.pending_3d_secure? && invoice.requires_3d_secure) || invoice.status == 'Past Due'
+                                -elsif (invoice&.subscription.pending_3d_secure? && invoice.requires_3d_secure) || (invoice.status == 'Past Due' && invoice.sca_verification_guid.present?)
                                   =link_to show_invoice_url(invoice.sca_verification_guid) do
                                     .btn.btn-primary.btn-xs
                                       =invoice.requires_3d_secure ? 'Authenticate' : 'Confirm Payment'

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -167,6 +167,7 @@
     displayCardError.text('');
     var stripe = Stripe('#{ENV['LEARNSIGNAL_V3_STRIPE_PUBLIC_KEY']}');
     var elements = stripe.elements();
+    var cardId = "#{@card&.id}"
 
     var cardElement = elements.create('card', {hidePostalCode: true, style: style});
     cardElement.mount('#card-element');
@@ -192,7 +193,9 @@
       if ($('#subscription_use_paypal').val() === 'true') {
         this.submit();
       } else {
-        upgradeStripeSubscription();
+        if (cardId && cardId.length > 0) {
+          upgradeStripeSubscription();
+        }
       }
     });
 

--- a/app/views/user_accounts/show_invoice.html.haml
+++ b/app/views/user_accounts/show_invoice.html.haml
@@ -39,36 +39,40 @@
 
                   .col-12.col-md-6.mb-4
                     .invoice-payment-details
-                      .invoice-payment-details-wrap
-                        %span.payment-content
-                          =image_tag('ico-card.svg', alt: 'Credit Card Icon', class: 'logo-icon mr-2 mr-sm-3')
-                          =@card.brand
-                          &#8226;
-                          &#8226;
-                          &#8226;
-                          =@card.last_4
+                      -if @card
+                        .invoice-payment-details-wrap
+                          %span.payment-content
+                            =image_tag('ico-card.svg', alt: 'Credit Card Icon', class: 'logo-icon mr-2 mr-sm-3')
+                            =@card.brand
+                            &#8226;
+                            &#8226;
+                            &#8226;
+                            =@card.last_4
 
 
-                      -if @invoice.status == 'Pending'
-                        %p
-                          The last charge attempt failed with this card.
-                        %p.invalid-details
-                          Your subscription will be cancelled if this invoice is not paid.
+                        -if @invoice.status == 'Pending'
+                          %p
+                            The last charge attempt failed with this card.
+                          %p.invalid-details
+                            Your subscription will be cancelled if this invoice is not paid.
 
-                        .col-10.offset-1
-                          %a{data: {target: '#add-card-modal', toggle: 'modal'}, href: '#', class: 'btn btn-primary full-width add-card'}
-                            =t('views.users.show.new_card')
+                          .col-10.offset-1
+                            %a{data: {target: '#add-card-modal', toggle: 'modal'}, href: '#', class: 'btn btn-primary full-width add-card'}
+                              =t('views.users.show.new_card')
 
+                        -else
+                          %p.invalid-details
+                            Your subscription will be cancelled if this invoice is not paid.
+                          .col-10.offset-1.mt-5
+                            .btn.btn-primary.full-width#triggerAuth{onclick: 'ReAuth(); return false;'}
+                              ='Confirm Payment'
+                            .spinner
+                              .bounce1
+                              .bounce2
+                              .bounce3
                       -else
                         %p.invalid-details
-                          Your subscription will be cancelled if this invoice is not paid.
-                        .col-10.offset-1.mt-5
-                          .btn.btn-primary.full-width#triggerAuth{onclick: 'ReAuth(); return false;'}
-                            ='Confirm Payment'
-                          .spinner
-                            .bounce1
-                            .bounce2
-                            .bounce3
+                          You need to add a valid payment card to your account. Your subscription will be cancelled if this invoice is not paid. Please visit the card details section in your account.
 
 
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -409,9 +409,9 @@ ActiveRecord::Schema.define(version: 2019_12_02_154124) do
     t.boolean "is_video", default: false, null: false
     t.boolean "is_quiz", default: false, null: false
     t.boolean "active", default: true, null: false
-    t.datetime "destroyed_at"
-    t.string "seo_description"
+    t.string "seo_description", limit: 255
     t.boolean "seo_no_index", default: false
+    t.datetime "destroyed_at"
     t.integer "number_of_questions", default: 0
     t.float "duration", default: 0.0
     t.string "temporary_label"
@@ -430,9 +430,9 @@ ActiveRecord::Schema.define(version: 2019_12_02_154124) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cme_count", default: 0
-    t.datetime "destroyed_at"
-    t.string "seo_description"
+    t.string "seo_description", limit: 255
     t.boolean "seo_no_index", default: false
+    t.datetime "destroyed_at"
     t.integer "number_of_questions", default: 0
     t.integer "subject_course_id"
     t.float "video_duration", default: 0.0

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -142,13 +142,23 @@ describe Product do
       end
     end
 
-    context '.name_by_type' do
-      it 'cbe product' do
-        expect(cbe_product.name_by_type).to eq(cbe_product.cbe.name)
+    describe '.name_by_type' do
+      context 'for CBE Products' do
+        it 'returns the name of the CBE' do
+          expect(cbe_product.name_by_type).to eq(cbe_product.cbe.name)
+        end
       end
 
-      it 'not cbe product' do
-        expect(correction_pack_product.name_by_type).to eq(correction_pack_product.mock_exam.name)
+      context 'for non-CBE Procucts' do
+        let(:product_without_mock) { build_stubbed(:product, mock_exam: nil) }
+
+        it 'returns the name of the MockExam (if it exists as an association)' do
+          expect(correction_pack_product.name_by_type).to eq(correction_pack_product.mock_exam.name)
+        end
+
+        it 'returns the name of the Product (if there is no MockExam)' do
+          expect(product_without_mock.name_by_type).to eq(correction_pack_product.mock_exam.name)
+        end
       end
     end
   end


### PR DESCRIPTION
1. [Here's the Airbrake](
https://learnsignal.airbrake.io/projects/107826/groups/2607553114736372939/notices/2607553104151100179?tab=notice-detail). Basically we were sending all past_due invoices for SCA verification but old invoices were not part of SCA stuff. So there's a fallback now.
2. [Here's the Airbrake](https://learnsignal.airbrake.io/projects/107826/groups/2626560250610918229?tab=notice-detail). This basically relates to really old products that may not have a Mock Exam associated with them. 
3. [Airbrake](https://learnsignal.airbrake.io/projects/107826/groups/2609056752285723954?tab=notice-detail). Missing card details for display on an invoice.
4. [Airbrake](https://learnsignal.airbrake.io/projects/107826/groups/2575321167943642056/notices/2625815540872283554?tab=notice-detail). Missing default card error for the user when trying to change plans. Stripe does the update no problem but we get an error on our side.
5. [Airbrake 1](https://learnsignal.airbrake.io/projects/107826/groups/2626331483774853983?tab=overview) and [Airbrake 2](https://learnsignal.airbrake.io/projects/107826/groups/2622381123121129916?tab=overview) ActionController::InvalidAuthenticityToken.