### PR TITLE
FIX: Load balancers don't exist on worker environments.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,8 +111,9 @@ Rails.application.configure do
   }
 
   config.exceptions_app = self.routes
-  config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES +
-                                           ENV['AWS_LOAD_BALANCERS'].split(',').map { |alp| IPAddr.new(alp) }
+  config.action_dispatch.trusted_proxies = 
+    (ActionDispatch::RemoteIp::TRUSTED_PROXIES +
+      ENV['AWS_LOAD_BALANCERS'].split(',').map { |alp| IPAddr.new(alp) }) if ENV['AWS_LOAD_BALANCERS']
 
   config.require_master_key = true
 end


### PR DESCRIPTION
This line throws an error on the workers because they don't have a load balancer.

```
config.action_dispatch.trusted_proxies = 
    (ActionDispatch::RemoteIp::TRUSTED_PROXIES +
      ENV['AWS_LOAD_BALANCERS'].split(',').map { |alp| IPAddr.new(alp) })
```