### PR TITLE
External Banner Summernote Editor Issue

### DIFF
--- a/app/views/external_banners/_form.html.haml
+++ b/app/views/external_banners/_form.html.haml
@@ -60,5 +60,8 @@
 
   $('#editor').summernote({
     disableDragAndDrop: true,
-    height: 150
+    height: 150,
+    linkTargetBlank: false
   });
+
+  $("#sn-checkbox-open-in-new-window").css({"position": "initial", "opacity": "1"});


### PR DESCRIPTION
Uncheck the target blank option for external banner editor links and made it visible.