### PR TITLE
(BUG) Zendesk contact error

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -85,7 +85,9 @@ class LibraryController < ApplicationController
   end
 
   def user_contact_form
-    if verify_recaptcha && check_if_params_present
+    if invalid_email_format?(params[:email_address])
+      flash[:error] = 'Invalid email, please try again.'
+    elsif verify_recaptcha && check_if_params_present
       Zendesk::RequestWorker.perform_async(params[:full_name],
                                            params[:email_address],
                                            params[:type],
@@ -102,6 +104,10 @@ class LibraryController < ApplicationController
 
   def check_if_params_present
     return true if params[:full_name].present? && params[:email_address].present? && params[:type].present? && params[:question].present?
+  end
+
+  def invalid_email_format?(email)
+    !email.match(RFC822::EMAIL_REGEXP_WHOLE)
   end
 
   protected

--- a/app/services/zendesk/requests.rb
+++ b/app/services/zendesk/requests.rb
@@ -15,6 +15,8 @@ module Zendesk
 
     def create
       zendesk_api.requests.create!(parser_request_data)
+    rescue ZendeskAPI::Error::RecordInvalid => e
+      Rails.logger.error e.message
     end
 
     private

--- a/app/views/library/_user_form_modal.html.haml
+++ b/app/views/library/_user_form_modal.html.haml
@@ -21,7 +21,7 @@
             .col-sm-6
               .form-group
                 =label_tag :email, 'Email'
-                =email_field_tag :email_address, nil, class: 'form-control', placeholder: 'Enter your Email', required: true
+                =email_field_tag :email_address, nil, class: 'form-control', placeholder: 'Enter your Email', type: :email, required: true
 
             .col-sm-12
               .form-group

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -2,6 +2,7 @@
 
 SALES_REPORT_EMAIL = Rails.env.production? ? 'sales-reports@learnsignal.com' : 'giordano@learnsignal.com'
 MARKETING_EMAIL = Rails.env.production? ? 'marketing-team@learnsignal.com' : 'giordano@learnsignal.com'
+
 LEARNSIGNAL_HOST =
   case Rails.env
   when 'development'

--- a/config/initializers/rfc822.rb
+++ b/config/initializers/rfc822.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RFC822
+  QTEXT = '[^\\x0d\\x22\\x5c\\x80-\\xff]'
+  DTEXT = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]'
+  ATOM = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+'
+  QUOTED_PAIR = '\\x5c[\\x00-\\x7f]'
+  DOMAIN_LITERAL = "\\x5b(?:#{DTEXT}|#{QUOTED_PAIR})*\\x5d"
+  QUOTED_STRING = "\\x22(?:#{QTEXT}|#{QUOTED_PAIR})*\\x22"
+  DOMAIN_REF = ATOM
+  SUB_DOMAIN = "(?:#{DOMAIN_REF}|#{DOMAIN_LITERAL})"
+  WORD = "(?:#{ATOM}|#{QUOTED_STRING})"
+  DOMAIN = "#{SUB_DOMAIN}(?:\\x2e#{SUB_DOMAIN})*"
+  LOCAL_PART = "#{WORD}(?:\\x2e#{WORD})*"
+  ADDR_SPEC = "#{LOCAL_PART}\\x40#{DOMAIN}"
+
+  EMAIL_REGEXP_WHOLE = Regexp.new("\\A#{ADDR_SPEC}\\z", nil, 'n')
+  EMAIL_REGEXP_PART = Regexp.new(ADDR_SPEC.to_s, nil, 'n')
+end


### PR DESCRIPTION
Zendesk is triggering an error when a wrong formatted email is passed as params in contact form.

I'm trying to avoid it using 2 validations before hit zendesk service.

1. Add a type in contact email html field, this will check format before call controller.
2. Add a check is in library controller, I added a new email regex format check before call zendesk work.
 

If request sill pass for those two checks, it will get by zendesk rescue I added in requests service, this will log in a specific zendesk file instead trigger an error.

### How to test it?

Access http://localhost:3000/en/contact address and add some invalid email format in form.
We should be blocking most part of wrong formats and write in zendesk log when zendesk doesn't accept it.

### Email format regex

Here the links I used to get that regex we're using:

[Explanation about regex format]( https://stackoverflow.com/a/201378)
[Article about email validation](https://blog.mailtrap.io/rails-email-validation/)
[email regex and test](http://emailregex.com/)