### PR TITLE
FIX: Airbrake invoice format.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,7 +163,7 @@ Rails.application.routes.draw do
     resource :preferred_exam_body, only: %i[edit update]
 
     resources :invoices, only: %i[show update] do
-      get 'pdf', action: :pdf, on: :member
+      get :pdf, on: :member, defaults: { format: 'pdf' }
     end
 
     # Internal Landing Pages - post sign-up or upgrade or purchase


### PR DESCRIPTION
Fix for [this](https://learnsignal.airbrake.io/projects/107826/groups/2708988677573519547?tab=notice-detail) Airbrake.

Just instituted a default format for the action.