### PR TITLE
REFACTOR: The dreaded User model

### DIFF
--- a/app/models/concerns/user_accessable.rb
+++ b/app/models/concerns/user_accessable.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module UserAccessable
+  extend ActiveSupport::Concern
+
+  def student_user?
+    user_group&.student_user
+  end
+
+  def non_student_user?
+    !user_group&.student_user
+  end
+
+  def standard_student_user?
+    student_user? && user_group&.trial_or_sub_required
+  end
+
+  def complimentary_user?
+    user_group&.student_user && !user_group&.trial_or_sub_required
+  end
+
+  def non_verified_user?
+    !email_verified && email_verification_code
+  end
+
+  def blocked_user?
+    user_group&.blocked_user
+  end
+
+  def system_requirements_access?
+    user_group&.system_requirements_access
+  end
+
+  def tutor_user?
+    user_group&.tutor
+  end
+
+  def content_management_access?
+    user_group&.content_management_access
+  end
+
+  def exercise_corrections_access?
+    user_group&.exercise_corrections_access
+  end
+
+  def stripe_management_access?
+    user_group&.stripe_management_access
+  end
+
+  def user_management_access?
+    user_group&.user_management_access
+  end
+
+  def developer_access?
+    user_group&.developer_access
+  end
+
+  def marketing_resources_access?
+    user_group&.marketing_resources_access
+  end
+
+  def user_group_management_access?
+    user_group&.user_group_management_access
+  end
+
+  def admin?
+    user_group_management_access? && developer_access? && system_requirements_access?
+  end
+
+  def referred_user?
+    student_user? && referred_signup
+  end
+end

