### PR TITLE
Cbe improvements

### DIFF
--- a/app/controllers/api/v1/cbes/introduction_pages_controller.rb
+++ b/app/controllers/api/v1/cbes/introduction_pages_controller.rb
@@ -25,9 +25,11 @@ module Api
         end
 
         def destroy
-          @page.destroy
-
-          render json: { message: "Page #{@page.id} was deleted." }, status: :accepted
+          if @page.destroy
+            render json: { message: "Page #{@page.id} was deleted." }, status: :accepted
+          else
+            render json: { errors: @page.errors }, status: :unprocessable_entity
+          end
         end
 
         private

--- a/app/controllers/api/v1/cbes/questions_controller.rb
+++ b/app/controllers/api/v1/cbes/questions_controller.rb
@@ -28,9 +28,11 @@ module Api
         end
 
         def destroy
-          @question.destroy
-
-          render json: { message: "Question #{@question.id} was deleted." }, status: :accepted
+          if @question.destroy
+            render json: { message: "Question #{@question.id} was deleted." }, status: :accepted
+          else
+            render json: { errors: @question.errors }, status: :unprocessable_entity
+          end
         end
 
         private

--- a/app/controllers/api/v1/cbes/resources_controller.rb
+++ b/app/controllers/api/v1/cbes/resources_controller.rb
@@ -25,9 +25,11 @@ module Api
         end
 
         def destroy
-          @resource.destroy
-
-          render json: { message: "Resource #{@resource.id} was deleted." }, status: :accepted
+          if @resource.destroy
+            render json: { message: "Resource #{@resource.id} was deleted." }, status: :accepted
+          else
+            render json: { errors: @resource.errors }, status: :unprocessable_entity
+          end
         end
 
         private

--- a/app/controllers/api/v1/cbes/scenarios_controller.rb
+++ b/app/controllers/api/v1/cbes/scenarios_controller.rb
@@ -24,9 +24,11 @@ module Api
         end
 
         def destroy
-          @scenario.destroy
-
-          render json: { message: "Scenario #{@scenario.id} was deleted." }, status: :accepted
+          if @scenario.destroy
+            render json: { message: "Scenario #{@scenario.id} was deleted." }, status: :accepted
+          else
+            render json: { errors: @scenario.errors }, status: :unprocessable_entity
+          end
         end
 
         private

--- a/app/controllers/api/v1/cbes/sections_controller.rb
+++ b/app/controllers/api/v1/cbes/sections_controller.rb
@@ -25,9 +25,11 @@ module Api
         end
 
         def destroy
-          @section.destroy
-
-          render json: { message: "Section #{@section.id} was deleted." }, status: :accepted
+          if @section.destroy
+            render json: { message: "Section #{@section.id} was deleted." }, status: :accepted
+          else
+            render json: { errors: @section.errors }, status: :unprocessable_entity
+          end
         end
 
         private
@@ -36,6 +38,7 @@ module Api
           params.require(:cbe_section).permit(:name,
                                               :score,
                                               :kind,
+                                              :random,
                                               :sorting_order,
                                               :content,
                                               :cbe_id)

--- a/app/helpers/exercises_helper.rb
+++ b/app/helpers/exercises_helper.rb
@@ -12,7 +12,7 @@ module ExercisesHelper
   end
 
   def cbe_score(cbe_user_log)
-    total_scores  = cbe_user_log.cbe.questions.map(&:score).sum
+    total_scores  = cbe_user_log.questions.map { |q| q.cbe_question.score }.sum
     student_score = cbe_user_log.score
 
     "Total Score: #{student_score}/#{total_scores}"

--- a/app/javascript/components/cbe/UserHome.vue
+++ b/app/javascript/components/cbe/UserHome.vue
@@ -22,7 +22,7 @@
               :cbe_data="cbe_data"
             />
           </b-navbar-nav>
-          <b-navbar-nav v-if="$route.name == 'review' && user_cbe_data.status !== 'corrected'">
+          <b-navbar-nav v-if="$route.name == 'review' && (user_cbe_data.status !== 'corrected' && user_cbe_data.status !== 'finished')">
             <b-nav-text
               class="arrow-right-icon"
               @click="submitExam"

--- a/app/javascript/components/cbe/admin/Edit.vue
+++ b/app/javascript/components/cbe/admin/Edit.vue
@@ -112,6 +112,7 @@
                       :initial-score="section.score"
                       :initial-sorting-order="section.sorting_order"
                       :initial-kind="section.kind"
+                      :initial-random="section.random"
                       :initial-content="section.content"
                       @rm-section="removeSection"
                     />
