### PR TITLE
FIX: CRON errors (PayPal and Exercises)

### DIFF
--- a/app/controllers/api/cron_tasks_controller.rb
+++ b/app/controllers/api/cron_tasks_controller.rb
@@ -6,6 +6,7 @@ module Api
 
     def create
       CronService.new.initiate_task(params[:id])
+      head :no_content
     end
   end
 end

--- a/app/services/cron_service.rb
+++ b/app/services/cron_service.rb
@@ -9,10 +9,6 @@ class CronService
     send(task_name)
   end
 
-  def ping
-    Rails.logger.info 'CRON: I just got a PING'
-  end
-
   def paypal_sync
     Rails.logger.info "CRON: Called the 'paypal_sync' task"
     Paypal::SubscriptionValidation.run_paypal_sync

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -17,11 +17,9 @@ class SlackService
        title: 'Daily Orders Summary (Last 24hrs)',
        color: '#7CD197',
        fields: [
-         { title: 'Mock Exams', value: orders.product_type_count('mock_exam'),
-           short: true },
-         { title: 'General Corrections',
-           value: orders.product_type_count('correction_pack'),
-           short: true }
+         { title: 'Mock Exams', value: orders.product_type_count('mock_exam'), short: true },
+         { title: 'General Corrections', value: orders.product_type_count('correction_pack'), short: true },
+         { title: 'CBE', value: orders.product_type_count('cbe'), short: true }
        ] }]
   end
 

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,8 +1,5 @@
 version: 1
 cron:
- - name: "ping"
-   url: "/api/cron_tasks/ping"
-   schedule: "* * * * *"
  - name: "paypal-sync"
    url: "/api/cron_tasks/paypal_sync"
    schedule: "30 6 * * *"

--- a/spec/services/cron_service_spec.rb
+++ b/spec/services/cron_service_spec.rb
@@ -7,9 +7,9 @@ describe CronService, type: :service do
     end
 
     it 'calls the instance method of the task passed in' do
-      expect(subject).to receive(:ping)
+      expect(subject).to receive(:paypal_sync)
 
-      subject.initiate_task('ping')
+      subject.initiate_task('paypal_sync')
     end
   end
 


### PR DESCRIPTION
Once this goes onto `production`, we'll need to purge the queue with the existing tasks (and dead letter queue) in order to  bring the health of the worker back up to green. 

I made some changes to the Slack CRON job for the exercises as well but not sure if they will limit the number of pushes to slack. We'll see once it hits production as I couldn't recreate from our side without pushing stuff to `prod`. The reason they were all showing as zero was because a new type of exercise was introduced, **CBE**, so I have added that to the output now.