--- a/spec/concerns/user_accessable_spec.rb
+++ b/spec/concerns/user_accessable_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'user_accessable' do
+  let(:user) { create(:user) }
+
+  describe '#student_user?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.student_user?).to be_falsey
+    end
+
+    it 'returns TRUE for a student_user user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.student_user?).to be_truthy
+    end
+
+    it 'returns FALSE for a non student_user user_group' do
+      user = build_stubbed(:tutor_user)
+
+      expect(user.student_user?).to be_falsey
+    end
+  end
+
+  describe '#non_student_user?' do
+    it 'returns TRUE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.non_student_user?).to be_truthy
+    end
+
+    it 'returns TRUE for a non_student_user user_group' do
+      user = build_stubbed(:tutor_user)
+
+      expect(user.non_student_user?).to be_truthy
+    end
+
+    it 'returns FALSE for a student_user user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.non_student_user?).to be_falsey
+    end
+  end
+
+  describe '#standard_student_user?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.standard_student_user?).to be_falsey
+    end
+
+    it 'returns FALSE for a non student_user' do
+      user = build_stubbed(:tutor_user)
+
+      expect(user.standard_student_user?).to be_falsey
+    end
+
+    it 'returns FALSE for a student_user if the user_group does not have trial_or_sub_required' do
+      group = build_stubbed(:student_user_group, trial_or_sub_required: false)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.standard_student_user?).to be_falsey
+    end
+
+    it 'returns TRUE for a student_user if the user_group has trial_or_sub_required' do
+      group = build_stubbed(:student_user_group, trial_or_sub_required: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.standard_student_user?).to be_truthy
+    end
+  end
+
+  describe '#complimentary_user?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.complimentary_user?).to be_falsey
+    end
+
+    it 'returns FALSE for a non student_user' do
+      user = build_stubbed(:tutor_user)
+
+      expect(user.complimentary_user?).to be_falsey
+    end
+
+    it 'returns TRUE for a student_user if the user_group does not have trial_or_sub_required' do
+      group = build_stubbed(:student_user_group, trial_or_sub_required: false)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.complimentary_user?).to be_truthy
+    end
+
+    it 'returns FALSE for a student_user if the user_group has trial_or_sub_required' do
+      group = build_stubbed(:student_user_group, trial_or_sub_required: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.complimentary_user?).to be_falsey
+    end
+  end
+
+  describe '#non_verified_user?' do
+    it 'returns TRUE if email_verified is FALSE and an email_verification_code exists' do
+      user = build_stubbed(:user, email_verified: false, email_verification_code: 'code')
+
+      expect(user.non_verified_user?).to be_truthy
+    end
+
+    it 'returns FALSE if email_verified is TRUE' do
+      user = build_stubbed(:user, email_verified: true)
+
+      expect(user.non_verified_user?).to be_falsey
+    end
+
+    it 'returns FALSE if there is no email_verification_code' do
+      user = build_stubbed(:user, email_verified: true, email_verification_code: nil)
+
+      expect(user.non_verified_user?).to be_falsey
+    end
+  end
+
+  describe '#blocked_user?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.blocked_user?).to be_falsey
+    end
+
+    it 'returns TRUE if the blocked_user value for the user_group is true' do
+      group = build_stubbed(:user_group, blocked_user: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.blocked_user?).to be_truthy
+    end
+
+    it 'returns FALSE if the blocked_user value for the user_group is FALSE' do
+      group = build_stubbed(:user_group, blocked_user: false)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.blocked_user?).to be_falsey
+    end
+  end
+
+  describe '#system_requirements_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.system_requirements_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a system_requirements_access user_group' do
+      group = build_stubbed(:user_group, system_requirements_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.system_requirements_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non system_requirements_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.system_requirements_access?).to be_falsey
+    end
+  end
+
+  describe '#tutor_user?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.tutor_user?).to be_falsey
+    end
+
+    it 'returns TRUE for a tutor user_group' do
+      group = build_stubbed(:user_group, tutor: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.tutor_user?).to be_truthy
+    end
+
+    it 'returns FALSE for a non tutor user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.tutor_user?).to be_falsey
+    end
+  end
+
+  describe '#content_management_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.content_management_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a content_management_access user_group' do
+      group = build_stubbed(:user_group, content_management_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.content_management_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non content_management_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.content_management_access?).to be_falsey
+    end
+  end
+
+  describe '#exercise_corrections_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.exercise_corrections_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a exercise_corrections_access user_group' do
+      group = build_stubbed(:user_group, exercise_corrections_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.exercise_corrections_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non exercise_corrections_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.exercise_corrections_access?).to be_falsey
+    end
+  end
+
+  describe '#stripe_management_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.stripe_management_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a stripe_management_access user_group' do
+      group = build_stubbed(:user_group, stripe_management_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.stripe_management_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non stripe_management_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.stripe_management_access?).to be_falsey
+    end
+  end
+
+  describe '#user_management_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.user_management_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a user_management_access user_group' do
+      group = build_stubbed(:user_group, user_management_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.user_management_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non user_management_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.user_management_access?).to be_falsey
+    end
+  end
+
+  describe '#developer_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.developer_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a developer_access user_group' do
+      group = build_stubbed(:user_group, developer_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.developer_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non developer_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.developer_access?).to be_falsey
+    end
+  end
+
+  describe '#marketing_resources_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.marketing_resources_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a marketing_resources_access user_group' do
+      group = build_stubbed(:user_group, marketing_resources_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.marketing_resources_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non marketing_resources_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.marketing_resources_access?).to be_falsey
+    end
+  end
+
+  describe '#user_group_management_access?' do
+    it 'returns FALSE if there is no user_group' do
+      user = build_stubbed(:user, user_group: nil)
+
+      expect(user.user_group_management_access?).to be_falsey
+    end
+
+    it 'returns TRUE for a user_group_management_access user_group' do
+      group = build_stubbed(:user_group, user_group_management_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.user_group_management_access?).to be_truthy
+    end
+
+    it 'returns FALSE for a non user_group_management_access user_group' do
+      user = build_stubbed(:student_user)
+
+      expect(user.user_group_management_access?).to be_falsey
+    end
+  end
+
+  # def admin?
+  #   user_group_management_access? && developer_access? && system_requirements_access?
+  # end
+
+  describe '#admin?' do
+    it 'returns TRUE if the user is in the three correct groups' do
+      group = build_stubbed(:user_group, user_group_management_access: true, developer_access: true, system_requirements_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.admin?).to be_truthy
+    end
+
+    it 'returns FALSE if the user is not user_group_management_access' do
+      group = build_stubbed(:user_group, user_group_management_access: false, developer_access: true, system_requirements_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.admin?).to be_falsey
+    end
+
+    it 'returns FALSE if the user is not developer_access' do
+      group = build_stubbed(:user_group, user_group_management_access: true, developer_access: false, system_requirements_access: true)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.admin?).to be_falsey
+    end
+
+    it 'returns FALSE if the user is not system_requirements_access' do
+      group = build_stubbed(:user_group, user_group_management_access: true, developer_access: true, system_requirements_access: false)
+      user = build_stubbed(:user, user_group: group)
+
+      expect(user.admin?).to be_falsey
+    end
+  end
+
+  describe '#referred_user?' do
+    it 'returns TRUE for student users with referred_signup' do
+      referred_signup = build_stubbed(:referred_signup)
+      user = build_stubbed(:student_user, referred_signup: referred_signup)
+
+      expect(user.referred_user?).to be_truthy
+    end
+
+    it 'returns FALSE for a non-student_user' do
+      referred_signup = build_stubbed(:referred_signup)
+      user = build_stubbed(:tutor_user, referred_signup: referred_signup)
+
+      expect(user.referred_user?).to be_falsey
+    end
+
+    it 'returns FALSE for a student_user without referred_signup' do
+      user = build_stubbed(:student_user, referred_signup: nil)
+
+      expect(user.referred_user?).to be_falsey
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -176,6 +176,7 @@ FactoryBot.define do
       sequence(:name_url)               { |n| "tutor_#{n}" }
       active                            { true }
       stripe_customer_id                { nil }
