### PR TITLE
Cancel pending subscription after failed authentication

### DIFF
--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -7,8 +7,8 @@ module OrdersHelper
       link_to exercise_path_by_state(exercise), target: '_blank' do
         'View'
       end
-    else
-      link_to order&.product&.mock_exam&.file&.url, target: '_blank' do
+    elsif order.product&.mock_exam
+      link_to order.product.mock_exam.file.url, target: '_blank' do
         'View'
       end
     end
@@ -34,7 +34,7 @@ module OrdersHelper
     if order.product.payment_description.present?
       order.product.payment_description
     elsif order.product.mock_exam?
-      'Purchase your Mock Exam today. Once submitted we will give you a solution paper, your result, question by question, personalised feedback on your exam and study topic recommendations.'
+      'Purchase your Mock Exam today. Once submitted we will give you a solution paper, your result, question by question, personalised feedback on your exam and study topic recommendations within 3 days.'
     elsif order.product.cbe?
       'Purchase your CBE today to start practicing for your online exam by simulating the computer based exam on the learnsignal site.'
     else

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -37,7 +37,7 @@ class Subscription < ApplicationRecord
   delegate :currency, to: :subscription_plan
 
   # Constants
-  STATUSES        = %w[incomplete active past_due canceled canceled-pending pending_cancellation].freeze
+  STATUSES        = %w[incomplete active past_due canceled canceled-pending pending_cancellation incomplete_expired].freeze
   VALID_STATES    = %w[active past_due canceled-pending pending_cancellation paused].freeze
   PAYPAL_STATUSES = %w[Pending Active Suspended Cancelled Expired].freeze
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -424,8 +424,8 @@
           if(data.status == 'incomplete'){
             handlePayment(data.client_secret, data.subscription_id)
           } else if(data.status == 'active'){
-            subscriptionCreation(data);
             window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+            subscriptionCreation(data);
           }
         },
         error: function(request, status, error){
@@ -448,25 +448,30 @@
         if (result.error) {
           resetForm(result.error.message);
           intentStatus = 'pending';
+          $.ajax({
+            type: 'post',
+            url: "/subscriptions/" + subscription_id + "/expire_incomplete",
+            data: { },
+            dataType: 'json'
+          });
         } else {
           intentStatus = result['paymentIntent']['status'];
-        }
-
-        $.ajax({
-          type: 'post',
-          url: "/subscriptions/" + subscription_id + "/status_from_stripe",
-          data: { status: intentStatus },
-          dataType: 'json',
-          success: function(data,status,xhr){
-            if( $.inArray(intentStatus, statusArray) !== -1){
-              subscriptionCreation(data);
-              window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+          $.ajax({
+            type: 'post',
+            url: "/subscriptions/" + subscription_id + "/status_from_stripe",
+            data: { status: intentStatus },
+            dataType: 'json',
+            success: function(data,status,xhr){
+              if( $.inArray(intentStatus, statusArray) !== -1){
+                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+                subscriptionCreation(data);
+              }
+            },
+            error: function(xhr,status,error){
+              resetForm(error);
             }
-          },
-          error: function(xhr,status,error){
-            resetForm(error);
-          }
-        });
+          });
+        }
       });
     }
 

--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -86,9 +86,9 @@
                     =link_to 'Change Subscription Plan', new_subscription_plan_changes_path(subscription), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
                   -if subscription.paused?
                     =link_to 'Reactivate Subscription', subscriptions_suspension_path(id: subscription.id), method: :delete, class: 'btn btn-secondary btn-xs', style: 'vertical-align: top;'
-                  -if !subscription.cancelled?
+                  -if subscription.active?
                     =link_to 'Cancel Subscription', new_subscription_cancellation_path(subscription), class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
-                  -else
+                  -if subscription.cancelled?
                     =link_to 'Renew Subscription', subscription_checkout_special_link(subscription.subscription_plan.exam_body_id), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
         get 'execute'
         get 'unapproved'
         post 'status_from_stripe'
+        post 'expire_incomplete'
       end
       scope module: 'subscriptions' do
         resources :cancellations, only: %i[new create]

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -76,7 +76,7 @@ describe OrdersHelper do
   describe '#order_description' do
     context 'returns order description name' do
       it 'mock exam description' do
-        expect(order_description(order)).to eq('Purchase your Mock Exam today. Once submitted we will give you a solution paper, your result, question by question, personalised feedback on your exam and study topic recommendations.')
+        expect(order_description(order)).to eq('Purchase your Mock Exam today. Once submitted we will give you a solution paper, your result, question by question, personalised feedback on your exam and study topic recommendations within 3 days.')
       end
 
       it 'cbe description' do


### PR DESCRIPTION
**Cancel pending subscription after failed authentication:**
- Added a cancel subscription call to handlePayment to cancel the subscription when resetting the form.
- Removed the cancel subscription btn unless the subscription is active. Also, added new language to orders helpers