### PR TITLE
UPDATE: Forked PayPal-Ruby-SDK with new certificate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'sidekiq', require: %w(sidekiq sidekiq/web)
 gem 'split', require: 'split/dashboard'
 gem 'state_machines-activerecord'
 gem 'stripe', '~> 4.21.0' #, git: 'https://github.com/stripe/stripe-ruby'
-gem 'paypal-sdk-rest'
+gem 'paypal-sdk-rest', git: "https://github.com/quilligana/PayPal-Ruby-SDK.git", branch: "add-g2-certificate"
 gem 'summernote-rails'
 gem 'turbolinks', '~> 5' # speeds up page loading - has negative side-effects
 gem 'uglifier', '>= 1.3.0' # compresses Javascript when sending it to users in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/quilligana/PayPal-Ruby-SDK.git
+  revision: 3d5d179a005d752df0dea23fb2aee01e69acdaea
+  branch: add-g2-certificate
+  specs:
+    paypal-sdk-rest (1.7.4)
+      multi_json (~> 1.0)
+      xml-simple
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -287,9 +296,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
-    paypal-sdk-rest (1.7.4)
-      multi_json (~> 1.0)
-      xml-simple
     pdf-core (0.7.0)
     pg (1.1.4)
     popper_js (1.14.5)
@@ -631,7 +637,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri (>= 1.10.8)
   paperclip (~> 6.1.0)
-  paypal-sdk-rest
+  paypal-sdk-rest!
   pg
   powder
   prawn


### PR DESCRIPTION
This issue is fully related to PayPal updating a root certificate on their sandbox and production APIs. Details about the migration of certificates are provided by PayPal [here](https://www.paypal.com/us/smarthelp/article/remove-support-of-verisign-g5-root-certificate-ts2240). I have now signed up to the "Status" emails from them so that we can hopefully pick up on any future updates. I'd suggest you do the same @JamesMacRedmond.

Per this PR, I have updated the certificates to the latest versions. This could only be done by forking the **PayPal-Ruby-SDK** repo and pointing our Gemfile to the forked version with updated certificates.

Have bundled locally and confirmed that all is good locally while it was failing on the old certificates. Once this lands on `staging` in the morning, I can test and check that the fix works there to. Then we can hopefully push through with the `production` deploy.