### PR TITLE
Updated the ExamSittings worker

### DIFF
--- a/app/models/exam_sitting.rb
+++ b/app/models/exam_sitting.rb
@@ -54,7 +54,7 @@ class ExamSitting < ApplicationRecord
   end
 
   def formatted_date
-    self.computer_based ? 'Computer Based Exam' : date.strftime("%B %Y")
+    computer_based ? 'Computer Based Exam' : date.strftime("%B %Y")
   end
 
   protected
@@ -68,7 +68,9 @@ class ExamSitting < ApplicationRecord
   end
 
   def create_expiration_worker
-    ExamSittingExpirationWorker.perform_at(self.date.to_datetime + 23.hours, self.id) unless Rails.env.test?
+    return if Rails.env.test?
+
+    ExamSittingExpirationWorker.perform_at(date.to_datetime + 23.hours, id)
   end
 
 end

--- a/app/views/exam_sittings/_form.html.haml
+++ b/app/views/exam_sittings/_form.html.haml
@@ -25,6 +25,11 @@
             =f.label :date, t('views.exam_sittings.form.date')
             .input-group.input-group-lg
               =f.text_field :date, placeholder: t('views.exam_sittings.form.date_placeholder'), class: 'form-control', data: {'date-format' => t('controllers.application.datepicker_datetime_format')}, id: 'datetimepicker'
+        -else
+          .form-group
+            =f.label :date, t('views.exam_sittings.form.date')
+            .input-group.input-group-lg
+              =f.text_field :date, placeholder: t('views.exam_sittings.form.date_placeholder'), class: 'form-control', data: {'date-format' => t('controllers.application.datepicker_datetime_format')}, id: 'datetimepicker', readonly: true
 
         .col-sm-12
           .col-sm-6

--- a/app/workers/exam_sitting_expiration_worker.rb
+++ b/app/workers/exam_sitting_expiration_worker.rb
@@ -5,11 +5,16 @@ class ExamSittingExpirationWorker
 
   def perform(exam_sitting_id)
     sitting = ExamSitting.find(exam_sitting_id)
-    if sitting && sitting.date
+
+    return unless sitting
+
+    if Time.now.in_time_zone.to_date >= sitting.date
       sitting.update_attribute(:active, false)
       sitting.enrollments.each do |enrollment|
         EnrollmentExpirationWorker.perform_async(enrollment.id)
       end
+    else
+      ExamSittingExpirationWorker.perform_at(sitting.date.to_datetime + 23.hours, sitting.id)
     end
   end
 


### PR DESCRIPTION
Updated the ExamSittings worker to ensure it only deactivates the sitting if the sitting date is in the past; otherwise it creates a new sitting worker. This is to allow for the editing of ExamSitting expiration dates.