### PR TITLE
FIX: Editor height can now be set dynamically

### DIFF
--- a/app/javascript/components/TinyEditor.vue
+++ b/app/javascript/components/TinyEditor.vue
@@ -9,12 +9,13 @@
         branding: false,
         menubar: false,
         statusbar: false,
+        height: editorHeight,
         image_dimensions: true,
         toolbar: toolbarOptions(),
         plugins: 'fullscreen lists table code paste searchreplace image',
         images_upload_handler: imageUploadHandler,
         image_advtab: true,
-        skin: 'custom'
+        skin: 'custom',
       }"
       @input="$emit('update:fieldModel', localFieldModel)"
     />
@@ -34,7 +35,11 @@ export default {
   props: {
     editorId: String,
     fieldModel: String,
-    aditionalToolbarOptions: Array
+    aditionalToolbarOptions: Array,
+    editorHeight: {
+      type: Number,
+      default: 300,
+    }
   },
   data() {
     return {

--- a/app/javascript/components/cbe/answers/OpenAnswer.vue
+++ b/app/javascript/components/cbe/answers/OpenAnswer.vue
@@ -4,6 +4,7 @@
       <TinyEditor
         :field-model.sync="question"
         :aditional-toolbar-options="[]"
+        :editor-height="520"
         @blur="$v.question.$touch()"
       />
     </div>


### PR DESCRIPTION
I have set a value for the student view as well but we can now specify it dynamically for any future use cases.

<img width="1309" alt="Screenshot 2019-12-10 at 11 13 33" src="https://user-images.githubusercontent.com/5478185/70524929-23287e00-1b3e-11ea-9bc9-a0e11afee047.png">
