### PR TITLE
Fix CIMA correction packs issue

### DIFF
--- a/app/controllers/footer_pages_controller.rb
+++ b/app/controllers/footer_pages_controller.rb
@@ -48,7 +48,7 @@ class FooterPagesController < ApplicationController
     @products      = valid_products.where('mock_exam_id IS NOT NULL OR cbe_id IS NOT NULL').
                        where('product_type IN (?)', [Product.product_types[:mock_exam], Product.product_types[:cbe]])
     @questions     = valid_products.where('mock_exam_id IS NOT NULL').
-                       where('product_type = ?', Product.product_types[:correction_pack])
+                       where('product_type = ?', Product.product_types[:correction_pack]).order(:group_id).limit(3)
   end
 
   def profile

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -108,7 +108,7 @@ class LibraryController < ApplicationController
     @currency_id = @country ? @country.currency_id : Currency.all_active.all_in_order.first
     @correction_pack_products = []
 
-    valid_products = Product.includes(mock_exam: :subject_course).
+    valid_products = Product.includes(mock_exam: :subject_course).for_group(@group.id).
                        in_currency(@currency_id).all_active.all_in_order
 
     if @course.has_correction_packs

--- a/app/models/mock_exam.rb
+++ b/app/models/mock_exam.rb
@@ -25,7 +25,7 @@ class MockExam < ApplicationRecord
   # Constants
 
   # relationships
-  belongs_to :subject_course
+  belongs_to :subject_course, optional: true
   has_many :products
   has_many :orders
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -32,6 +32,7 @@ class Product < ApplicationRecord
   belongs_to :currency
   belongs_to :group
   belongs_to :mock_exam, optional: true
+  belongs_to :subject_course, optional: true
   belongs_to :cbe, optional: true
   has_many :orders, dependent: :restrict_with_error
   has_many :exercises, dependent: :restrict_with_error
@@ -44,7 +45,7 @@ class Product < ApplicationRecord
   validates :stripe_sku_guid, presence: true, uniqueness: true, on: :update
   validates :group_id, numericality: { only_integer: true, greater_than: 0 }
   validates :mock_exam_id, numericality: { only_integer: true,
-                                           greater_than: 0 }, if: :mock_exam?
+                                           greater_than: 0 }, unless: :cbe?
   validates :cbe_id, numericality: { only_integer: true,
                                      greater_than: 0 }, if: :cbe?
   validates :correction_pack_count, presence: true,

--- a/app/views/footer_pages/media_library.html.haml
+++ b/app/views/footer_pages/media_library.html.haml
@@ -57,7 +57,7 @@
             .row.row-lg
               -@questions.each do |question|
                 .col-xs-12.col-sm-6.col-md-4
-                  =link_to product_checkout_special_link(question.mock_exam.subject_course.group.exam_body.id, question.id), class: 'card card-link text-center mb-5',onclick: "addToCart('#{question.currency.iso_code}', '#{question.name}', '#{question.id}', '#{question.price}', '#{question.mock_exam.subject_course.exam_body.name}');" do
+                  =link_to product_checkout_special_link(question.group.exam_body.id, question.id), class: 'card card-link text-center mb-5',onclick: "addToCart('#{question.currency.iso_code}', '#{question.name}', '#{question.id}', '#{question.price}', '#{question.group.exam_body.name}');" do
                     .py-4
                       %h4.text-ellipsis.mb-4
                         =question.mock_exam.try(:name)

--- a/app/views/library/course_show.html.haml
+++ b/app/views/library/course_show.html.haml
@@ -146,7 +146,7 @@
 
               - @correction_pack_products.each do |product|
                 .col-sm-6
-                  =link_to product_checkout_special_link(product.mock_exam.subject_course.group.exam_body.id, product.id), class: 'card card-horizontal card-horizontal-sm flex-row' do
+                  =link_to product_checkout_special_link(product.group.exam_body.id, product.id), class: 'card card-horizontal card-horizontal-sm flex-row' do
                     .card-header.bg-white.d-flex.align-items-center.justify-content-center
                       %i.budicon-files-tick{"aria-label" => "", :role => "img"}
                     .card-body.d-flex.align-items-center.pl-1

--- a/spec/models/mock_exam_spec.rb
+++ b/spec/models/mock_exam_spec.rb
@@ -27,8 +27,8 @@ describe MockExam do
   it { should have_many(:orders) }
 
   # validation
-  it 'is invalid without a subject_course' do
-    expect(build_stubbed(:mock_exam, subject_course: nil)).not_to be_valid
+  it 'is valid without a subject_course' do
+    expect(build_stubbed(:mock_exam, subject_course: nil)).to be_valid
   end
 
   it { should validate_presence_of(:name) }


### PR DESCRIPTION
 * Made subject_course relationship optional
 * Removed subject_course from product special link and limited correction packs to 3
 * Added group filter to correction packs on course page and removed subject course from product special link