### PR TITLE
disabled save and view button for quiz on the dom

### DIFF
--- a/app/views/admin/course_quizzes/_fields_for_standard_question.html.haml
+++ b/app/views/admin/course_quizzes/_fields_for_standard_question.html.haml
@@ -60,15 +60,15 @@
           -if parent.object.id.nil?
             -# new parent
             =f.submit t('views.course_quizzes.form.advanced_setup_link'), class: 'btn btn-secondary'
-            =f.submit t('views.course_quizzes.form.preview_button'), class: 'btn btn-primary'
+            =f.submit t('views.course_quizzes.form.preview_button'), class: 'btn btn-primary', style: 'display:none'
           -elsif question.object.id.nil?
             -# new question
             =link_to t('views.course_quizzes.form.advanced_setup_link'), new_quiz_question_url(quiz_step_id: parent.object.id), class: 'btn btn-secondary'
-            =f.submit t('views.course_quizzes.form.preview_button'), class: 'btn btn-primary'
+            =f.submit t('views.course_quizzes.form.preview_button'), class: 'btn btn-primary', style: 'display:none'
           -else
             -# edit question of existing quiz
             =link_to t('views.course_quizzes.form.advanced_setup_link'), edit_quiz_question_url(id: question.object.id, quiz_step_id: parent.object.id), class: 'btn btn-secondary'
-            =link_to t('views.course_quizzes.form.preview_button'), question.object, class: 'btn btn-primary'
+            =link_to t('views.course_quizzes.form.preview_button'), question.object, class: 'btn btn-primary', style: 'display:none'
           -if question.object.id.nil?
             =link_to t('views.general.delete'), '#', onclick: "if(confirm('" +t('views.general.delete_confirmation') + "')) {$('#the_new_question').remove()}; return false;", class: 'btn btn-danger'
           -elsif question.object.destroyable?


### PR DESCRIPTION
- **What?** When editing quiz questions in the console the save and view btn causes an error.
- **Why?** This needs to be retooled and implemented across all course steps.
- **How?** Disabled save and view button for quiz on the dom.
- **How to test?** In the console go to a course lesson that contains a quiz course step, click on the edit button of that course step. All quiz questions should show the buttons Advanced and Delete, they should **not** contain the button Save and View.

https://learnsignal-team.monday.com/boards/224818924/pulses/975336882