### PR TITLE
FIX: Airbrake for missing product when creating on stripe.

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -58,8 +58,8 @@ class Product < ApplicationRecord
                                                     greater_than: 0 }, if: :correction_pack?
 
   # callbacks
-  after_create :create_on_stripe
-  after_update :update_on_stripe
+  after_commit :create_on_stripe, on: :create
+  after_commit :update_on_stripe, on: :update
 
   # scopes
   scope :all_in_order,  -> { order(:sorting_order, :name) }

--- a/app/workers/stripe_product_worker.rb
+++ b/app/workers/stripe_product_worker.rb
@@ -2,7 +2,6 @@
 
 class StripeProductWorker
   include Sidekiq::Worker
-
   sidekiq_options queue: 'medium'
 
   def perform(product_id, action)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -70,10 +70,6 @@ describe Product do
   it { should validate_presence_of(:stripe_guid).on(:update) }
   it { should validate_presence_of(:stripe_sku_guid).on(:update) }
 
-  # callbacks
-  it { should callback(:create_on_stripe).after(:create) }
-  it { should callback(:update_on_stripe).after(:update) }
-
   # scopes
   it { expect(Product).to respond_to(:all_in_order) }
   it { expect(Product).to respond_to(:all_active) }
@@ -84,6 +80,21 @@ describe Product do
   # class methods
   it { expect(Product).to respond_to(:search) }
   it { expect(Product).to respond_to(:filter_by_state) }
+
+  describe 'callbacks' do
+    it 'calls create_on_stripe after a record is created' do
+      expect_any_instance_of(Product).to receive(:create_on_stripe)
+
+      create(:product)
+    end
+
+    it 'calls update_on_stripe after a record is updated' do
+      product = create(:product)
+      expect_any_instance_of(Product).to receive(:update_on_stripe)
+
+      product.update(name: 'New Name')
+    end
+  end
 
   describe 'Methods' do
     before do


### PR DESCRIPTION
https://learnsignal.airbrake.io/projects/107826/groups/2713294525632293418?tab=notice-detail

Most likely this is being caused by the `after_create` hook firing too fast for the DB transaction to be unlocked. So it's not finding the product. Have introduced a 10 second delay to the calling of the worker as well as a fallback slack notification if it still fails.