+      association :user_group, factory: :tutor_user_group
     end
 
     factory :system_requirements_user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,8 +57,10 @@
 #  currency_id                     :bigint
 #
 require 'rails_helper'
+require Rails.root.join 'spec/concerns/user_accessable_spec.rb'
 
 describe User do
+  it_behaves_like 'user_accessable'
   it 'should have a valid factory' do
     expect(build(:user)).to be_valid
   end
@@ -195,17 +197,12 @@ describe User do
   it { should respond_to(:activate_user) }
   it { should respond_to(:validate_user) }
   it { should respond_to(:generate_email_verification_code) }
-  it { should respond_to(:create_referral) }
   it { should respond_to(:destroyable?) }
-  it { should respond_to(:full_name) }
-  it { should respond_to(:this_hour) }
-  it { should respond_to(:course_log_course_ids) }
   it { should respond_to(:enrolled_courses) }
   it { should respond_to(:valid_enrolled_courses) }
   it { should respond_to(:visit_campaigns) }
   it { should respond_to(:visit_sources) }
   it { should respond_to(:visit_landing_pages) }
-  it { should respond_to(:enrolled_course_ids) }
   it { should respond_to(:valid_enrollments_in_sitting_order) }
   it { should respond_to(:expired_enrollments_in_sitting_order) }
   it { should respond_to(:active_enrollments_in_sitting_order) }
@@ -220,54 +217,176 @@ describe User do
   it { should respond_to(:last_subscription) }
   it { should respond_to(:onboarding_state) }
 
-  describe '.search' do
-    let(:example_user) { create(:user) }
+  describe 'scopes' do
+    describe 'all_students' do
+      let(:student) { create(:student_user) }
+      let(:non_student) { create(:admin_user) }
 
-    before :each do
-      allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
-      create(:subscription, user: example_user, paypal_subscription_guid: 'I-testGuid1234567')
+      it 'calls the relevant scope' do
+        expect(User.all_students).to include(student)
+        expect(User.all_students).not_to include(non_student)
+      end
     end
 
-    it 'returns the correct user for a PayPal subscription' do
-      expect(User.search('I-test').first.id).to eq example_user.id
+    describe 'all_trial_or_sub_students' do
+      let(:student) { create(:student_user) }
+      let(:comp_user) { create(:comp_user) }
+
+      it 'calls the relevant scope' do
+        expect(User.all_trial_or_sub_students).to include(student)
+        expect(User.all_trial_or_sub_students).not_to include(comp_user)
+      end
+    end
+
+    describe 'all_tutors' do
+      let(:student) { create(:student_user) }
+      let(:tutor) { create(:tutor_user) }
+
+      it 'calls the relevant scope' do
+        expect(User.all_tutors).to include(tutor)
+        expect(User.all_tutors).not_to include(student)
+      end
     end
   end
 
