### PR TITLE
(CHORE) Custom errors in appsignal.

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -30,7 +30,7 @@ module Admin
       flash[:success] = 'Product successfully updated'
       redirect_to admin_order_path(@order)
     rescue => e
-      Airbrake::AirbrakeLogger.new(logger).error e.message
+      notify_error_monitors(e)
 
       flash[:error] = 'Could not update an order'
       redirect_to admin_orders_path
@@ -38,10 +38,16 @@ module Admin
 
     private
 
+    def notify_error_monitors(error)
+      Airbrake::AirbrakeLogger.new(logger).error error.message
+      Appsignal.send_error(error)
+    end
+
     def set_order
       @order = Order.find(params[:id])
     rescue ActiveRecord::RecordNotFound => e
       Airbrake::AirbrakeLogger.new(logger).error e.message
+      Appsignal.send_error(e)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,8 +48,9 @@ class ApplicationController < ActionController::Base
     super
   end
 
-  def log_in_airbrake(e)
-    Airbrake.notify(e)
+  def log_in_airbrake(error)
+    Airbrake.notify(error)
+    Appsignal.send_error(error)
     true
   end
 
@@ -238,7 +239,8 @@ class ApplicationController < ActionController::Base
   def vimeo_as_main?
     SystemSetting.find_by(environment: Rails.env).settings['vimeo_as_main_player?'].to_bool
   rescue NoMethodError => e
-    Airbrake::AirbrakeLogger.new(logger).error e.message
+    Airbrake::AirbrakeLogger.new(logger).error(e.message)
+    Appsignal.send_error(e)
     true
   end
 

--- a/app/controllers/subscription_management_controller.rb
+++ b/app/controllers/subscription_management_controller.rb
@@ -109,7 +109,8 @@ class SubscriptionManagementController < ApplicationController
       stripe_cancellation(subscription)
     end
   rescue Learnsignal::SubscriptionError => e
-    Airbrake::AirbrakeLogger.new(logger).error e.message
+    Airbrake::AirbrakeLogger.new(logger).error(e.message)
+    Appsignal.send_error(e)
     false
   end
 

--- a/app/models/cbe.rb
+++ b/app/models/cbe.rb
@@ -61,6 +61,7 @@ class Cbe < ApplicationRecord
     new_cbe
   rescue ActiveRecord::RecordInvalid => e
     Airbrake.notify(e)
+    Appsignal.send_error(e)
     e
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -166,6 +166,7 @@ class Course < ApplicationRecord
     new_course
   rescue ActiveRecord::RecordInvalid => e
     Airbrake.notify(e)
+    Appsignal.send_error(e)
     e
   end
 

--- a/app/services/accredible/credentials.rb
+++ b/app/services/accredible/credentials.rb
@@ -28,7 +28,11 @@ module Accredible
     def service(path, method, query = nil)
       response = response(path: path, method: method, query: query)
 
-      Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body if response.code != '200'
+      if response.code != '200'
+        Appsignal.send_error(Exception.new(response.body), {}, 'services')
+        Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
+      end
+
       JSON.parse(response.body).merge(status: response.code).with_indifferent_access
     end
   end

--- a/app/services/accredible/groups.rb
+++ b/app/services/accredible/groups.rb
@@ -13,7 +13,11 @@ module Accredible
     def service(path, method)
       response = response(path: path, method: method)
 
-      Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body if response.code != '200'
+      if response.code != '200'
+        Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
+        Appsignal.send_error(Exception.new(response.body), {}, 'services')
+      end
+
       JSON.parse(response.body).merge(status: response.code).with_indifferent_access
     end
   end

--- a/app/services/hub_spot/contacts.rb
+++ b/app/services/hub_spot/contacts.rb
@@ -15,6 +15,7 @@ module HubSpot
 
       return response if response.code == '200'
 
+      Appsignal.send_error(Exception.new(response.body), {}, 'services')
       Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
     end
 
@@ -27,6 +28,7 @@ module HubSpot
 
       return response if response.code == '202'
 
+      Appsignal.send_error(Exception.new(response.body), {}, 'services')
       Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
     end
 

--- a/app/services/hub_spot/form_contacts.rb
+++ b/app/services/hub_spot/form_contacts.rb
@@ -14,6 +14,7 @@ module HubSpot
 
       return response if response.code == '200'
 
+      Appsignal.send_error(Exception.new(response.body), {}, 'services')
       Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
     end
 

--- a/app/views/courses/_video_player.html.haml
+++ b/app/views/courses/_video_player.html.haml
@@ -9,5 +9,6 @@
     -error_message << "User: #{current_user.id}: #{current_user.name}"
     -Rails.logger.error error_message
     -Airbrake::AirbrakeLogger.new(logger).error error_message
+    -Appsignal.send_error(Exception.new(error_message))
 -else
   =render partial: 'courses/players/dacast', locals: { cme: cme }

--- a/spec/services/paypal/subscription_validation_spec.rb
+++ b/spec/services/paypal/subscription_validation_spec.rb
@@ -329,7 +329,7 @@ describe Paypal::SubscriptionValidation, type: :service do
     it 'calls #notify on Airbrake' do
       expect(Airbrake).to receive(:notify)
 
-      good_instance.send(:log_to_airbrake, 'test message')
+      good_instance.send(:log_to_airbrake, Exception.new('test message'))
     end
   end
 end


### PR DESCRIPTION
We are currently sending some custom errors to airbrake, this commit changes will trigger those errors to notify appsignal too.

- What? Custom errors in appsignal;
- Why? We are currently sending some custom errors to airbrake, need to send it to appsignal too;
- How? Adding triggers to notify appsignal too;
- How to test?

Open rails console and try to trigger accredible error using: `Accredible::Credentials.new.details(77777)`.
Check the env dev in appsignal application.