### PR TITLE
(BUG) Hubspot bad gatway error.

### DIFF
--- a/app/services/hub_spot/contacts.rb
+++ b/app/services/hub_spot/contacts.rb
@@ -34,7 +34,9 @@ module HubSpot
       path     = "/contacts/v1/contact/email/#{email}/profile"
       response = service(path, 'get', { propertyMode: 'value_only', showListMemberships: 'false' })
 
-      JSON.parse(response.body)
+      parsed = JSON.parse(response.body) if response.code != '502'
+
+      return parsed if parsed['status'] != 'error'
     end
 
     private


### PR DESCRIPTION
Sometimes hubspot is retuning bad gatway to our api calls.

I added some checks to not parser invalid data.

Invoices reports will fill empty data when this cases happens in report generation.

[task link](https://learnsignal-team.monday.com/boards/224818924/pulses/975336145)

How I tested it:

I expend a lot of time here trying to replicate the gatway error but could not get it done, my guess was we are hitting some rate limit in their api, but I could simulate it(rate limit) and when this happens they also send a json response to us.