-  describe '.get_and_verify' do
-    before do
-      allow_any_instance_of(HubSpot::Contacts).to receive(:batch_create).and_return(:ok)
-    end
+  describe 'Class Methods' do
+    describe '.search' do
+      let(:example_user) { create(:user) }
 
-    it 'returns NIL unless a matching user can be found' do
-      expect(User.get_and_verify('test_code', 1)).to be_nil
-    end
-
-    describe 'with a matching user' do
       before :each do
+        allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
+        create(:subscription, user: example_user, paypal_subscription_guid: 'I-testGuid1234567')
+      end
+
+      it 'returns the correct user for a PayPal subscription' do
+        expect(User.search('I-test').first.id).to eq example_user.id
+      end
+    end
+
+    describe '.get_and_verify' do
+      before do
         allow_any_instance_of(HubSpot::Contacts).to receive(:batch_create).and_return(:ok)
       end
 
-      let!(:test_user) { create(:user, active: false, country: nil) }
-
-      it 'returns the matching user object' do
-        expect(User.get_and_verify(test_user.email_verification_code, 1).id).to equal test_user.id
+      it 'returns NIL unless a matching user can be found' do
+        expect(User.get_and_verify('test_code', 1)).to be_nil
       end
 
-      it 'calls #verify on the user object' do
-        expect_any_instance_of(User).to receive(:verify)
+      describe 'with a matching user' do
+        before :each do
+          allow_any_instance_of(HubSpot::Contacts).to receive(:batch_create).and_return(:ok)
+        end
 
-        User.get_and_verify(test_user.email_verification_code, 1)
+        let!(:test_user) { create(:user, active: false, country: nil) }
+
+        it 'returns the matching user object' do
+          expect(User.get_and_verify(test_user.email_verification_code, 1).id).to equal test_user.id
+        end
+
+        it 'calls #verify on the user object' do
+          expect_any_instance_of(User).to receive(:verify)
+
+          User.get_and_verify(test_user.email_verification_code, 1)
+        end
+      end
+    end
+
+    describe '.sort_by' do
+      it 'calls .all_in_order unless the sort option is whitelisted' do
+        expect(User).to receive(:all_in_order)
+
+        User.sort_by('zip_code')
+      end
+
+      it 'calls .all_in_order when user_group is passed as the sort key' do
+        expect(User).to receive(:all_in_order)
+
+        User.sort_by('user_group')
+      end
+
+      it 'calls .sort_by_name when name is passed as the sort key' do
+        expect(User).to receive(:sort_by_name)
+
+        User.sort_by('name')
+      end
+
+      it 'calls .sort_by_email when email is passed as the sort key' do
+        expect(User).to receive(:sort_by_email)
+
+        User.sort_by('email')
+      end
+
+      it 'calls .sort_by_recent_registration when created is passed as the sort_key' do
+        expect(User).to receive(:sort_by_recent_registration)
+
+        User.sort_by('created')
+      end
+    end
+
+    describe '.to_csv' do
+      it 'calls .generate on CSV and passed any options' do
+        expect(CSV).to receive(:generate).with({})
+
+        User.to_csv
+      end
+
+      it 'returns a CSV file' do
+        create(:student_user)
+
+        expect(User.to_csv).to be_kind_of String
+      end
+    end
+
+    describe '.to_csv_with_enrollments' do
+      it 'calls .to_csv with the correct options' do
+        expect(User).to receive(:to_csv).with({}, %w[first_name last_name email student_number date_of_birth enrolled_courses valid_enrolled_courses])
+
+        User.to_csv_with_enrollments
+      end
+    end
+
+    describe '.to_csv_with_visits' do
+      it 'calls .to_csv with the correct options' do
+        expect(User).to receive(:to_csv).with({}, %w[email id visit_campaigns visit_sources visit_landing_pages])
+
+        User.to_csv_with_visits
       end
     end
   end
 
-  describe 'Methods' do
+  describe 'Instance Methods' do
+    let(:user) { create(:user) }
+
+    describe '#check_country' do
+      it 'calls the UserCountryWorker' do
+        expect(UserCountryWorker).to receive(:perform_async)
+
+        user.check_country('113.444.555')
+      end
+    end
+
+    describe '#name' do
+      it 'returns the first name and surname' do
+        tt = build_stubbed(:user, first_name: 'Sexy', last_name: 'Giordano')
+
+        expect(tt.name).to eq 'Sexy Giordano'
+      end
+    end
+
+    describe '#default_card' do
+      before :each do
+        create(:subscription_payment_card, user: user, status: 'card-live', is_default_card: true)
+      end
+
+      it 'calls find on subscription_payment_cards' do
+        expect(user.default_card).not_to be_nil
+      end
+    end
+
     describe '#viewable_subscriptions' do
       before :each do
         allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
       end
