### PR TITLE
(BUG) Invalid subscription type.

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -21,6 +21,8 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
+    valid_subscription_type?(params['payment-options'])
+
     @subscription        = Subscription.new(subscription_params)
     subscription_service = SubscriptionService.new(@subscription)
     subscription_service.check_valid_subscription?(params)
@@ -182,6 +184,12 @@ class SubscriptionsController < ApplicationController
     when 'pending'
       @subscription.mark_pending!
     end
+  end
+
+  def valid_subscription_type?(type)
+    return if %w[stripe paypal].include?(type)
+
+    raise Learnsignal::SubscriptionError, t('views.subscriptions.new_subscription.invalid_type')
   end
 
   def set_variables

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1458,6 +1458,7 @@ en:
         credit_card: Credit/Debit Card
         coupon_code: Coupon Code
         remember_cancel_anytime: Remember, you can cancel at anytime
+        invalid_type: Invalid subscription type. Please contact our support team.
 
       upgrade_complete:
         h1: Thank you for subscribing


### PR DESCRIPTION
Add a new validation before create subscription to allow just paypal and stripe as subscription types.

Any value but those too will return a validation message to user.

![Screenshot 2021-01-21 at 14 30 25](https://user-images.githubusercontent.com/136358/105369447-794d6900-5bfa-11eb-991c-279088b764bd.png)
