### PR TITLE
Add PastDue to State Machine

### DIFF
--- a/app/models/stripe_api_event.rb
+++ b/app/models/stripe_api_event.rb
@@ -184,7 +184,7 @@ class StripeApiEvent < ApplicationRecord
 
       # A NextPaymentAttempt Date value means that another payment attempt will be made
       MandrillWorker.perform_async(user.id, 'send_card_payment_failed_email', self.account_url) unless Rails.env.test?
-
+      subscription.mark_past_due
     else
       set_process_error "Error finding User-#{stripe_customer_guid}, Invoice-#{stripe_invoice_guid} OR Subscription- #{stripe_subscription_guid}. InvoicePaymentFailed Event"
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -83,7 +83,7 @@ class Subscription < ApplicationRecord
   scope :in_created_order,         -> { order(:created_at) }
   scope :in_reverse_created_order, -> { order(created_at: :desc) }
   scope :all_of_status,            ->(status) { where(stripe_status: status) }
-  scope :all_active,               -> { with_states(:active, :paused, :errored, :pending_cancellation) }
+  scope :all_active,               -> { with_states(:active, :past_due, :paused, :errored, :pending_cancellation) }
   scope :all_valid,                -> { where(state: VALID_STATES) }
   scope :not_pending,              -> { where.not(state: 'pending') }
   scope :this_week,                -> { where(created_at: Time.zone.now.beginning_of_week..Time.zone.now.end_of_week) }
@@ -112,6 +112,10 @@ class Subscription < ApplicationRecord
 
     event :cancel_pending do
       transition active: :pending_cancellation
+    end
+
+    event :mark_past_due do
+      transition active: :past_due
     end
 
     event :cancel do


### PR DESCRIPTION
- Added state machine transition mark_past_due and set trigger in the StripeApiEvent invoice_payment_failed method.
- Need clarification of how PayPal handles failed payments to ensure it processes the webhook correctly.