@@ -557,7 +558,10 @@ export default {
     removeScenarioQuestion(data) {
       const filtered =
         this.edit_cbe_data.sections.filter(function(section){
-          section.questions = section.questions.filter((question) => question.id !== data.questionId);
+          section.scenarios.filter(function(scenario){
+            scenario.questions = scenario.questions.filter((question) => question.id !== data);
+            return scenario
+          });
           return section
         });
 

--- a/app/javascript/components/cbe/admin/Home.vue
+++ b/app/javascript/components/cbe/admin/Home.vue
@@ -111,6 +111,7 @@
                         :initial-score="section.score"
                         :initial-sorting-order="section.sorting_order"
                         :initial-kind="section.kind"
+                        :initial-random="section.random"
                         :initial-content="section.content"
                         @rm-section="removeSection"
                       />
@@ -554,7 +555,10 @@ export default {
     removeScenarioQuestion(questionId) {
       const filtered =
         this.sections.filter(function(section){
-          section.questions = section.questions.filter((question) => question.id !== questionId);
+          section.scenarios.filter(function(scenario){
+            scenario.questions = scenario.questions.filter((question) => question.id !== data);
+            return scenario
+          });
           return section
         });
 

--- a/app/javascript/components/cbe/admin/Section.vue
+++ b/app/javascript/components/cbe/admin/Section.vue
@@ -28,6 +28,7 @@
           id="sectionKindSelect"
           v-model="kind"
           :options="sectionKinds"
+          @change="onChangeKind($event)"
           class="input-group input-group-lg"
         >
           <template slot="first">
@@ -45,6 +46,19 @@
         >
           field is required
         </p>
+      </div>
+
+      <div class="form-group" v-if="showRandom">
+        <b-form-group
+          id="checkbox-input-group"
+
+        >
+          <b-form-checkbox
+            v-model="random"
+          >
+            Randomize Questions?
+          </b-form-checkbox>
+        </b-form-group>
       </div>
     </div>
 
@@ -199,6 +213,10 @@ export default {
       type: String,
       default: ""
     },
+    initialRandom: {
+      type: Boolean,
+      default: false
+    },
   },
   data() {
     return {
@@ -213,6 +231,8 @@ export default {
         "objective_test_case",
         "constructed_response"
       ],
+      random: this.initialRandom,
+      showRandom: this.initialKind == "objective" ? true : false,
       submitStatus: null,
       deleteStatus: null
     };
@@ -248,6 +268,7 @@ export default {
         this.sectionDetails.score = this.score;
         this.sectionDetails.sorting_order = this.sortingOrder;
         this.sectionDetails.kind = this.kind;
+        this.sectionDetails.random = this.random;
         this.sectionDetails.content = this.content;
         this.sectionDetails.cbe_id = this.$store.state.cbeId;
 
@@ -264,6 +285,7 @@ export default {
               this.sectionDetails = {};
               this.name = this.initialName;
               this.kind = this.initialKind;
+              this.random = this.initialKind == "objective" ? true : false;
               this.score = this.initialScore;
               this.sortingOrder += 1;
               this.content = null;
@@ -286,6 +308,7 @@ export default {
         this.sectionDetails.score = this.score;
         this.sectionDetails.sorting_order = this.sortingOrder;
         this.sectionDetails.kind = this.kind;
+        this.sectionDetails.random = this.random;
         this.sectionDetails.content = this.content;
         this.sectionDetails.cbe_id = this.$store.state.cbeId;
 
@@ -303,6 +326,7 @@ export default {
             this.score = this.updatedSection.score;
             this.sortingOrder = this.updatedSection.sorting_order;
             this.kind = this.updatedSection.kind;
+            this.random = this.updatedSection.random;
             this.submitStatus = "OK";
             this.$v.$reset();
           })
@@ -339,6 +363,10 @@ export default {
     },
     shouldAppendErrorClass(field) {
       return field.$error;
+    },
+    onChangeKind(kind) {
+      this.random = false
+      this.showRandom = kind == "objective" ? true : false
     }
   }
 };

--- a/app/models/cbe.rb
+++ b/app/models/cbe.rb
@@ -34,6 +34,7 @@ class Cbe < ApplicationRecord
                               scenarios: { questions: :cbe_section_id }
                             ]
                           ], validate: false
+
     new_cbe.update(name: "#{name} COPY", active: false)
   end
 end

--- a/app/models/cbe/question.rb
+++ b/app/models/cbe/question.rb
@@ -2,8 +2,9 @@
 
 class Cbe
   class Question < ApplicationRecord
-    # enum
+    # concerns
     include CbeQuestionTypes
+    include CbeSupport
 
     # relationships
     belongs_to :section, class_name: 'Cbe::Section', foreign_key: 'cbe_section_id',

--- a/app/models/cbe/scenario.rb
+++ b/app/models/cbe/scenario.rb
@@ -2,6 +2,9 @@
 
 class Cbe
   class Scenario < ApplicationRecord
+    # concerns
+    include CbeSupport
+
     # relationships
     belongs_to :section, class_name: 'Cbe::Section', foreign_key: 'cbe_section_id',
                          inverse_of: :scenarios

--- a/app/models/cbe/section.rb
+++ b/app/models/cbe/section.rb
@@ -2,6 +2,9 @@
 
 class Cbe
   class Section < ApplicationRecord
+    # concerns
+    include CbeSupport
+
     # relationships
     belongs_to :cbe
     has_many :questions, class_name: 'Cbe::Question', foreign_key: 'cbe_section_id',

--- a/app/models/cbe/user_log.rb
+++ b/app/models/cbe/user_log.rb
@@ -31,6 +31,10 @@ class Cbe
       self.status ||= 'started'
     end
 
+    def sections_in_user_log
+      questions.includes(:section).map(&:section).uniq.sort_by(&:sorting_order)
+    end
+
     private
 
     def update_exercise_status

--- a/app/models/concerns/cbe_support.rb
+++ b/app/models/concerns/cbe_support.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CbeSupport
+  extend ActiveSupport::Concern
+
+  included do
+    scope :active,   -> { where(active: true) }
+    scope :inactive, -> { where(active: false) }
+  end
+
+  def destroy
+    self.destroyed_at = Time.zone.now
+    self.active       = false
+    inactive_children
+
+    save
+  end
+
+  def inactive_children
+    scenarios.map(&:destroy) if respond_to?(:scenarios)
+    questions.map(&:destroy) if respond_to?(:questions)
+  end
+end

--- a/app/views/admin/exercises/cbe_user_question_update.js.erb
+++ b/app/views/admin/exercises/cbe_user_question_update.js.erb
@@ -1,2 +1,3 @@
 $('.cbe_score').html("Score: <%= @user_log.score %>")
 $('#<%= @question.id %>-response').html("<%= @response %>")
+$('#user_question_<%= @question.id %>').html("Score: <%= @question.score %>")

--- a/app/views/admin/exercises/correct_cbe.html.haml
+++ b/app/views/admin/exercises/correct_cbe.html.haml
@@ -9,7 +9,7 @@
     .card-body.bg-gray4
       %nav
         %ul.nav.nav-tabs.nav-fill{id: 'sectionTabs', role: 'tablist'}
-          - @cbe_user_log.cbe.sections.order(:sorting_order).each_with_index do |section, section_index|
+          - @cbe_user_log.sections_in_user_log.each_with_index do |section, section_index|
             %li.nav-item
               %a{class: "nav-link #{section_index == 0 ? 'active' : ''}", data: {toggle: 'tab'}, href: "#section-#{section.id}", aria: {controls: "#{section.id}", selected: 'false'}, role: 'tab'}
                 =section.name
@@ -17,22 +17,23 @@
       .bg-gray5
         .container.py-1
           #sectionTabsContent.tab-content
-            -@cbe_user_log.cbe.sections.order(:sorting_order).each_with_index do |section, section_index|
+            -@cbe_user_log.sections_in_user_log.each_with_index do |section, section_index|
+              -section_questions =  @cbe_user_log.questions.by_section(section.id)
               .tab-pane{id: "section-#{section.id}", class: "tab-#{section.id} #{section_index == 0 ? 'active show' : ''} ", "aria-labelledby" => "section-#{section.id}-tab", :role => "tabpanel"}
                 .row.pt-4
                   .col-sm-2
                     %nav.mb-4.account-nav
                       %ul#questionTabs.nav.nav-tabs.nav-tabs-vertical{:role => "tablist"}
-                        -section.questions.order(:sorting_order).each_with_index do |question, index|
+                        -section_questions.each_with_index do |question, index|
                           %li.nav-item
                             %a.nav-link{class: index == 0 ? 'active' : '', id: "#section-#{section.id}-question-#{question.id}", "aria-controls" => "section-#{section.id}-question-#{question.id}", "aria-selected" => "true", "data-toggle" => "tab", :href => "#section-#{section.id}-question-#{question.id}", :role => "tab"}
                               ="Question #{index+1}"
 
                   .col-sm-10
                     #questionTabsContent.tab-content
-                      -section.questions.order(:sorting_order).each_with_index do |question, index|
-                        -user_question = @cbe_user_log.questions.by_section(section.id).select{ |q| q.cbe_question.id == question.id }.first
-                        .tab-pane.tab-account.tab-personal-info{class: index == 0 ? 'show active' : '', id: "section-#{section.id}-question-#{question.id}", "aria-labelledby" => "personal-info-tab", :role => "tabpanel"}
+                      -section_questions.each_with_index do |user_question, index|
+                        -question = user_question.cbe_question
+                        .tab-pane.tab-account.tab-personal-info{class: index == 0 ? 'show active' : '', id: "section-#{section.id}-question-#{user_question.id}", "aria-labelledby" => "personal-info-tab", :role => "tabpanel"}
                           .row
                             .col-sm
                               .h4
@@ -44,7 +45,7 @@
                                   Correct:
                                   =user_question.correct
                               .col-sm-3
-                                .h4
+                                .h4{ id: "user_question_#{user_question.id}" }
                                   Score:
                                   =user_question.score
 
@@ -74,8 +75,6 @@
                               =render_admin_answers(user_question)
                             -else
                               Question not answered by the student
-
-
 
   .row
     .col-sm-12

--- a/app/views/api/v1/cbes/_cbe.json.jbuilder
+++ b/app/views/api/v1/cbes/_cbe.json.jbuilder
@@ -26,7 +26,7 @@ json.resources cbe.resources.order(:sorting_order) do |resource|
   end
 end
 
-json.sections cbe.sections.order(:sorting_order) do |section|
+json.sections cbe.sections.active.order(:sorting_order) do |section|
   json.partial! 'api/v1/cbes/sections/section', locals: { section: section }
 end
 

--- a/app/views/api/v1/cbes/_edit_cbe.json.jbuilder
+++ b/app/views/api/v1/cbes/_edit_cbe.json.jbuilder
@@ -26,7 +26,7 @@ json.resources cbe.resources.order(:sorting_order) do |resource|
   end
 end
 
-json.sections cbe.sections.all_in_order do |section|
+json.sections cbe.sections.active.all_in_order do |section|
   json.partial! 'api/v1/cbes/sections/section_edit', locals: { section: section }
 end
 

--- a/app/views/api/v1/cbes/scenarios/_scenario.json.jbuilder
+++ b/app/views/api/v1/cbes/scenarios/_scenario.json.jbuilder
@@ -5,10 +5,10 @@ json.name             scenario.name
 json.content          scenario.content
 json.section_id       scenario.cbe_section_id
 
-json.questions scenario.questions do |question|
+json.questions scenario.questions.active do |question|
   json.partial! 'api/v1/cbes/questions/question_edit', locals: { question: question }
 end
 
-json.section_questions scenario.section.questions do |question|
+json.section_questions scenario.section.questions.active do |question|
   json.partial! 'api/v1/cbes/questions/question_edit', locals: { question: question }
 end

--- a/app/views/api/v1/cbes/scenarios/_scenario_edit.json.jbuilder
+++ b/app/views/api/v1/cbes/scenarios/_scenario_edit.json.jbuilder
@@ -5,10 +5,10 @@ json.name             scenario.name
 json.content          scenario.content
 json.section_id       scenario.cbe_section_id
 
-json.questions scenario.questions do |question|
+json.questions scenario.questions.active do |question|
   json.partial! 'api/v1/cbes/questions/question_edit', locals: { question: question }
 end
 
-json.section_questions scenario.section.questions do |question|
+json.section_questions scenario.section.questions.active do |question|
   json.partial! 'api/v1/cbes/questions/question_edit', locals: { question: question }
 end

--- a/app/views/api/v1/cbes/sections/_section.json.jbuilder
+++ b/app/views/api/v1/cbes/sections/_section.json.jbuilder
@@ -4,13 +4,20 @@ json.id             section.id
 json.name           section.name
 json.score          section.score
 json.kind           section.kind
+json.random         section.random
 json.sorting_order  section.sorting_order
 json.content        section.content
 
-json.scenarios section.scenarios do |scenario|
+json.scenarios section.scenarios.active do |scenario|
   json.partial! 'api/v1/cbes/scenarios/scenario', locals: { scenario: scenario }
 end
 
-json.questions section.questions.order(:sorting_order) do |question|
-  json.partial! 'api/v1/cbes/questions/question', locals: { question: question }
+if section.random
+  json.questions section.questions.active.shuffle do |question|
+    json.partial! 'api/v1/cbes/questions/question', locals: { question: question }
+  end
+else
+  json.questions section.questions.active.order(:sorting_order) do |question|
+    json.partial! 'api/v1/cbes/questions/question', locals: { question: question }
+  end
 end

--- a/app/views/api/v1/cbes/sections/_section_edit.json.jbuilder
+++ b/app/views/api/v1/cbes/sections/_section_edit.json.jbuilder
@@ -4,13 +4,20 @@ json.id             section.id
 json.name           section.name
 json.score          section.score
 json.kind           section.kind
+json.random         section.random
 json.sorting_order  section.sorting_order
 json.content        section.content
 
-json.scenarios section.scenarios do |scenario|
+json.scenarios section.scenarios.active do |scenario|
   json.partial! 'api/v1/cbes/scenarios/scenario_edit', locals: { scenario: scenario }
 end
 
-json.questions section.questions.without_scenario.order(:sorting_order) do |question|
-  json.partial! 'api/v1/cbes/questions/question_edit', locals: { question: question }
+if section.random
+  json.questions section.questions.active.without_scenario.shuffle do |question|
+    json.partial! 'api/v1/cbes/questions/question', locals: { question: question }
+  end
+else
+  json.questions section.questions.active.without_scenario.order(:sorting_order) do |question|
+    json.partial! 'api/v1/cbes/questions/question', locals: { question: question }
+  end
 end

--- a/app/views/exercises/_cbe_user_log.html.haml
+++ b/app/views/exercises/_cbe_user_log.html.haml
@@ -1,14 +1,13 @@
 %nav
   %ul.nav.nav-tabs.nav-fill{id: 'sectionTabs', role: 'tablist'}
-
-    - @exercise.cbe_user_log.cbe.sections.order(:sorting_order).each_with_index do |section, section_index|
+    - @exercise.cbe_user_log.sections_in_user_log.each_with_index do |section, section_index|
       %li.nav-item
         %a{class: "nav-link #{section_index == 0 ? 'active' : ''}", data: {toggle: 'tab'}, href: "#section-#{section.id}", aria: {controls: "#{section.id}", selected: 'false'}, role: 'tab'}
           =section.name
 
 .container.py-4
   #sectionTabsContent.tab-content
-    - @exercise.cbe_user_log.cbe.sections.order(:sorting_order).each_with_index do |section, section_index|
+    - @exercise.cbe_user_log.sections_in_user_log.each_with_index do |section, section_index|
       -section_questions =  @exercise.cbe_user_log.questions.by_section(section.id)
       .tab-pane{id: "section-#{section.id}", class: "tab-#{section.id} #{section_index == 0 ? 'active show' : ''} ", "aria-labelledby" => "section-#{section.id}-tab", :role => "tabpanel"}
         .row.row-lg.py-3
@@ -22,16 +21,16 @@
                 .col-sm-2
                   %nav.mb-4.account-nav
                     %ul#questionTabs.nav.nav-tabs.nav-tabs-vertical{:role => "tablist"}
-                      -section.questions.order(:sorting_order).each_with_index do |question, index|
+                      -section_questions.each_with_index do |question, index|
                         %li.nav-item
                           %a.nav-link{class: index == 0 ? 'active' : '', id: "#section-#{section.id}-question-#{question.id}", "aria-controls" => "section-#{section.id}-question-#{question.id}", "aria-selected" => "true", "data-toggle" => "tab", :href => "#section-#{section.id}-question-#{question.id}", :role => "tab"}
                             ="Question #{index+1}"
 
                 .col-sm-10
                   #questionTabsContent.tab-content
-                    -section.questions.order(:sorting_order).each_with_index do |question, index|
-                      -user_question = @exercise.cbe_user_log.questions.by_section(section.id).select{ |q| q.cbe_question.id == question.id }.first
-                      .tab-pane.tab-account{class: index == 0 ? 'show active' : '', id: "section-#{section.id}-question-#{question.id}", "aria-labelledby" => "section-#{section.id}-question-#{question.id}-tab", :role => "tabpanel"}
+                    -section_questions.each_with_index do |user_question, index|
+                      -question = user_question.cbe_question
+                      .tab-pane.tab-account{class: index == 0 ? 'show active' : '', id: "section-#{section.id}-question-#{user_question.id}", "aria-labelledby" => "section-#{section.id}-question-#{user_question.id}-tab", :role => "tabpanel"}
                         -if user_question&.answers.present?
                           %h4.mb-4
                             ="Marks: #{user_question.score.to_i}/#{question.score.to_i}"
@@ -42,21 +41,21 @@
                           .py-3
                             .accordion#resultsAccordion
                               .card
-                                .card-header#questionHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{question.id}-questionsCard"}, aria:{expanded: "true", controls: "questionCard"}, style: 'padding: 10px;'}
+                                .card-header#questionHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{user_question.id}-questionsCard"}, aria:{expanded: "true", controls: "questionCard"}, style: 'padding: 10px;'}
                                   %h2.mb-0
                                     .btn.btn-link
                                       ='Question Content: '
-                                .collapse.show{id: "section#{section.id}-question-#{question.id}-questionsCard", aria: {labelledby: "questionHeading"}, data: {parent: "#resultsAccordion"}}
+                                .collapse.show{id: "section#{section.id}-question-#{user_question.id}-questionsCard", aria: {labelledby: "questionHeading"}, data: {parent: "#resultsAccordion"}}
                                   .card-body{style: 'margin-left: 10px;'}
                                     =raw(question.content)
 
                               -if question.answers.present?
                                 .card
-                                  .card-header#optionsHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{question.id}-optionsCard"}, aria:{expanded: "true", controls: "optionsCard"}, style: 'padding: 10px;'}
+                                  .card-header#optionsHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{user_question.id}-optionsCard"}, aria:{expanded: "true", controls: "optionsCard"}, style: 'padding: 10px;'}
                                     %h2.mb-0
                                       .btn.btn-link
                                         ='Options: '
-                                  .collapse{id: "section#{section.id}-question-#{question.id}-optionsCard", aria: {labelledby: "optionsHeading"}, data: {parent: "#resultsAccordion"}}
+                                  .collapse{id: "section#{section.id}-question-#{user_question.id}-optionsCard", aria: {labelledby: "optionsHeading"}, data: {parent: "#resultsAccordion"}}
                                     .card-body{style: 'margin-left: 10px;'}
                                       %ul
                                         -question.answers.each do |answer|
@@ -65,11 +64,11 @@
 
                               -if user_question&.answers.present? && %w[open spreadsheet].exclude?(question.kind)
                                 .card
-                                  .card-header#answersHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{question.id}-answersCard"}, aria:{expanded: "true", controls: "answersCard"}, style: 'padding: 10px;'}
+                                  .card-header#answersHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{user_question.id}-answersCard"}, aria:{expanded: "true", controls: "answersCard"}, style: 'padding: 10px;'}
                                     %h2.mb-0
                                       .btn.btn-link
                                         ='Answered:'
-                                  .collapse{id: "section#{section.id}-question-#{question.id}-answersCard", aria: {labelledby: "answersHeading"}, data: {parent: "#resultsAccordion"}}
+                                  .collapse{id: "section#{section.id}-question-#{user_question.id}-answersCard", aria: {labelledby: "answersHeading"}, data: {parent: "#resultsAccordion"}}
                                     .card-body{style: 'margin-left: 10px;'}
                                       %ul
                                         -user_question.answers.each do |answer|
@@ -77,11 +76,11 @@
                                             =raw(question_answer(answer))
 
                               .card
-                                .card-header#solutionHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{question.id}-solutionCard"}, aria:{expanded: "true", controls: "solutionCard"}, style: 'padding: 10px;'}
+                                .card-header#solutionHeading{type: "button", data:{toggle: "collapse", target: "#section#{section.id}-question-#{user_question.id}-solutionCard"}, aria:{expanded: "true", controls: "solutionCard"}, style: 'padding: 10px;'}
                                   %h2.mb-0
                                     .btn.btn-link
                                       ='Suggested Solution: '
-                                .collapse{id: "section#{section.id}-question-#{question.id}-solutionCard", aria: {labelledby: "solutionHeading"}, data: {parent: "#resultsAccordion"}}
+                                .collapse{id: "section#{section.id}-question-#{user_question.id}-solutionCard", aria: {labelledby: "solutionHeading"}, data: {parent: "#resultsAccordion"}}
                                   .card-body{style: 'margin-left: 10px;'}
                                     =raw(question.solution)
                         - else

--- a/db/migrate/20200214160012_add_destroyed_at_cbe_models.rb
+++ b/db/migrate/20200214160012_add_destroyed_at_cbe_models.rb
@@ -1,0 +1,10 @@
+class AddDestroyedAtCbeModels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cbe_sections, :destroyed_at, :datetime
+    add_column :cbe_sections, :active, :boolean, default: true
+    add_column :cbe_scenarios, :destroyed_at, :datetime
+    add_column :cbe_scenarios, :active, :boolean, default: true
+    add_column :cbe_questions, :destroyed_at, :datetime
+    add_column :cbe_questions, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20200218094010_add_rand_to_cbe_section.rb
+++ b/db/migrate/20200218094010_add_rand_to_cbe_section.rb
@@ -1,0 +1,5 @@
+class AddRandToCbeSection < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cbe_sections, :random, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_11_113807) do
+ActiveRecord::Schema.define(version: 2020_02_18_094010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -120,6 +120,8 @@ ActiveRecord::Schema.define(version: 2020_02_11_113807) do
     t.integer "sorting_order"
     t.bigint "cbe_scenario_id"
     t.text "solution"
+    t.datetime "destroyed_at"
+    t.boolean "active", default: true
     t.index ["cbe_scenario_id"], name: "index_cbe_questions_on_cbe_scenario_id"
     t.index ["cbe_section_id"], name: "index_cbe_questions_on_cbe_section_id"
   end
@@ -143,6 +145,8 @@ ActiveRecord::Schema.define(version: 2020_02_11_113807) do
     t.datetime "updated_at", null: false
     t.bigint "cbe_section_id"
     t.string "name"
+    t.datetime "destroyed_at"
+    t.boolean "active", default: true
     t.index ["cbe_section_id"], name: "index_cbe_scenarios_on_cbe_section_id"
   end
 
@@ -155,6 +159,9 @@ ActiveRecord::Schema.define(version: 2020_02_11_113807) do
     t.integer "kind"
     t.integer "sorting_order"
     t.text "content"
+    t.datetime "destroyed_at"
+    t.boolean "active", default: true
+    t.boolean "random", default: false
     t.index ["cbe_id"], name: "index_cbe_sections_on_cbe_id"
   end
 
@@ -410,9 +417,9 @@ ActiveRecord::Schema.define(version: 2020_02_11_113807) do
     t.boolean "is_video", default: false, null: false
     t.boolean "is_quiz", default: false, null: false
     t.boolean "active", default: true, null: false
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.float "duration", default: 0.0
     t.string "temporary_label"
@@ -431,9 +438,9 @@ ActiveRecord::Schema.define(version: 2020_02_11_113807) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cme_count", default: 0
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.integer "subject_course_id"
     t.float "video_duration", default: 0.0

--- a/spec/concerns/archivable_spec.rb
+++ b/spec/concerns/archivable_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'archivable' do
+  let(:model) { described_class }
+  let(:obj)   { model.new }
+
+  describe '.destroy' do
+    it 'model destroyed_at should be updated' do
+      obj.destroy
+      expect(obj.destroyed_at).not_to be_nil
+    end
+  end
+
+  describe '.un_delete' do
+    it 'model destroyed_at should be updated' do
+      obj.un_delete
+      expect(obj.destroyed_at).to be_nil
+    end
+  end
+end

--- a/spec/concerns/cbe_support_spec.rb
+++ b/spec/concerns/cbe_support_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'cbe_support' do
+  let(:model) { described_class }
+  let(:obj)   { model.new }
+
+  describe '.destroy' do
+    it 'model destroyed_at should be updated' do
+      obj.destroy
+      expect(obj.destroyed_at).not_to be_nil
+      expect(obj.destroyed_at).not_to be_falsey
+    end
+  end
+end

--- a/spec/concerns/filterable_spec.rb
+++ b/spec/concerns/filterable_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-shared_examples_for "filterable" do
+shared_examples_for 'filterable' do
   let(:model) { described_class }
 
   describe '.search_scopes' do
@@ -24,9 +26,9 @@ shared_examples_for "filterable" do
       expect(model).to receive(model.search_scopes.first)
 
       model.filter(
-        ActionController::Parameters.new({
+        ActionController::Parameters.new(
           model.search_scopes.first.to_sym => 'test'
-        })
+        )
       )
     end
 
@@ -34,18 +36,18 @@ shared_examples_for "filterable" do
       expect(model).not_to receive(model.search_scopes.first)
 
       model.filter(
-        ActionController::Parameters.new({
+        ActionController::Parameters.new(
           model.search_scopes.first.to_sym => ''
-        })
+        )
       )
     end
 
     it 'returns an ActiveRecord::Relation' do
       expect(
         model.filter(
-          ActionController::Parameters.new({
+          ActionController::Parameters.new(
             model.search_scopes.first.to_sym => 'test'
-          })
+          )
         )
       ).to be_kind_of ActiveRecord::Relation
     end

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ProductsController, type: :controller do
         end
 
         it 'return a same product list' do
-          expect(Product.all.pluck(:sorting_order)).to eq([1, 2])
+          expect(Product.all_in_order.pluck(:sorting_order)).to eq([1, 2])
         end
       end
 

--- a/spec/models/cbe/question_spec.rb
+++ b/spec/models/cbe/question_spec.rb
@@ -1,4 +1,6 @@
+
 require 'rails_helper'
+require 'concerns/cbe_support_spec.rb'
 
 RSpec.describe Cbe::Question, type: :model do
   let(:cbe_question) { build(:cbe_question, :with_section) }
@@ -10,6 +12,8 @@ RSpec.describe Cbe::Question, type: :model do
     it { should respond_to(:sorting_order) }
     it { should respond_to(:cbe_section_id) }
     it { should respond_to(:cbe_scenario_id) }
+    it { should respond_to(:active) }
+    it { should respond_to(:destroyed_at) }
     it { should respond_to(:created_at) }
     it { should respond_to(:updated_at) }
   end
@@ -32,6 +36,10 @@ RSpec.describe Cbe::Question, type: :model do
                     fill_in_the_blank: 3, drag_drop: 4, dropdown_list: 5,
                     hot_spot: 6, spreadsheet: 7, open: 8)
     end
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'cbe_support'
   end
 
   describe 'Factory' do

--- a/spec/models/cbe/scenario_spec.rb
+++ b/spec/models/cbe/scenario_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'concerns/cbe_support_spec.rb'
 
 RSpec.describe Cbe::Scenario, type: :model do
   let(:cbe_scenario) { build(:cbe_scenario, :with_section) }
@@ -7,6 +8,8 @@ RSpec.describe Cbe::Scenario, type: :model do
     it { should respond_to(:name) }
     it { should respond_to(:content) }
     it { should respond_to(:cbe_section_id) }
+    it { should respond_to(:active) }
+    it { should respond_to(:destroyed_at) }
     it { should respond_to(:created_at) }
     it { should respond_to(:updated_at) }
   end
@@ -18,6 +21,10 @@ RSpec.describe Cbe::Scenario, type: :model do
   describe 'Validations' do
     it { should validate_presence_of(:content) }
     it { should validate_presence_of(:cbe_section_id) }
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'cbe_support'
   end
 
   describe 'Factory' do

--- a/spec/models/cbe/section_spec.rb
+++ b/spec/models/cbe/section_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'concerns/cbe_support_spec.rb'
 
 RSpec.describe Cbe::Section, type: :model do
   let(:cbe_section) { build(:cbe_section, :with_cbe) }
@@ -10,6 +11,9 @@ RSpec.describe Cbe::Section, type: :model do
     it { should respond_to(:sorting_order) }
     it { should respond_to(:content) }
     it { should respond_to(:cbe_id) }
+    it { should respond_to(:active) }
+    it { should respond_to(:destroyed_at) }
+    it { should respond_to(:random) }
     it { should respond_to(:created_at) }
     it { should respond_to(:updated_at) }
   end
@@ -24,6 +28,10 @@ RSpec.describe Cbe::Section, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:kind) }
     it { should validate_presence_of(:cbe_id) }
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'cbe_support'
   end
 
   describe 'Enums' do