-
-      let(:user) { create(:user) }
 
       context 'for in-active exam bodies' do
         let(:bad_exam_body) { create(:exam_body, active: false) }
@@ -351,12 +470,33 @@ describe User do
       end
     end
 
+    describe '#valid_order_ids' do
+      before :each do
+        create(:order, :for_stripe, user: user, stripe_status: 'paid')
+        create(:order, :for_stripe, user: user, stripe_status: 'created')
+      end
+
+      it 'only returns paid orders' do
+        expect(user.valid_order_ids.count).to eq 1
+      end
+    end
+
+    describe '#valid_orders?' do
+      it 'returns TRUE if there are valid orders' do
+        create(:order, :for_stripe, user: user, stripe_status: 'paid')
+        expect(user.valid_orders?).to be true
+      end
+
+      it 'returns FALSE if there are no valid orders' do
+        create(:order, :for_stripe, user: user, stripe_status: 'created')
+        expect(user.valid_orders?).to be false
+      end
+    end
+
     describe '.last_subscription' do
       before :each do
         allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
       end
-
-      let(:user) { create(:user) }
 
       context 'for in-active exam bodies' do
         let(:bad_exam_body) { create(:exam_body, active: false) }
@@ -414,7 +554,6 @@ describe User do
     end
 
     describe '#currency_locked?' do
-      let(:user) { create(:user) }
 
       before :each do
         allow_any_instance_of(SubscriptionPlanService).to receive(:queue_async)
@@ -434,6 +573,44 @@ describe User do
         create(:order, :for_stripe, user: user)
 
         expect(user.currency_locked?).to be_truthy
+      end
+    end
+
+    describe '#create_stripe_customer' do
+      it 'calls the StripeCustomerCreationWorker' do
+        expect(StripeCustomerCreationWorker).to receive(:perform_async).with(user.id)
+
+        user.create_stripe_customer
+      end
+    end
+
+    describe 'visit_elements' do
+      it 'returns an array' do
+        expect(user.visit_elements('test')).to be_kind_of Array
+      end
+    end
+
+    describe 'visit_campaigns' do
+      it 'calls visit_elements with :utm_campaign' do
+        expect(user).to receive(:visit_elements).with(:utm_campaign)
+
+        user.visit_campaigns
+      end
+    end
+
+    describe 'visit_sources' do
+      it 'calls visit_elements with :utm_campaign' do
+        expect(user).to receive(:visit_elements).with(:utm_source)
+
+        user.visit_sources
+      end
+    end
+
+    describe 'visit_landing_pages' do
+      it 'calls visit_elements with :utm_campaign' do
+        expect(user).to receive(:visit_elements).with(:landing_page)
+
+        user.visit_landing_pages
       end
     end
 
@@ -474,6 +651,145 @@ describe User do
       it 'skips email verification updates if they are already completed' do
         user.update(email_verified: true)
         expect { user.verify(1) }.not_to change { user.email_verified_at }
