### PR TITLE
FEATURE: Change user currency from admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -171,7 +171,7 @@ class UsersController < ApplicationController
   def allowed_params
     params.require(:user).permit(:email, :first_name, :last_name, :user_group_id, :address, :country_id,
                                  :profile_image, :date_of_birth, :description, :student_number, :name_url,
-                                 :stripe_account_balance, :preferred_exam_body_id,
+                                 :stripe_account_balance, :preferred_exam_body_id, :currency_id,
                                  student_access_attributes: [:id, :account_type])
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -107,6 +107,7 @@ class Order < ApplicationRecord
 
   def self.send_daily_orders_update
     return if (orders = orders_completed_in_time(24.hours.ago)) && orders.empty?
+
     slack = SlackService.new
     slack.notify_channel('corrections', slack.order_summary_attachment(orders),
                          icon_emoji: ':chart_with_upwards_trend:')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,6 +337,11 @@ class User < ApplicationRecord
     UserCountryWorker.perform_async(self.id, ip_address)
   end
 
+  def currency_locked?
+    subscriptions.where.not(stripe_guid: nil).any? ||
+      orders.where.not(stripe_customer_id: nil).any?
+  end
+
   ## UserGroup Access methods
   def student_user?
     user_group&.student_user

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -22,7 +22,7 @@ class SubscriptionService
     @coupon = Coupon.get_and_verify(coupon_code, @subscription.subscription_plan_id)
     return if @coupon
 
-    raise Learnsignal::SubscriptionError.new('Sorry! That is not a valid coupon code.')
+    raise Learnsignal::SubscriptionError, 'Sorry! That is not a valid coupon code.'
   end
 
   def un_cancel
@@ -62,7 +62,7 @@ class SubscriptionService
   def check_valid_subscription?(params)
     return true if valid_paypal_subscription?(params) || valid_stripe_subscription?(params)
 
-    raise Learnsignal::SubscriptionError.new('Sorry! The data entered is not valid. Please contact us for assistance.')
+    raise Learnsignal::SubscriptionError, 'Sorry! The data entered is not valid. Please contact us for assistance.'
   end
 
   def validate_referral

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -35,6 +35,13 @@
           =f.label :date_of_birth, t('views.users.form.date_of_birth')
           .input-group.input-group-lg
             =f.text_field :date_of_birth, placeholder: t('views.users.form.date_of_birth_placeholder'), class: 'form-control', data: {'date-format' => t('controllers.application.datepicker_datetime_format')}, id: 'datetimepicker'
+    
+    .row
+      .col-sm-6
+        .form-group
+          =f.label :currency
+          .input-group.input-group-lg
+            =f.collection_select :currency_id, Currency.all, :id, :name, {}, {class: 'form-control custom-select', disabled: @user.currency_locked? }
 
 
     #tutor-info.pt-4

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -180,7 +180,7 @@ describe Order do
 
     it 'doesn not call slack when there are no relevant orders' do
       create_list(:order, 3, state: 'completed', product: mock_product,
-                  created_at: 2.days.ago)
+                             created_at: 2.days.ago)
 
       expect_any_instance_of(SlackService).not_to receive(:notify_channel)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -386,5 +386,29 @@ describe User do
         expect(data_users[rand_count].split(',').third).to eq(data_parsed[rand_count].last_name)
       end
     end
+
+    describe '#currency_locked?' do
+      let(:user) { create(:user) }
+
+      before :each do
+        allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
+      end
+
+      it 'returns FALSE if there are no Stripe subscriptions or orders for a user' do
+        expect(user.currency_locked?).to be_falsy
+      end
+
+      it 'returns TRUE if there are any Stripe subscriptions' do
+        create(:stripe_subscription, user: user)
+
+        expect(user.currency_locked?).to be_truthy
+      end
+
+      it 'returns TRUE if there are any Stripe orders' do
+        create(:order, :for_stripe, user: user)
+
+        expect(user.currency_locked?).to be_truthy
+      end
+    end
   end
 end

--- a/spec/services/subscription_service_spec.rb
+++ b/spec/services/subscription_service_spec.rb
@@ -32,7 +32,43 @@ describe SubscriptionService, type: :service do
   end
 
   describe '#check_for_valid_coupon?' do
-    it 'does stuff'
+    it 'returns NIL if the coupon code is blank' do
+      expect(sub_service.check_for_valid_coupon?('')).to be nil
+    end
+
+    it 'raises an error if no coupon matches the code' do
+      allow(Coupon).to receive(:get_and_verify).and_return(nil)
+
+      expect { sub_service.check_for_valid_coupon?('code') }.to raise_error
+    end
+
+    it 'returns NIL if a valid coupon is present' do
+      allow(Coupon).to receive(:get_and_verify).and_return(true)
+
+      expect(sub_service.check_for_valid_coupon?('code')).to be nil
+    end
+  end
+
+  describe '#check_valid_subscription?' do
+    it 'returns TRUE if the #valid_paypal_subscription? is true' do
+      allow(sub_service).to receive(:valid_paypal_subscription?).and_return(true)
+
+      expect(sub_service.check_valid_subscription?({})).to be_truthy
+    end
+
+    it 'returns TRUE if the #valid_stripe_subscription? is true' do
+      allow(sub_service).to receive(:valid_paypal_subscription?).and_return(false)
+      allow(sub_service).to receive(:valid_stripe_subscription?).and_return(true)
+
+      expect(sub_service.check_valid_subscription?({})).to be_truthy
+    end
+
+    it 'raises an error if neither #valid_paypal_subscription? or #valid_stripe_subscription? return true' do
+      allow(sub_service).to receive(:valid_paypal_subscription?).and_return(false)
+      allow(sub_service).to receive(:valid_stripe_subscription?).and_return(false)
+
+      expect { sub_service.check_valid_subscription?({}) }.to raise_error
+    end
   end
 
   describe '#un_cancel' do


### PR DESCRIPTION
Before they attempt a Stripe payment!

Looking for your thoughts on this one @JamesMacRedmond. 

From what I can see, all of the failed payment attempts for subscriptions (like [this one](https://dashboard.stripe.com/invoices/in_H2JRkDPByVcdGI)) leave a `pending` subscription attached to `User` on our side. So in order to decide if the option to change currency for a user should be disabled, I'm querying for any **Stripe** subscriptions attached to the user (in any state).

In terms of the **Order** objects created by attempted purchases of mock exams, I'm not certain that we have something to reference for failed payments (i.e. a pending order, although I have found some of these attached to users). 