--- a/spec/models/cbe/user_log_spec.rb
+++ b/spec/models/cbe/user_log_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Cbe::UserLog, type: :model do
       expect { cbe_user_log.default_status }.to change { cbe_user_log.status }.from(nil).to('started')
     end
 
+    it '.sections_in_user_log' do
+      expect(cbe_user_log.sections_in_user_log).to be_empty
+    end
+
     it 'update_exercise_status' do
       private_cbe_user_log.questions.map { |q| q.cbe_question.update(kind: 'multiple_choice') }
       private_cbe_user_log.update(status: 'finished')

--- a/spec/models/course_module_element_quiz_spec.rb
+++ b/spec/models/course_module_element_quiz_spec.rb
@@ -12,6 +12,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe CourseModuleElementQuiz do
 
@@ -49,4 +50,7 @@ describe CourseModuleElementQuiz do
     it { should respond_to(:destroyable_children) }
   end
 
+  describe 'Concern' do
+    it_behaves_like 'archivable'
+  end
 end

--- a/spec/models/course_module_element_resource_spec.rb
+++ b/spec/models/course_module_element_resource_spec.rb
@@ -16,6 +16,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe CourseModuleElementResource do
   describe 'relationships' do
@@ -39,5 +40,9 @@ describe CourseModuleElementResource do
 
   describe 'instance methods' do
     it { should respond_to(:destroyable?) }
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'archivable'
   end
 end