+      end
+    end
+
+    describe '#validate_user' do
+      let(:user) { build_stubbed(:user, email_verification_code: 'test') }
+
+      it 'sets the correct variables on the user object' do
+        expect(user.email_verified).to be false
+        expect(user.email_verified_at).to be_nil
+        expect(user.email_verification_code).not_to be_nil
+
+        user.validate_user
+
+        expect(user.email_verified).to be true
+        expect(user.email_verified_at).to be_within(2.seconds).of(Time.zone.now)
+        expect(user.email_verification_code).to be_nil
+      end
+    end
+
+    describe '#generate_email_verification_code' do
+      let(:user) { build_stubbed(:basic_student) }
+
+      it 'sets the correct variables on the user object' do
+        expect(user.email_verified).to be true
+        expect(user.email_verified_at).not_to be_nil
+        expect(user.email_verification_code).to be_nil
+
+        user.generate_email_verification_code
+
+        expect(user.email_verified).to be false
+        expect(user.email_verified_at).to be_nil
+        expect(user.email_verification_code).not_to be_nil
+      end
+    end
+
+    describe '#full_name' do
+      it 'returns the first name and surname' do
+        tt = build_stubbed(:user, first_name: 'Sexy', last_name: 'Giordano')
+
+        expect(tt.full_name).to eq 'Sexy Giordano'
+      end
+
+      it 'titelizes the first_name' do
+        tt = build_stubbed(:user, first_name: 'sexy', last_name: 'Giordano')
+
+        expect(tt.full_name).to eq 'Sexy Giordano'
+      end
+
+      it 'removes spaces between apostrophes' do
+        tt = build_stubbed(:user, first_name: 'Giordano', last_name: "O' Reilly")
+
+        expect(tt.full_name).to eq "Giordano O' Reilly"
+      end
+    end
+
+    describe '#get_currency' do
+      it 'returns the users currency if one is present' do
+        cur = create(:currency, name: 'Aidan Dollars')
+        tt = build_stubbed(:user, currency: cur)
+
+        expect(tt.get_currency(tt.country)).to eq cur
+      end
+
+      it 'returns the default currency for the users country' do
+        country = create(:country)
+        tt = build_stubbed(:user, currency: nil, country: country)
+
+        expect(tt.get_currency(tt.country)).to eq country.currency
+      end
+    end
+
+    describe '#update_stripe_customer' do
+      before :each do
+        allow(Rails.env).to receive(:test?).and_return(false)
+        allow(HubSpotContactWorker).to receive(:perform_async)
+      end
+
+      it 'returns NIL unless the user email has changed' do
+        allow(user).to receive(:saved_change_to_email?).and_return(false)
+
+        expect(user.send(:update_stripe_customer)).to be_nil
+      end
+
+      it 'calls #retrieve on Stripe::Customer' do
+        user.stripe_customer_id = 'cus_12234555'
+        customer = double(:email= => true)
+        allow(customer).to receive(:save)
+        expect(Stripe::Customer).to receive(:retrieve).with('cus_12234555').and_return(customer)
+
+        user.send(:update_stripe_customer)
+      end
+
+      it 'updates the user email' do
+        user.stripe_customer_id = 'cus_12234555'
+        customer = double
+        expect(customer).to receive(:email=).with(user.email)
+        allow(customer).to receive(:save)
+        allow(Stripe::Customer).to receive(:retrieve).with('cus_12234555').and_return(customer)
+
+        user.send(:update_stripe_customer)
+      end
+
+      it 'saves the Stripe::Customer' do
+        user.stripe_customer_id = 'cus_12234555'
+        customer = double()
+        allow(customer).to receive(:email=)
+        expect(customer).to receive(:save)
+        allow(Stripe::Customer).to receive(:retrieve).with('cus_12234555').and_return(customer)
+
+        user.send(:update_stripe_customer)
+      end
+    end
+
+    describe '#delete_stripe_customer' do
+      before :each do
+        allow(Rails.env).to receive(:test?).and_return(false)
+        allow(HubSpotContactWorker).to receive(:perform_async)
+      end
+
+      it 'returns unless ther is a stripe_customer_id' do
+        expect(user.send(:delete_stripe_customer)).to be_nil
+      end
+
+      it 'call #retrieve on Stripe::Customer' do
+        user.stripe_customer_id = 'cus_12234555'
+        customer = double(delete: true)
+        allow(customer).to receive(:delete).with('cus_12234555')
+        expect(Stripe::Customer).to receive(:retrieve).with('cus_12234555').and_return(customer)
+
+        user.send(:delete_stripe_customer)
+      end
+
+      it 'call #delete on an instance of Stripe::Customer' do
+        user.stripe_customer_id = 'cus_12234555'
+        customer = double(delete: true)
+        expect(Stripe::Customer).to receive(:retrieve).with('cus_12234555').and_return(customer)
+        expect(customer).to receive(:delete).with('cus_12234555')
+
+        user.send(:delete_stripe_customer)
       end
     end
   end


### PR DESCRIPTION
Methods removed as I was unable to find any usage of these within the codebase:
- `create_referral`
- `this_hour`
- `course_log_course_ids`
- `enrolled_course_ids`