### PR TITLE
(BUG) Refund raise error.

### DIFF
--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -90,6 +90,6 @@ class Refund < ApplicationRecord
            livemode: stripe_refund[:livemode],
            stripe_refund_data: stripe_refund.to_hash.deep_dup)
   rescue Stripe::InvalidRequestError => e
-    raise Learnsignal::PaymentError, e[:message]
+    raise Learnsignal::PaymentError, e.message
   end
 end


### PR DESCRIPTION
Refund isn't treating the error triggering by stripe InvalidRequestError correctly.
The problem was a sintaxy mistake when we trigger a raise by our side, I add a fix to solve it.