### PR TITLE
altered height,padding,fontsize of spreadsheetwrapper to limit row he…

### DIFF
--- a/app/assets/stylesheets/components/practice-questions/_master.scss
+++ b/app/assets/stylesheets/components/practice-questions/_master.scss
@@ -404,7 +404,7 @@ button2.btn-settings:active {
     }
   }
 }
-.exhibits-spread-sheet {
+.spreadsheetwrapper {
   .btn-group {
     width: 60%;
   }
@@ -414,7 +414,18 @@ button2.btn-settings:active {
       height: 2em;
     }
   }
+  .btn-row:nth-child(3) {
+    .btn-group {
+      width: 60%;
+      height: 3.5em;
+      .form-control {
+        padding:0;
+        font-size: 15px;
+      }
+    }
+  }
 }
+
 .prac-ques-ans-box {
   padding:0;
   .container-fluid {


### PR DESCRIPTION
- **What?** On the spreadsheet editor the row containing the font styling is too large and the font number is hidden. 
- **Why?** The editor has custom styling that affects font row.
- **How?** altered height, padding, font size of spreadsheetwrapper to limit row height and show font number
- **How to test?** Practice questions on admin side. Practice question spreadsheet modal. Practice question solution modal.

If you guys know of any other place where spreadsheet is used let me know so I can test.

https://learnsignal-team.monday.com/boards/224818924/pulses/993123631