--- a/spec/models/course_module_element_spec.rb
+++ b/spec/models/course_module_element_spec.rb
@@ -26,6 +26,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe CourseModuleElement do
   describe 'relationships' do
@@ -85,6 +86,10 @@ describe CourseModuleElement do
 
     it { should respond_to(:type_name) }
     it { should respond_to(:cme_is_video?) }
+
+    describe 'Concern' do
+      it_behaves_like 'archivable'
+    end
 
     describe User, '#available_to_user' do
       it 'for unverified_user it returns false and verification-required' do

--- a/spec/models/course_module_element_video_spec.rb
+++ b/spec/models/course_module_element_video_spec.rb
@@ -14,6 +14,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe CourseModuleElementVideo do
   let(:cme) { build_stubbed(:course_module_element_video) }
@@ -55,5 +56,9 @@ describe CourseModuleElementVideo do
         expect(cme.parent).to eq(cme.course_module_element)
       end
     end
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'archivable'
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -27,6 +27,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe Group do
   subject { FactoryBot.build(:group) }
@@ -91,5 +92,7 @@ describe Group do
   it { should respond_to(:destroyable?) }
   it { should respond_to(:destroyable_children) }
 
-
+  describe 'Concern' do
+    it_behaves_like 'archivable'
+  end
 end

