### PR TITLE
Fixed issue with ConstructedResponse spreadsheet answer not saving.

### DIFF
--- a/app/views/courses/_constructed_response.html.haml
+++ b/app/views/courses/_constructed_response.html.haml
@@ -407,6 +407,11 @@
     $('.submission-pane-content').removeClass('hidden d-none');
     closeNavDialog();
     closeScratchPadDialog();
+
+    $('.answer_spreadsheet').each(function (index, value){
+      updateHiddenField($(this).attr('sq_attempt_id'), $(this).attr('sa_attempt_id'))
+    });
+
     submitForm();
   };
 


### PR DESCRIPTION
The issue here was that the Constructed Responses are being created with just one question. SO students were not clicking on the next button but going straight to the submission page. By not clicking the next button the spreadsheet data wasn't update into the hidden field.

This fix is not ideal but it will do for now, as we'll be replacing this ConstructedResponse feature with a new Vue.js version soon.