### PR TITLE
Fixed issues with quiz results order & admin form questions order

### DIFF
--- a/app/controllers/admin/course_steps_controller.rb
+++ b/app/controllers/admin/course_steps_controller.rb
@@ -64,6 +64,7 @@ module Admin
         cm = @course_step.parent
         if @course_step.is_quiz
           @course_step.course_quiz.add_an_empty_question
+          @quiz_questions = @course_step&.course_quiz&.quiz_questions&.all_in_order
         elsif @course_step.is_video
           @course_step.build_video_resource unless @course_step.video_resource
         elsif @course_step.is_constructed_response

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -231,9 +231,9 @@ class CoursesController < ApplicationController
     @number_of_questions = @course_step.course_quiz.number_of_questions
     @quiz_questions      =
       if @strategy == 'random'
-        @course_step.course_quiz.quiz_questions.includes(:quiz_contents).shuffle.take(@number_of_questions)
+        @course_step.course_quiz.quiz_questions.all_in_order.includes(:quiz_contents).shuffle.take(@number_of_questions)
       else
-        @course_step.course_quiz.quiz_questions.includes(:quiz_contents).take(@number_of_questions)
+        @course_step.course_quiz.quiz_questions.all_in_order.includes(:quiz_contents).take(@number_of_questions)
       end
   end
 

--- a/app/models/course_quiz.rb
+++ b/app/models/course_quiz.rb
@@ -39,6 +39,14 @@ class CourseQuiz < ApplicationRecord
   # class methods
 
   # instance methods
+  def parent
+    course_step
+  end
+
+  def children
+    quiz_questions
+  end
+
   def duplicate
     new_cme_quiz =
       deep_clone include: [

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -41,6 +41,7 @@ class QuizQuestion < ApplicationRecord
 
   # callbacks
   before_validation :set_course_step
+  before_create :set_sorting_order
 
   # scopes
   scope :all_in_order, -> { order(:sorting_order) }
@@ -49,6 +50,16 @@ class QuizQuestion < ApplicationRecord
   # class methods
 
   # instance methods
+
+  ## Parent & Child associations ##
+
+  def parent
+    course_quiz
+  end
+
+  def children
+    quiz_answers
+  end
 
   ## Archivable methods ##
   def destroyable?

--- a/app/views/admin/course_quizzes/_fields_for_question.html.haml
+++ b/app/views/admin/course_quizzes/_fields_for_question.html.haml
@@ -1,3 +1,3 @@
 =f.fields_for :course_quiz do |cme_quiz|
-  =cme_quiz.fields_for :quiz_questions do |question|
+  =cme_quiz.fields_for :quiz_questions, @quiz_questions do |question|
     =render partial: 'admin/course_quizzes/fields_for_standard_question', locals: {f: f, question: question, parent: cme_quiz, mode: 'full'}

--- a/app/views/admin/course_quizzes/_fields_for_standard_question.html.haml
+++ b/app/views/admin/course_quizzes/_fields_for_standard_question.html.haml
@@ -24,7 +24,8 @@
 
           .col-sm-8
             -counter = 0
-            =question.fields_for :quiz_answers do |answer|
+            -answers = question.object&.quiz_answers.order(id: :asc)
+            =question.fields_for :quiz_answers, answers do |answer|
               .row.quiz_answer
                 .col-sm-8
                   .row

--- a/app/views/courses/_show_results.html.haml
+++ b/app/views/courses/_show_results.html.haml
@@ -18,7 +18,7 @@
           =@course_step_log.quiz_attempts.where(correct: true).count
           &#47;
           =@course_step_log.quiz_attempts.count
-        -@course_step_log.quiz_attempts.each_with_index do |attempt, counter|
+        -@course_step_log.quiz_attempts.order(id: :asc).each_with_index do |attempt, counter|
           .answer.mt-2{class: attempt.correct ? 'answer-correct' : 'answer-failed', id: "#{counter}", onclick: 'showSolution.call(this); return false;'}
             %p.text-inline.text-bold Question #{counter + 1}
             %i.text-inline{style: 'font-size: 25px; float: right'}=tick_or_cross attempt.try(:correct)
@@ -53,7 +53,7 @@
 
 
 
-      -@course_step_log.quiz_attempts.each_with_index do |attempt, counter|
+      -@course_step_log.quiz_attempts.order(id: :asc).each_with_index do |attempt, counter|
         -if attempt
           =render partial: 'courses/show_solution', locals: {attempt: attempt, counter: counter}
 

--- a/spec/models/course_quiz_spec.rb
+++ b/spec/models/course_quiz_spec.rb
@@ -41,6 +41,8 @@ describe CourseQuiz do
   end
 
   describe 'instance methods' do
+    it { should respond_to(:parent) }
+    it { should respond_to(:children) }
     it { should respond_to(:enough_questions?) }
     it { should respond_to(:add_an_empty_question) }
     it { should respond_to(:all_ids_random) }

--- a/spec/models/quiz_question_spec.rb
+++ b/spec/models/quiz_question_spec.rb
@@ -35,6 +35,7 @@ describe QuizQuestion do
   describe 'callbacks' do
     it { should callback(:check_dependencies).before(:destroy) }
     it { should callback(:set_course_step).before(:validation) }
+    it { should callback(:set_sorting_order).before(:create) }
   end
   describe 'scopes' do
     it { expect(QuizQuestion).to respond_to(:all_in_order) }
@@ -43,6 +44,8 @@ describe QuizQuestion do
   end
 
   describe 'instance methods' do
+    it { should respond_to(:parent) }
+    it { should respond_to(:children) }
     it { should respond_to(:destroyable?) }
     it { should respond_to(:destroyable_children) }
   end


### PR DESCRIPTION
Fixed issues with quiz results order showing as reversed and the questions and answers orders on admin edit form:
 * Added order to QuizAttempts on results page. Since changed to be created by AJAX per questions the order was reversed.
 * Added the parent and children methods to CourseQuiz & QuizQuestion models to allow the set_sorting_order callback in LearnSignalModelExtras the used. Ensured the admin forms correctly render the edit for Questions and Answers using the sorting order.
 * Added model specs for new methods and callbacks