### PR TITLE
(STRIPE) Many changes in subscriptions.

### DIFF
--- a/app/controllers/subscriptions/cancellations_controller.rb
+++ b/app/controllers/subscriptions/cancellations_controller.rb
@@ -4,39 +4,58 @@ module Subscriptions
   class CancellationsController < ApplicationController
     before_action :logged_in_required
     before_action do
-      ensure_user_has_access_rights(%w[student_user])
+      ensure_user_has_access_rights(%w[student_user system_requirements_access])
     end
     before_action :set_subscription
 
-    def new; end
+    def new
+      if params[:role] == 'admin'
+        @layout = 'management'
+        render :admin_new
+      end
+    end
 
     def create
-      @subscription.cancelling_subscription = true
-      if @subscription.update(subscription_params) && @subscription.cancel_by_user
-        flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
-        flash[:datalayer_cancel] = @subscription.user_readable_name
+      ActiveRecord::Base.transaction do
+        if @subscription.update(subscription_params) && cancel_subscription(@subscription)
+          flash[:success] = I18n.t('controllers.subscriptions.destroy.flash.success')
+          flash[:datalayer_cancel] = @subscription.user_readable_name
 
-        redirect_to account_url(anchor: 'account-info')
-      else
-        Rails.logger.warn "WARN: Subscription#delete failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
-        flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
-        @subscription.errors.add(:cancellation_reason, 'please select an option')
+          redirect_to account_url(anchor: 'account-info')
+        else
+          Rails.logger.warn "WARN: Subscription#delete failed to cancel a subscription. Errors:#{@subscription.errors.inspect}"
+          flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
+          @subscription.errors.add(:cancellation_reason, 'please select an option')
 
-        redirect_to new_subscription_cancellation_path(@subscription)
+          redirect_to redirect_back(fallback_location: root_path)
+        end
       end
     rescue Learnsignal::SubscriptionError
       flash[:error] = I18n.t('controllers.subscriptions.destroy.flash.error')
-      redirect_to new_subscription_cancellation_path(@subscription)
+      redirect_back(fallback_location: root_path)
     end
 
     private
+
+    def cancel_subscription(subscription)
+      if %w[past_due pending_3d_secure].include?(subscription.state)
+        subscription.immediate_cancel
+      else
+        subscription.cancel_by_user
+      end
+    end
 
     def set_subscription
       @subscription = Subscription.find_by(id: params[:subscription_id])
     end
 
     def subscription_params
-      params.require(:subscription).permit(:cancellation_reason, :cancellation_note)
+      params.require(:subscription).permit(
+        :cancellation_reason,
+        :cancellation_note,
+        :cancelled_by_id,
+        :cancelling_subscription
+      )
     end
   end
 end

--- a/app/controllers/subscriptions/plan_changes_controller.rb
+++ b/app/controllers/subscriptions/plan_changes_controller.rb
@@ -44,10 +44,12 @@ module Subscriptions
     private
 
     def change_stripe_subscription(subscription, plan_id)
-      @subscription, data = StripeSubscriptionService.new(subscription).
-                              change_plan(plan_id)
+      sub_service = StripeSubscriptionService.new(subscription)
+      @subscription, data = sub_service.change_plan(plan_id)
 
       if data[:status] == :ok
