### PR TITLE
FIX: Authlogic airbrake error - authlogic session.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,11 +27,15 @@ class ApplicationController < ActionController::Base
   ### User access control and authentication
 
   def current_user_session
-    @current_user_session ||= UserSession.find
+    return @current_user_session if defined?(@current_user_session)
+
+    @current_user_session = UserSession.find
   end
 
   def current_user
-    @current_user ||= current_user_session&.record
+    return @current_user if defined?(@current_user)
+
+    @current_user = current_user_session&.record
   end
 
   def log_out_user


### PR DESCRIPTION
Airbrake listed [here](https://learnsignal.airbrake.io/projects/107826/groups/2711724839404775892?tab=notice-detail). 

Just reverting some of the changes we introduced to remove the previous CSRF error.