### PR TITLE
FEATURE: Paypal syncing service

### DIFF
--- a/app/controllers/api/cron_tasks_controller.rb
+++ b/app/controllers/api/cron_tasks_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Api
+  class CronTasksController < Api::BaseController
+    protect_from_forgery except: :create
+    
+    def create
+      CronService.new.initiate_task(params[:id])
+    end
+  end
+end

--- a/app/controllers/cron_tasks_controller.rb
+++ b/app/controllers/cron_tasks_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class CronTasksController < ApplicationController
-  skip_before_action :verify_authenticity_token
-
-  def create
-    CronService.new.initiate_task(params[:id])
-  end
-end

--- a/app/services/cron_service.rb
+++ b/app/services/cron_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CronService
-  TASK_LIST = %w[paypal_sync].freeze
+  TASK_LIST = %w[paypal_sync ping].freeze
 
   def initiate_task(task_name)
     raise(StandardError, "Cron Task #{task_name} is not defined") unless TASK_LIST.include?(task_name)
@@ -9,7 +9,12 @@ class CronService
     send(task_name)
   end
 
+  def ping
+    Rails.logger.info 'CRON: I just got a PING'
+  end
+
   def paypal_sync
     Rails.logger.info "CRON: Called the 'paypal_sync' task"
+    Paypal::SubscriptionValidation.run_paypal_sync
   end
 end

--- a/app/services/paypal/subscription_validation.rb
+++ b/app/services/paypal/subscription_validation.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Paypal
+  class SubscriptionValidation
+    include PayPal::SDK::REST
+
+    class << self
+      def run_paypal_sync
+        Subscription.all_paypal.all_active.each do |sub|
+          new(sub).sync_with_paypal
+        end
+      end
+    end
+
+    def initialize(subscription)
+      @subscription = subscription
+    end
+
+    def sync_with_paypal
+      agreement = Agreement.find(@subscription.paypal_subscription_guid)
+      return if agreement.state == @subscription.paypal_status
+
+      match_with_state(agreement)
+    end
+
+    private
+
+    def match_with_state(agreement)
+      case agreement.state
+      when 'Active'
+        log_to_airbrake unless @subscription.restart
+      when 'Suspended'
+        log_to_airbrake unless @subscription.pause
+      when 'Cancelled'
+        log_to_airbrake unless @subscription.cancel
+      else
+        Airbrake.notify("PAYPAL SYNC ERROR: Weird PayPal state for subscription #{@subscription.id}")
+      end
+    end
+
+    def log_to_airbrake
+      Airbrake.notify("PAYPAL SYNC ERROR: We ran into an error syncing subscription #{@subscription.id} with PayPal")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,12 @@ Rails.application.routes.draw do
 
   get '404' => redirect('404-page')
 
-  post 'cron_tasks/:id', to: 'cron_tasks#create'
-
   # API
   namespace :api do
     post 'stripe_webhooks', to: 'stripe_webhooks#create'
     post 'stripe_v02',      to: 'stripe_webhooks#create'
     post 'paypal_webhooks', to: 'paypal_webhooks#create'
+    post 'cron_tasks/:id',  to: 'cron_tasks#create'
 
     namespace :v1, constraints: ApiConstraint.new(version: 1) do
       resources :subject_courses, only: :index

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,8 @@
 version: 1
 cron:
- - name: "paypal-sync"
-   url: "/cron_tasks/paypal_sync"
+ - name: "ping"
+   url: "/api/cron_tasks/ping"
    schedule: "* * * * *"
+ - name: "paypal-sync"
+   url: "/api/cron_tasks/paypal_sync"
+   schedule: "30 6 * * *"

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -47,6 +47,12 @@ FactoryBot.define do
       stripe_customer_id     { 'cus_1235455' }
     end
 
+    factory :paypal_subscription do
+      sequence(:paypal_subscription_guid) { |n| "sub_DUMMY-#{n}" }
+      paypal_token                        { 'tok_1235455' }
+      paypal_status                       { 'Active' }
+    end
+
     factory :valid_subscription do
       stripe_status        { 'active' }
       active               { true }

--- a/spec/services/cron_service_spec.rb
+++ b/spec/services/cron_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe CronService, type: :service do
+  describe '#initiate_task' do
+    it 'raises an error unless a valid task is called' do
+      expect { subject.initiate_task('test') }.to raise_error(StandardError)
+    end
+
+    it 'calls the instance method of the task passed in' do
+      expect(subject).to receive(:ping)
+
+      subject.initiate_task('ping')
+    end
+  end
+
+  describe '#paypal_sync' do
+    it 'calls #run_paypal_sync on the Paypal::SubscriptionValidation class' do
+      expect(Paypal::SubscriptionValidation).to receive(:run_paypal_sync)
+
+      subject.initiate_task('paypal_sync')
+    end
+  end
+end

--- a/spec/services/paypal/subscription_validation_spec.rb
+++ b/spec/services/paypal/subscription_validation_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Paypal::SubscriptionValidation, type: :service do
+  before :each do
+    allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
+  end
+
+  describe '#sync_with_paypal' do
+    let(:agreement_dbl) {
+      double(
+        'Agreement',
+        id: 'I-ERW92H1T8T1ST',
+        state: 'Active'
+      )
+    }
+    let(:subscription) { create(:paypal_subscription, paypal_status: 'Active') }
+    let(:other_sub) { create(:paypal_subscription, paypal_status: 'Cancelled') }
+    let(:good_instance) { Paypal::SubscriptionValidation.new(subscription) }
+    let(:bad_instance) { Paypal::SubscriptionValidation.new(other_sub) }
+
+    it 'returns NIL if the PayPal agreement has the same state as the subscription' do
+      allow(PayPal::SDK::REST::DataTypes::Agreement).to receive(:find).and_return(agreement_dbl)
+
+      expect(good_instance.sync_with_paypal).to be nil
+    end
+
+    it 'calls #match_with_state if the state does not match' do
+      allow(PayPal::SDK::REST::DataTypes::Agreement).to receive(:find).and_return(agreement_dbl)
+      expect(bad_instance).to receive(:match_with_state).with(agreement_dbl)
+
+      bad_instance.sync_with_paypal
+    end
+  end
+end


### PR DESCRIPTION
Specific cron tasks for syncing with PayPal

* Moving cron tasks to the API namespace.
* Paypal syncing tasks and moved cron_tasks_controller to api only.
* Cron schedule setup.