+        retrieved_subscription = StripeSubscriptionService.new(@subscription).retrieve_subscription
+        @subscription.un_cancel if retrieved_subscription[:cancel_at_period_end]
         render 'subscriptions/create'
       else
         render json: { subscription_id: @subscription.id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,6 +96,7 @@ class User < ApplicationRecord
   has_many :subscriptions, inverse_of: :user
   has_many :subscription_payment_cards
   has_many :subscription_transactions
+  has_many :subscriptions_cancelled, class_name: 'Subscription', foreign_key: 'cancelled_by_id', inverse_of: :cancelled_by
   has_many :student_exam_tracks
   has_many :course_section_user_logs
   has_many :subject_course_user_logs
@@ -444,7 +445,7 @@ class User < ApplicationRecord
   end
 
   def default_card
-    subscription_payment_cards.where(is_default_card: true, status: 'card-live').first
+    subscription_payment_cards.find_by(is_default_card: true, status: 'card-live')
   end
 
   def subscriptions_for_exam_body(exam_body_id)

--- a/app/pdfs/invoice_document.rb
+++ b/app/pdfs/invoice_document.rb
@@ -44,10 +44,10 @@ class InvoiceDocument < Prawn::Document
         row(0).column(0).style(font_style: :bold)
       end
 
-    invoice_date    = invoice.issued_at.strftime('%e %b %Y')
     invoice_id      = invoice.id.to_s
+    invoice_date    = invoice.issued_at.strftime('%e %b %Y')
     invoice_details =
-      make_table([['Invoice Date:', invoice_date], ['Invoice No:', invoice_id]], width: 185, cell_style: { padding: 5, border_width: 0.5 }) do
+      make_table([['Invoice Date:', invoice_date], ['Invoice No:', invoice_id], ['Invoice Status:', invoice.status]], width: 185, cell_style: { padding: 5, border_width: 0.5 }) do
         row(0..10).style(size: 9)
         row(0..10).column(0).style(font_style: :bold)
       end

--- a/app/services/stripe_subscription_service.rb
+++ b/app/services/stripe_subscription_service.rb
@@ -116,7 +116,12 @@ class StripeSubscriptionService < StripeService
       subscription_id: new_subscription.id, account_type: 'Subscription',
       content_access: true
     )
-    @subscription.update(stripe_status: 'canceled', state: 'cancelled')
+
+    reason = "Changed plan to #{new_subscription.subscription_plan.interval_name}"
+    @subscription.update(stripe_status: 'canceled',
+                         state: 'cancelled',
+                         cancelled_at: Time.current,
+                         cancellation_reason: reason)
   end
 
   def client_secret_from_sub(subscription)

--- a/app/views/subscriptions/cancellations/admin_new.html.haml
+++ b/app/views/subscriptions/cancellations/admin_new.html.haml
@@ -1,0 +1,32 @@
+%main
+  %article.dashboard.bg-gray5
+    .container
+      %header
+        %h1.h1-hero.pt-5
+          ="Cancel #{@subscription.user.name} subscription"
+
+      %section.pb-md-6.pt-4
+        .form-box
+          .row
+            .col-sm-12
+              %p
+                At LearnSignal we’re keen to keep improving our service.
+              %p.h6
+                Why do you want to cancel?
+
+              =form_for @subscription, url: subscription_cancellations_path(id: @subscription.id), method: :post do |f|
+                =f.hidden_field(:cancelled_by_id, value: current_user.id)
+                =f.hidden_field(:cancelling_subscription, value: true)
+                =f.hidden_field(:cancellation_reason, value: "Admin(#{current_user.email}) canceled it.")
+
+                .row
+                  .col-sm-6
+                    .form-group
+                      =f.label :cancellation_note, 'Cancellation note:', class: 'block-label h4'
+                      #cancellation-note-error
+                      =f.text_area :cancellation_note, :rows => 4, class: 'form-control'
+
+
+                .row.mt-4
+                  .col-sm-4
+                    =f.submit 'Cancel', id: 'confirm_cancellation_button', class: 'btn btn-danger btn-sm', data: { disable_with: false }

--- a/app/views/subscriptions/cancellations/new.html.haml
+++ b/app/views/subscriptions/cancellations/new.html.haml
@@ -15,6 +15,8 @@
                 Why do you want to cancel?
 
               =form_for @subscription, url: subscription_cancellations_path(id: @subscription.id), method: :post, html: { :id => "attempt_subscription_cancellation" } do |f|
+                =f.hidden_field(:cancelled_by_id, value: current_user.id)
+                =f.hidden_field(:cancelling_subscription, value: true)
                 .row
                   .col-sm-6
                     .form-group.cancellation-reason

