### PR TITLE
FIX: Updating plans on stripe

### DIFF
--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -58,7 +58,7 @@ class SubscriptionPlan < ApplicationRecord
   # callbacks
   before_validation :generate_guid, on: :create
   after_create :create_remote_plans
-  after_update :update_remote_plans, if: :name_changed?
+  after_update :update_remote_plans, if: :name_previously_changed?
   after_destroy :delete_remote_plans
 
   # scopes

--- a/spec/models/subscription_plan_spec.rb
+++ b/spec/models/subscription_plan_spec.rb
@@ -73,11 +73,34 @@ describe SubscriptionPlan, type: :model do
   end
 
   describe 'callbacks' do
+    before :each do
+      allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
+    end
+
     it { should callback(:check_dependencies).before(:destroy) }
+
+    it 'calls #create_remote_plans after creation' do
+      expect_any_instance_of(SubscriptionPlan).to receive(:create_remote_plans)
+
+      create(:subscription_plan)
+    end
+
+    it 'calls #update_remote_plans after updating the name of the plan' do
+      plan = create(:subscription_plan)
+      expect(plan).to receive(:update_remote_plans)
+
+      plan.update(name: 'New Name')
+    end
+
+    it 'does not call #update_remote_plans if the name is not updated' do
+      plan = create(:subscription_plan)
+      expect(plan).not_to receive(:update_remote_plans)
+
+      plan.update(payment_frequency_in_months: 400)
+    end
   end
 
   describe 'class methods' do
-
     before :each do
       allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
     end


### PR DESCRIPTION
This issue was elated to the Rails 5 upgrade where ActiveModel::Dirty changed the `attribute_changed?` behaviour. I'm logging a task on Monday.com to track any other occurrences that may be affected in the same way. I think we reviewed this at the time but obviously missed this one.