--- a/spec/models/quiz_answer_spec.rb
+++ b/spec/models/quiz_answer_spec.rb
@@ -12,14 +12,13 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe QuizAnswer do
-
   # Constants
   it { expect(QuizAnswer.const_defined?(:WRONGNESS)).to eq(true) }
 
   # relationships
-
   it { should have_many(:quiz_attempts) }
   it { should have_many(:quiz_contents) }
   it { should belong_to(:quiz_question) }
@@ -46,4 +45,7 @@ describe QuizAnswer do
   it { should respond_to(:destroyable?) }
   it { should respond_to(:destroyable_children) }
 
+  describe 'Concern' do
+    it_behaves_like 'archivable'
+  end
 end

--- a/spec/models/quiz_content_spec.rb
+++ b/spec/models/quiz_content_spec.rb
@@ -18,56 +18,62 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe QuizContent do
-
-  # relationships
-  it { should belong_to(:quiz_answer) }
-  it { should belong_to(:quiz_question) }
-  it { should belong_to(:quiz_solution) }
-
-  # validation
-  # tests for custom-validator 'one_parent_only'
-  context 'if both values set...' do
-    before :each do
-      allow(subject).to receive_messages(quiz_question_id: 1, quiz_answer_id: 1,
-                                         text_content: 'ABC', sorting_order: 1)
-      subject.save!
-      subject.sorting_order = 2
-      subject.valid?
-    end
-
-    it { expect(subject.errors[:base].try(:first)).to eq(I18n.t('models.quiz_content.can_t_assign_to_multiple_things')) }
+  describe 'relationships' do
+    it { should belong_to(:quiz_answer) }
+    it { should belong_to(:quiz_question) }
+    it { should belong_to(:quiz_solution) }
   end
 
