### PR TITLE
FIX: CBE UI not updating properly after editing or deleting a resource file.

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -2,7 +2,8 @@
 
 module Api
   module V1
-    class ApplicationController < ActionController::API
+    class ApplicationController < ActionController::Base
+      protect_from_forgery unless: -> { request.format.json? }
     end
   end
 end

--- a/app/javascript/components/cbe/admin/Resource.vue
+++ b/app/javascript/components/cbe/admin/Resource.vue
@@ -206,7 +206,9 @@ export default {
           method: 'post',
           url: `/api/v1/cbes/${this.$store.state.cbeId}/resources`,
           data: formData,
-          config: { headers: { 'Content-Type': 'multipart/form-data' } },
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
         })
           .then(response => {
             this.resourceDetails = response.data;
@@ -243,7 +245,10 @@ export default {
           method: 'patch',
           url: `/api/v1/cbes/${this.$store.state.cbeId}/resources/${this.id}`,
           data: formData,
-          config: { headers: { 'Content-Type': 'multipart/form-data' } },
+          headers: {
+            'Content-Type': 'multipart/form-data',
+            'X-CSRF-Token': document.getElementsByTagName('meta')['csrf-token'].getAttribute('content')
+          },
         })
           .then(response => {
             this.updateStatus = 'OK';
@@ -269,17 +274,18 @@ export default {
         } else {
           this.deleteStatus = 'PENDING';
           const resourceId = this.id;
-          axios
-            .delete(`/api/v1/cbes/${this.$store.state.cbeId}/resources/${resourceId}`)
-            .then(response => {
-              this.$emit('rm-resource', resourceId);
-              this.updateStatus = 'OK';
-              this.$v.$reset();
-            })
-            .catch(error => {
-              this.updateStatus = 'ERROR';
-              console.log(error);
-            });
+          axios({
+            method: 'delete',
+            url: `/api/v1/cbes/${this.$store.state.cbeId}/resources/${resourceId}`,
+          }).then(response => {
+            this.$emit('rm-resource', resourceId);
+            this.updateStatus = 'OK';
+            this.$v.$reset();
+          })
+          .catch(error => {
+            this.updateStatus = 'ERROR';
+            console.log(error);
+          });
         }
       }
     },

--- a/app/javascript/components/cbe/admin/Resources.vue
+++ b/app/javascript/components/cbe/admin/Resources.vue
@@ -8,7 +8,7 @@
         :initial-name="resource.name"
         :initial-file="resource.file"
         :initial-sorting-order="resource.sorting_order"
-        @rm-resource="$emit('rm-resource', resourceId)"
+        @rm-resource="(resourceId) => $emit('rm-resource', resourceId)"
       />
       <Resource
         :initial-sorting-order="sortingOrderValue(resources)"


### PR DESCRIPTION
We were missing the CSRF tag on the requests to update or delete a resources for a CBE. This was causing flakey behaviour when editing resources (it still works sometimes for some reason). Anyway, CSRF tag is in place for all resource CRUD.

There was also a propagation issue with the emitted event for removal of a resource. The resource was deleted on the server but this wasn't reflected on the UI so the user (Alan in [this case](https://learnsignal.airbrake.io/projects/107826/groups/2718968901509787313/notices/2718969013196889817?tab=notice-detail)) would keep trying to update / delete the resource.