### PR TITLE
FIX: IP Addresses and geocoding user countries

### DIFF
--- a/app/models/ip_address.rb
+++ b/app/models/ip_address.rb
@@ -14,11 +14,11 @@
 #
 
 class IpAddress < ApplicationRecord
-
   geocoded_by :ip_address
-  reverse_geocoded_by :latitude, :longitude do |obj,results|
-    if geo = results.first
-      obj.country_id = Country.find_by_iso_code(geo.country_code).try(:id) || 78
+
+  reverse_geocoded_by :latitude, :longitude do |obj, results|
+    if (geo = results.first)
+      obj.country_id = Country.find_by(iso_code: geo.country_code)&.id || 78
     else
       obj.country_id = 78 # UK
     end

--- a/db/migrate/20200323161559_remove_rechecked_on_from_ip_addresses.rb
+++ b/db/migrate/20200323161559_remove_rechecked_on_from_ip_addresses.rb
@@ -1,0 +1,5 @@
+class RemoveRecheckedOnFromIpAddresses < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :ip_addresses, :rechecked_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_05_095226) do
+ActiveRecord::Schema.define(version: 2020_03_23_161559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -435,9 +435,9 @@ ActiveRecord::Schema.define(version: 2020_03_05_095226) do
     t.boolean "is_video", default: false, null: false
     t.boolean "is_quiz", default: false, null: false
     t.boolean "active", default: true, null: false
-    t.datetime "destroyed_at"
-    t.string "seo_description"
+    t.string "seo_description", limit: 255
     t.boolean "seo_no_index", default: false
+    t.datetime "destroyed_at"
     t.integer "number_of_questions", default: 0
     t.float "duration", default: 0.0
     t.string "temporary_label"
@@ -458,9 +458,9 @@ ActiveRecord::Schema.define(version: 2020_03_05_095226) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cme_count", default: 0
-    t.datetime "destroyed_at"
-    t.string "seo_description"
+    t.string "seo_description", limit: 255
     t.boolean "seo_no_index", default: false
+    t.datetime "destroyed_at"
     t.integer "number_of_questions", default: 0
     t.integer "subject_course_id"
     t.float "video_duration", default: 0.0
@@ -839,7 +839,6 @@ ActiveRecord::Schema.define(version: 2020_03_05_095226) do
     t.integer "alert_level"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "rechecked_on"
     t.index ["country_id"], name: "index_ip_addresses_on_country_id"
   end
 


### PR DESCRIPTION
Two rake tasks added:
1. `ip_address:cleanup` deletes all IP addresses for IE or UK before 01/08/2019 or after 29/02/2020.
2. `ip_address:assign_countries` checks the country assigned to every user and, if the country doesn't match the value of the last Ahoy::Visit, then it updates it accordingly.