--- a/app/views/subscriptions/plan_changes/_update_card_modal.haml
+++ b/app/views/subscriptions/plan_changes/_update_card_modal.haml
@@ -27,17 +27,3 @@
             %div
               = f.button :submit, class: 'btn btn-primary float-left mb-2', id: 'card_submit' do
                 Submit Card Details
-
-              .sk-circle{style: 'margin-right: 50px; margin-left: 50px;'}
-                .sk-circle1.sk-child
-                .sk-circle2.sk-child
-                .sk-circle3.sk-child
-                .sk-circle4.sk-child
-                .sk-circle5.sk-child
-                .sk-circle6.sk-child
-                .sk-circle7.sk-child
-                .sk-circle8.sk-child
-                .sk-circle9.sk-child
-                .sk-circle10.sk-child
-                .sk-circle11.sk-child
-                .sk-circle12.sk-child

--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -26,10 +26,9 @@
               .col-md-4.text-md-right
                 -if subscription.pending_3d_secure? && subscription.pending_3ds_invoice
                   =link_to show_invoice_url(subscription.pending_3ds_invoice&.sca_verification_guid) do
-                    .btn.btn-secondary
+                    .btn.btn-primary.mb-3
                       Authenticate
-                -else
-                  %button.btn.btn-secondary.btn-sm.js-show-hide-details.collapsed.sub-details{"aria-controls" => "#sub-#{subscription.id}", "aria-expanded" => "false", "data-target" => "#sub-#{subscription.id}", "data-toggle" => "collapse"}
+                %button.btn.btn-secondary.js-show-hide-details.collapsed.sub-details{"aria-controls" => "#sub-#{subscription.id}", "aria-expanded" => "false", "data-target" => "#sub-#{subscription.id}", "data-toggle" => "collapse"}
 
             .collapse{id: "sub-#{subscription.id}"}
               .pt-5.pb-4
@@ -88,11 +87,12 @@
                     =link_to 'Reactivate Subscription', subscriptions_suspension_path(id: subscription.id), method: :delete, class: 'btn btn-secondary btn-xs', style: 'vertical-align: top;'
                   -if subscription.active?
                     =link_to 'Cancel Subscription', new_subscription_cancellation_path(subscription), class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
+                  -if subscription.pending_3d_secure? || subscription.past_due?
+                    =link_to 'Cancel Subscription', new_subscription_cancellation_path(subscription), data: { confirm: 'Warning: Because your latest invoice is overdue this cancelation will be immediate and full access will be removed.' }, class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
+                  -if subscription.pending_cancellation?
+                    =link_to 'Undo Subscription Cancel', un_cancel_subscription_path(subscription), data: { confirm: 'By clicking here you agree to undo the cancelation of  your currently plan.' }, method: :put, class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
                   -if subscription.cancelled?
                     =link_to 'Renew Subscription', subscription_checkout_special_link(subscription.subscription_plan.exam_body_id), class: 'btn btn-primary btn-xs', style: 'vertical-align: top;'
-
-
-
     -else
       %article.card.mb-5
         .card-body.card-body-sm

--- a/app/views/user_accounts/show_invoice.html.haml
+++ b/app/views/user_accounts/show_invoice.html.haml
@@ -74,9 +74,6 @@
                         %p.invalid-details
                           You need to add a valid payment card to your account. Your subscription will be cancelled if this invoice is not paid. Please visit the card details section in your account.
 
-
-
-
 #add-card.col-md-12.l-margin-top-big
 
 =render partial: 'add_card_modal_ajax'
@@ -124,6 +121,8 @@
             type: "POST",
             data: {id: "#{@invoice.id}"}
           })
+
+          window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
         }
       });
     }

--- a/app/views/users/user_subscription_status.html.haml
+++ b/app/views/users/user_subscription_status.html.haml
@@ -42,10 +42,11 @@
                     %td
                       =subscription.stripe? ? 'Stripe' : 'PayPal'
                     %td
