### PR TITLE
FIX: Returning correct status code for CRON tasks.

### DIFF
--- a/app/controllers/api/cron_tasks_controller.rb
+++ b/app/controllers/api/cron_tasks_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     def create
       CronService.new.initiate_task(params[:id])
-      head :no_content
+      head :ok
     end
   end
 end

--- a/spec/controllers/api/cron_tasks_controller_spec.rb
+++ b/spec/controllers/api/cron_tasks_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Api::CronTasksController, type: :controller do
+  describe 'POST #create' do
+    describe 'with a valid message' do
+      it 'creates a new instance of PaypalWebhookService' do
+        expect_any_instance_of(CronService).to receive(:initiate_task).with('test_task')
+
+        post :create, params: { id: 'test_task' }
+      end
+
+      it 'returns 200 Ok' do
+        allow(CronService).to receive(:new).and_return(double(initiate_task: true))
+
+        post :create, params: { id: 'test_task' }
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just looked at this earlier this morn when I saw the slack CRON messages coming in again. Everything was running fine but because the controller was returning 204 instead of 200 to the worker queue, it was logging it as an error and retrying.