-  context 'if neither value set...' do
-    before :each do
-      allow(subject).to receive_messages(quiz_question_id: nil, quiz_answer_id: nil,
-                                         text_content: 'ABC', sorting_order: 1)
-      subject.save!
-      subject.sorting_order = 2
-      subject.valid?
+  describe 'validations' do
+    # tests for custom-validator 'one_parent_only'
+    context 'if both values set...' do
+      before :each do
+        allow(subject).to receive_messages(quiz_question_id: 1, quiz_answer_id: 1,
+                                          text_content: 'ABC', sorting_order: 1)
+        subject.save!
+        subject.sorting_order = 2
+        subject.valid?
+      end
+
+      it { expect(subject.errors[:base].try(:first)).to eq(I18n.t('models.quiz_content.can_t_assign_to_multiple_things')) }
     end
-    it { expect(subject.errors[:base].try(:first)).to eq(I18n.t('models.quiz_content.must_assign_to_at_least_one_thing')) }
+
+    context 'if neither value set...' do
+      before :each do
+        allow(subject).to receive_messages(quiz_question_id: nil, quiz_answer_id: nil,
+                                          text_content: 'ABC', sorting_order: 1)
+        subject.save!
+        subject.sorting_order = 2
+        subject.valid?
+      end
+      it { expect(subject.errors[:base].try(:first)).to eq(I18n.t('models.quiz_content.must_assign_to_at_least_one_thing')) }
+    end
+
+    it { should_not validate_presence_of(:quiz_question_id) }
+    it { should_not validate_presence_of(:quiz_answer_id) }
+    it { should_not validate_presence_of(:quiz_solution_id) }
+    it { should validate_presence_of(:text_content) }
+    it { should validate_presence_of(:sorting_order) }
   end
 
