### PR TITLE
Revert Invalid Authenticity Token Changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,6 @@ class ApplicationController < ActionController::Base
   before_action :set_session_stuff # not for Api::
   before_action :set_layout_variables
   before_action :authorize_rack_profiler
-  rescue_from ActionController::InvalidAuthenticityToken, with: :log_out_user
 
   helper_method :current_user_session, :current_user
 
@@ -388,10 +387,4 @@ class ApplicationController < ActionController::Base
     @tag_manager_course = course
   end
   helper_method :tag_manager_data_layer
-
-  private
-
-  def handle_unverified_request
-    log_out_user
-  end
 end


### PR DESCRIPTION
Removed the rescue_from ActionController::InvalidAuthenticityToken from app controller as it seems the rescue is calling to destroy the session but it can't because the original error is during the session creation so there is no session to destroy. I think the rescue is hiding the actual error.