### PR TITLE
Fix button secondary class missing green border

### DIFF
--- a/app/assets/stylesheets/components/buttons/_standard_buttons.scss
+++ b/app/assets/stylesheets/components/buttons/_standard_buttons.scss
@@ -53,6 +53,8 @@
 }
 .btn:not(:disabled):not(.disabled) {
   cursor: pointer;
+}
+.btn-icon {
   border:none;
 }
 .btn.dropdown-toggle {


### PR DESCRIPTION
Move border none to new class for modal close button so it doesn't clash with other buttons