-                      =link_to subscription_management_url(subscription) do
-                        .btn.btn-secondary.btn-xs
-                          View
-
+                      -if subscription.pending_3d_secure? || subscription.past_due?
+                        =link_to 'Cancel', new_subscription_cancellation_path(subscription, role: :admin), data:  { confirm: "Warning: Because your latest invoice is overdue this cancelation will be immediate and full access will be removed." } , class: 'btn btn-danger btn-xs', style: 'vertical-align: top;'
+                        =link_to subscription_management_url(subscription) do
+                          .btn.btn-secondary.btn-xs
+                            View
 
     .row
       .col-md-12
@@ -85,7 +86,6 @@
                       %td
                         =tick_or_cross(card.is_default_card?)
 
-
     .row
       .col-md-12
         .box-item.table-box#invoices-panel
@@ -94,5 +94,3 @@
               =t('views.users.user_subscription_status.subscription_info.invoices')
             .table-responsive
               =render partial: 'subscription_management/invoices'
-
-

--- a/db/migrate/20200116090622_add_cancelled_by_in_subscription.rb
+++ b/db/migrate/20200116090622_add_cancelled_by_in_subscription.rb
@@ -1,0 +1,5 @@
+class AddCancelledByInSubscription < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :subscriptions, :cancelled_by, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_134915) do
+ActiveRecord::Schema.define(version: 2020_01_16_090622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -409,9 +409,9 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.boolean "is_video", default: false, null: false
     t.boolean "is_quiz", default: false, null: false
     t.boolean "active", default: true, null: false
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.float "duration", default: 0.0
     t.string "temporary_label"
@@ -430,9 +430,9 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cme_count", default: 0
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.integer "subject_course_id"
     t.float "video_duration", default: 0.0
@@ -667,8 +667,8 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.string "background_image_content_type"
     t.integer "background_image_file_size"
     t.datetime "background_image_updated_at"
-    t.string "background_colour"
     t.bigint "exam_body_id"
+    t.string "background_colour"
     t.string "seo_title"
     t.string "seo_description"
     t.string "short_description"
@@ -887,6 +887,7 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
 
   create_table "products", id: :serial, force: :cascade do |t|
     t.string "name"
+    t.integer "subject_course_id"
     t.integer "mock_exam_id"
     t.string "stripe_guid"
     t.boolean "live_mode", default: false
@@ -896,7 +897,6 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.integer "currency_id"
     t.decimal "price"
     t.string "stripe_sku_guid"
-    t.integer "subject_course_id"
     t.integer "sorting_order"
     t.integer "product_type", default: 0
     t.integer "correction_pack_count"
@@ -909,6 +909,7 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.index ["mock_exam_id"], name: "index_products_on_mock_exam_id"
     t.index ["name"], name: "index_products_on_name"
     t.index ["stripe_guid"], name: "index_products_on_stripe_guid"
+    t.index ["subject_course_id"], name: "index_products_on_subject_course_id"
   end
 
   create_table "quiz_answers", id: :serial, force: :cascade do |t|
@@ -1312,9 +1313,10 @@ ActiveRecord::Schema.define(version: 2019_12_09_134915) do
     t.string "cancellation_reason"
     t.text "cancellation_note"
     t.bigint "changed_from_id"
-    t.string "temp_guid"
     t.string "completion_guid"
     t.uuid "ahoy_visit_id"
+    t.bigint "cancelled_by_id"
+    t.index ["cancelled_by_id"], name: "index_subscriptions_on_cancelled_by_id"
     t.index ["changed_from_id"], name: "index_subscriptions_on_changed_from_id"
   end
 


### PR DESCRIPTION
* Fix redirect of change plan page based in user data;
* Add more details in old subscription when plan is changed;
* Confirm if stripe plan is un cancelled when plan is change;
* Add stripe status in invoice document;
* Don't filter user payment cards by status anymore, stripe will handle any expired card;
* Allow user immediate cancel a past due or pending 3d authentication subscription;
* Allow to admin cancel user subscriptions;
* Bringing back undo cancellation subscription;
* Redirect to user account after user complete invoice action in 3D authentication;