-  it { should_not validate_presence_of(:quiz_question_id) }
-  it { should_not validate_presence_of(:quiz_answer_id) }
-  it { should_not validate_presence_of(:quiz_solution_id) }
-  it { should validate_presence_of(:text_content) }
-  it { should validate_presence_of(:sorting_order) }
+  describe 'callbacks' do
+    it { should callback(:set_default_values).after(:initialize) }
+    it { should callback(:check_dependencies).before(:destroy) }
+  end
 
-  # callbacks
-  it { should callback(:set_default_values).after(:initialize) }
-  it { should callback(:check_dependencies).before(:destroy) }
+  describe 'scopes' do
+    it { expect(QuizContent).to respond_to(:all_in_order) }
+    it { expect(QuizContent).to respond_to(:all_destroyed) }
+  end
 
-  # scopes
-  it { expect(QuizContent).to respond_to(:all_in_order) }
-  it { expect(QuizContent).to respond_to(:all_destroyed) }
+  describe 'methods' do
+    it { should respond_to(:destroyable?) }
+  end
 
-  # class methods
-
-  # instance methods
-  it { should respond_to(:destroyable?) }
-
+  describe 'Concern' do
+    it_behaves_like 'archivable'
+  end
 end

--- a/spec/models/quiz_question_spec.rb
+++ b/spec/models/quiz_question_spec.rb
@@ -15,35 +15,39 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe QuizQuestion do
+  describe 'relationships' do
+    it { should belong_to(:subject_course) }
+    it { should belong_to(:course_module_element) }
+    it { should belong_to(:course_module_element_quiz) }
+    it { should have_many(:quiz_attempts) }
+    it { should have_many(:quiz_answers) }
+    it { should have_many(:quiz_contents) }
+    it { should have_many(:quiz_solutions) }
+  end
 
-  # relationships
-  it { should belong_to(:subject_course) }
-  it { should belong_to(:course_module_element) }
-  it { should belong_to(:course_module_element_quiz) }
-  it { should have_many(:quiz_attempts) }
-  it { should have_many(:quiz_answers) }
-  it { should have_many(:quiz_contents) }
-  it { should have_many(:quiz_solutions) }
+  describe 'validations' do
+   it { should validate_presence_of(:course_module_element_id).on(:update) }
+  end
 
-  # validation
+  describe 'callbacks' do
+    it { should callback(:check_dependencies).before(:destroy) }
+    it { should callback(:set_course_module_element).before(:validation) }
+  end
+  describe 'scopes' do
+    it { expect(QuizQuestion).to respond_to(:all_in_order) }
+    it { expect(QuizQuestion).to respond_to(:in_created_order) }
+    it { expect(QuizQuestion).to respond_to(:all_destroyed) }
+  end
 
-  it { should validate_presence_of(:course_module_element_id).on(:update) }
+  describe 'instance methods' do
+    it { should respond_to(:destroyable?) }
+    it { should respond_to(:destroyable_children) }
+  end
 
-  # callbacks
-  it { should callback(:check_dependencies).before(:destroy) }
-  it { should callback(:set_course_module_element).before(:validation) }
-
-  # scopes
-  it { expect(QuizQuestion).to respond_to(:all_in_order) }
-  it { expect(QuizQuestion).to respond_to(:in_created_order) }
-  it { expect(QuizQuestion).to respond_to(:all_destroyed) }
-
-  # class methods
-
-  # instance methods
-  it { should respond_to(:destroyable?) }
-  it { should respond_to(:destroyable_children) }
-
+  describe 'Concern' do
+    it_behaves_like 'archivable'
+  end
 end

--- a/spec/models/subject_course_spec.rb
+++ b/spec/models/subject_course_spec.rb
@@ -36,13 +36,12 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe SubjectCourse do
-
   describe 'relationships' do
     it { should belong_to(:exam_body) }
     it { should belong_to(:group) }
-
     it { should have_many(:course_tutor_details) }
     it { should have_many(:home_pages) }
     it { should have_many(:subject_course_resources) }
@@ -61,21 +60,15 @@ describe SubjectCourse do
   end
 
   describe 'validations' do
-    # Build a FactoryBot record for Rspec to test the uniqueness validations against
-    subject { FactoryBot.build(:subject_course) }
+    subject { build(:subject_course) }
 
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name) }
-
     it { should validate_presence_of(:name_url) }
     it { should validate_uniqueness_of(:name_url) }
-
     it { should validate_presence_of(:description) }
-
     it { should validate_presence_of(:quiz_pass_rate) }
-
     it { should validate_presence_of(:survey_url) }
-
     it { should validate_presence_of(:group_id) }
   end
 
@@ -107,13 +100,10 @@ describe SubjectCourse do
     it { should respond_to(:valid_children) }
     it { should respond_to(:first_active_child) }
     it { should respond_to(:first_active_cme) }
-
     it { should respond_to(:destroyable?) }
     it { should respond_to(:destroyable_children) }
