### PR TITLE
(PAYPAL) Move paypal sync to a worker.

### DIFF
--- a/app/services/cron_service.rb
+++ b/app/services/cron_service.rb
@@ -11,8 +11,10 @@ class CronService
   end
 
   def paypal_sync
+    return if Rails.env.staging?
+
     Rails.logger.info "CRON: Called the 'paypal_sync' task"
-    Paypal::SubscriptionValidation.run_paypal_sync
+    PaypalAnnualRenewalWorker.perform_async
   end
 
   def slack_exercises

--- a/app/workers/paypal_annual_renewal_worker.rb
+++ b/app/workers/paypal_annual_renewal_worker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PaypalAnnualRenewalWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :high
+
+  def perform
+    Paypal::SubscriptionValidation.run_paypal_sync
+  end
+end

--- a/spec/services/cron_service_spec.rb
+++ b/spec/services/cron_service_spec.rb
@@ -15,7 +15,7 @@ describe CronService, type: :service do
 
   describe '#paypal_sync' do
     it 'calls #run_paypal_sync on the Paypal::SubscriptionValidation class' do
-      expect(Paypal::SubscriptionValidation).to receive(:run_paypal_sync)
+      expect(PaypalAnnualRenewalWorker).to receive(:perform_async)
 
       subject.initiate_task('paypal_sync')
     end


### PR DESCRIPTION
Create a worker and call it on cron job to avoid timeout errors;