### PR TITLE
(BUG) Invoice user_id and subscription_id in paypal orders.

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -146,8 +146,9 @@ class Invoice < ApplicationRecord
   def self.build_from_paypal_data(paypal_body)
     inv = Invoice.find_or_initialize_by(paypal_payment_guid: paypal_body['resource']['id'])
     subscription = Subscription.find_by(paypal_subscription_guid: paypal_body['resource']['billing_agreement_id'])
+
     Invoice.transaction do
-      if subscription.user && subscription && subscription.currency
+      if subscription.user && subscription && subscription.currency && subscription.paypal_subscription_guid
         inv.assign_attributes(
           user_id: subscription.user.id,
           subscription_id: subscription.id,

--- a/app/services/paypal_service.rb
+++ b/app/services/paypal_service.rb
@@ -32,7 +32,7 @@ class PaypalService
     if payment_id == order.paypal_guid && payment.execute(payer_id: payer_id)
       payment = Payment.find(order.paypal_guid)
       order.update!(paypal_status: payment.state)
-      order.invoice.update!(paid: true, payment_closed:true)
+      order.invoice.update!(paid: true, payment_closed: true, paypal_payment_guid: payment_resources_id(payment))
       order.complete
     else
       order.record_error!
@@ -76,5 +76,9 @@ class PaypalService
         }
       ]
     }
+  end
+
+  def payment_resources_id(payment)
+    payment&.transactions&.last&.related_resources&.last&.sale&.id
   end
 end

--- a/lib/tasks/paypal_invoices.rake
+++ b/lib/tasks/paypal_invoices.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+namespace :paypal do
+  desc 'Fix up the badly user_id sets'
+  task fix_invoices_user_id: :environment do
+    Rails.logger = Logger.new(Rails.root.join('log/tasks.log'))
+    Rails.logger.info 'Running command to fix up bad bad user_id in invoices...'
+
+    total_time = Benchmark.measure do
+      invoices = Invoice.where(user_id: 72160)
+      # invoices = [Invoice.last]
+      Rails.logger.info "============= Total Records #{invoices.count} =============="
+
+      invoices.each do |invoice|
+        Rails.logger.info "Starting Invoice ##{invoice.id}..."
+
+        sale = PayPal::SDK::REST::Sale.find(invoice.paypal_payment_guid)
+        order = Order.find_by(paypal_guid: sale.parent_payment)
+
+        Rails.logger.info "Updating  ##{invoice.id} Invoice user_id from #{invoice.user_id} to #{order.user_id}"
+        Rails.logger.info "Paypal Sale: #{invoice.paypal_payment_guid}"
+        Rails.logger.info "Paypal Payment: #{order.paypal_guid}"
+
+        invoice.update(subscription_id: nil, user_id: order.user_id)
+
+        Rails.logger.info "Invoice ##{invoice.id} successfully updated."
+      rescue => e
+        Rails.logger.error "Invoice ##{invoice.id} not updated"
+        Rails.logger.error "Error: #{e.message}"
+      end
+    end
+    Rails.logger.info "============= Total time #{total_time.real} =============="
+    Rails.logger.info '=========================================================='
+  end
+end

--- a/spec/services/paypal_service_spec.rb
+++ b/spec/services/paypal_service_spec.rb
@@ -14,9 +14,9 @@ describe PaypalService, type: :service do
     }
 
     before :each do
-      allow(PayPal::SDK::REST::DataTypes::Payment).to(
-        receive(:new).and_return(payment_dbl)
-      )
+      allow(PayPal::SDK::REST::DataTypes::Payment).to(receive(:new).and_return(payment_dbl))
+      allow_any_instance_of(PaypalService).to receive(:payment_resources_id).and_return(nil)
+      # allow(PaypalService).to(receive(:payment_resources_id).and_return(nil))
     end
 
     it 'calls CREATE on an instance of Payment and returns the order object' do
@@ -78,10 +78,9 @@ describe PaypalService, type: :service do
     }
 
     before :each do
-      allow(PayPal::SDK::REST::DataTypes::Payment).to(
-        receive(:find).and_return(payment_dbl)
-      )
+      allow(PayPal::SDK::REST::DataTypes::Payment).to(receive(:find).and_return(payment_dbl))
       allow(order).to receive(:execute_order_completion)
+      allow_any_instance_of(PaypalService).to receive(:payment_resources_id).and_return(nil)
     end
 
     it 'ensures the paypal ID matches the paypal_guid of the order' do
@@ -177,4 +176,3 @@ describe PaypalService, type: :service do
     end
   end
 end
-


### PR DESCRIPTION
Invoices user_id and subscription_id was wrongly set to an uniq user when an order was created using paypal.

Fix paypal webhook to ignore when doesn't find a subscription;
Add payment sale id in invoice order when created;
Create a task to fix wrong records;

[Monday task](https://learnsignal-team.monday.com/boards/224818924/pulses/959850378)