### PR TITLE
added conditional padding to single question instances

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7130,6 +7130,9 @@ button.sub-details[aria-expanded="true"]:before{
     height: 1em;
   }
 }
+.practice-ques-single-question {
+  padding-top:1em;
+}
 .active-step {
   border: 1px solid #00e99d !important;
 }

--- a/app/javascript/components/practiceQuestions/MainView.vue
+++ b/app/javascript/components/practiceQuestions/MainView.vue
@@ -38,7 +38,7 @@
           />
         </span>
         <span v-else>
-          <ScenarioPane :content="practiceQuestion.content" />
+          <ScenarioPane :content="practiceQuestion.content" class="practice-ques-single-question" />
         </span>
       </splitpanes>
         <HelpBtn :helpPdf="practiceQuestion.document.url" />

--- a/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
+++ b/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
@@ -10,7 +10,8 @@
         <div id="rightPaneTopUnderline" class="right-pane-underline"></div>
       </ul>
 
-      <p v-html="questionContent.description"></p>
+      <p v-if="totalQuestions > 1" v-html="questionContent.description"></p>
+      <p v-else v-html="questionContent.description" class="practice-ques-single-question"></p>
 
       <div class="prac-ques-ans-box">
         <div v-if="questionContent.kind == 'open'">


### PR DESCRIPTION
- **What?** For practice question standard when on a single question the text is too high up on the page
- **Why?** When on multiple questions a question navigation element kicks in which handles the padding, single question doesn't have this element.
- **How?** added conditional padding to single question instances
- **How to test?** Choose practice question standard with only one question, verify that there is top spacing on right hand side text

https://learnsignal-team.monday.com/boards/224818924/pulses/993122649