### PR TITLE
FIX: Overriding the authlogic CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -382,4 +382,10 @@ class ApplicationController < ActionController::Base
     @tag_manager_course = course
   end
   helper_method :tag_manager_data_layer
+
+  private
+
+  def handle_unverified_request
+    log_out_user
+  end
 end


### PR DESCRIPTION
So that current_user_session is available to Authlogic.