### PR TITLE
forced the new user session format to html to avoid missing template …

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -10,7 +10,9 @@ class UserSessionsController < ApplicationController
     seo_title_maker('Log in to Start Studying Today | LearnSignal',
                     'Log in to your ACCA or CPD courses to access topic-by-topic tuition modules, explore online learning resources and kick-start your study today.',
                     false)
-    render 'user_sessions/new'
+    respond_to do |format|
+      format.html { render 'user_sessions/new' }
+    end
   end
 
   def create


### PR DESCRIPTION
- **What?** Requests made in a non html format result in a missing template error.
- **Why?** When a request comes in to a rails action to render a template in html, it will only accept an html format as that is the only way to render the template. Any other format will raise an error.
- **How?** Forced the new user session format to html to avoid missing template error.
- **How to test?** Try a new login session, if your login is successful it is working as before, though now it is filtering for only html format requests. 

https://learnsignal-team.monday.com/boards/224818924/pulses/975336316