### PR TITLE
hotfix/Onboarding Unsubscribe Guid Callback

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -37,7 +37,7 @@ class Message < ApplicationRecord
   validates :guid, presence: true, on: :create
 
   # callbacks
-  before_validation :set_guid
+  before_create :set_guid
   after_create_commit :send_message
 
   # scopes

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -51,6 +51,12 @@ describe Message do
     it { should validate_presence_of(:process_at) }
     it { should validate_presence_of(:template) }
     it { should validate_presence_of(:mandrill_id).on(:update) }
+
+    it { should validate_presence_of(:guid).on(:create) }
+  end
+
+  describe 'Callbacks' do
+    it { should callback(:set_guid).before(:create) }
   end
 
   it { expect(Message).to respond_to(:process_webhook_event) }


### PR DESCRIPTION
Change the set_guid callback to before_create to stop it getting reset by Mandrill update of the Message