-
     it { should respond_to(:recalculate_fields) }
     it { should respond_to(:set_count_fields) }
-
     it { should respond_to(:enrolled_user_ids) }
     it { should respond_to(:active_enrollment_user_ids) }
     it { should respond_to(:valid_enrollment_user_ids) }
@@ -122,15 +112,17 @@ describe SubjectCourse do
     it { should respond_to(:percentage_complete_by_user) }
     it { should respond_to(:number_complete_by_user) }
     it { should respond_to(:update_all_course_logs) }
-
     it { should respond_to(:new_enrollments) }
     it { should respond_to(:active_enrollments) }
     it { should respond_to(:expired_enrollments) }
     it { should respond_to(:non_expired_enrollments) }
     it { should respond_to(:completed_enrollments) }
     it { should respond_to(:total_enrollments) }
-
     it { should respond_to(:home_page) }
     it { should respond_to(:duplicate) }
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'archivable'
   end
 end

--- a/spec/models/video_resource_spec.rb
+++ b/spec/models/video_resource_spec.rb
@@ -14,6 +14,7 @@
 #
 
 require 'rails_helper'
+require 'concerns/archivable_spec.rb'
 
 describe VideoResource do
   let(:video) { build(:video_resource) }
@@ -46,5 +47,9 @@ describe VideoResource do
         expect(video).to be_destroyable
       end
     end
+  end
+
+  describe 'Concern' do
+    it_behaves_like 'archivable'
   end
 end

--- a/spec/requests/api/v1/cbes/introduction_pages_controller_spec.rb
+++ b/spec/requests/api/v1/cbes/introduction_pages_controller_spec.rb
@@ -134,5 +134,18 @@ RSpec.describe 'Api::V1::Cbe::IntroductionPagesController', type: :request do
         expect(body['message']).to eq("Page #{introduction_page.id} was deleted.")
       end
     end
+
+    context 'error when try to destroy a not valid CBE introduction_pages' do
+      let(:introduction_page) { create(:cbe_introduction_page, cbe: cbe) }
+
+      before do
+        allow_any_instance_of(Cbe::IntroductionPage).to receive(:destroy).and_return(false)
+        delete "/api/v1/cbes/#{cbe.id}/introduction_pages/#{introduction_page.id}"
+      end
+
+      it 'returns HTTP status 202' do
+        expect(response).to have_http_status 422
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/cbes/questions_controller_spec.rb
+++ b/spec/requests/api/v1/cbes/questions_controller_spec.rb
@@ -370,5 +370,19 @@ RSpec.describe 'Api::V1::Cbe::QuestionsController', type: :request do
         expect(response).to have_http_status 202
       end
     end
+
+    context 'error when try to destroy a not valid CBE question' do
+      let(:cbe_section) { create(:cbe_section, cbe: cbe) }
+      let(:question) { create(:cbe_question, section: cbe_section) }
+
+      before do
+        allow_any_instance_of(Cbe::Question).to receive(:destroy).and_return(false)
+        delete "/api/v1/questions/#{question.id}"
+      end
+
+      it 'returns HTTP status 202' do
+        expect(response).to have_http_status 422
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/cbes/resources_controller_spec.rb
+++ b/spec/requests/api/v1/cbes/resources_controller_spec.rb
@@ -132,5 +132,18 @@ RSpec.describe 'Api::V1::Cbe::ResourcesController', type: :request do
         expect(response).to have_http_status 202
       end
     end
+
+    context 'error when try to destroy a not valid CBE resource' do
+      let(:resource) { create(:cbe_resource, cbe: cbe) }
+
+      before do
+        allow_any_instance_of(Cbe::Resource).to receive(:destroy).and_return(false)
+        delete "/api/v1/cbes/#{cbe.id}/resources/#{resource.id}"
+      end
+
+      it 'returns HTTP status 202' do
+        expect(response).to have_http_status 422
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/cbes/scenarios_controller_spec.rb
+++ b/spec/requests/api/v1/cbes/scenarios_controller_spec.rb
@@ -111,5 +111,18 @@ RSpec.describe 'Api::V1::Cbe::ScenariosController', type: :request do
         expect(response).to have_http_status 202
       end
     end
+
+    context 'error when try to destroy a not valid CBE scenario' do
+      let(:scenario) { create(:cbe_scenario, :with_section) }
+
+      before do
+        allow_any_instance_of(Cbe::Scenario).to receive(:destroy).and_return(false)
+        delete "/api/v1/scenarios/#{scenario.id}"
+      end
+
+      it 'returns HTTP status 202' do
+        expect(response).to have_http_status 422
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/cbes/sections_controller_spec.rb
+++ b/spec/requests/api/v1/cbes/sections_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Api::V1::Cbe::SectionsController', type: :request do
                                                             name
                                                             score
                                                             kind
+                                                            random
                                                             sorting_order
                                                             content
                                                             scenarios
@@ -70,6 +71,7 @@ RSpec.describe 'Api::V1::Cbe::SectionsController', type: :request do
                                                   name
                                                   score
                                                   kind
+                                                  random
                                                   sorting_order
                                                   content
                                                   scenarios
@@ -122,6 +124,7 @@ RSpec.describe 'Api::V1::Cbe::SectionsController', type: :request do
                                                   name
                                                   score
                                                   kind
+                                                  random
                                                   sorting_order
                                                   content
                                                   scenarios
@@ -161,6 +164,20 @@ RSpec.describe 'Api::V1::Cbe::SectionsController', type: :request do
 
       it 'returns HTTP status 202' do
         expect(response).to have_http_status 202
+      end
+    end
+
+    context 'error when try to destroy a not valid CBE section' do
+      let!(:cbe) { create(:cbe) }
+      let(:section) { create(:cbe_section, cbe: cbe) }
+
+      before do
+        allow_any_instance_of(Cbe::Section).to receive(:destroy).and_return(false)
+        delete "/api/v1/sections/#{section.id}"
+      end
+
+      it 'returns HTTP status 202' do
+        expect(response).to have_http_status 422
       end
     end
   end


### PR DESCRIPTION
Use CbeSuppot concern to disable cbe:
* Sections;
* Scenarios;
* Questions;

Add error case in destroy methods in CBE api controllers;
Add tests to archivable concern;
Fix delete question inside scenarios;
Remove archivable concern call from CBE models.
Add specs in each other model which is using it;
Add active scopes in CBE sections, scenarios and questions.
Add random questions options in OT sections;
Add shuffle in questions of random sections;
Apply active scope of section, scenarios and questions to correction and corrected views.
Fix correction status to avoid submit more than one time.