### PR TITLE
changed outer scroll to inner scroll for all types of modals in pract…

### DIFF
--- a/app/assets/stylesheets/components/practice-questions/_master.scss
+++ b/app/assets/stylesheets/components/practice-questions/_master.scss
@@ -228,7 +228,7 @@ button2.btn-settings:active {
   border-radius: 10px;
   border: 6px solid #000032;
   box-shadow: 0 0 0 1px hsl(0, 0%, 80%), 0 0 0 2px hsl(0, 0%, 90%);
-  overflow-y: auto;
+  overflow: hidden;
 }
 .modal2-calc {
   overflow: hidden;
@@ -246,6 +246,7 @@ button2.btn-settings:active {
   background-color: #ffffff;
   z-index: 1030;
   left: 30px;
+  top: -50px;
   padding-right: 0 !important;
   padding-left: 0 !important;
   position: absolute !important;
@@ -254,7 +255,7 @@ button2.btn-settings:active {
   border-radius: 10px;
   border: 5px solid #000032;
   box-shadow: 0 0 0 1px hsl(0, 0%, 80%), 0 0 0 2px hsl(0, 0%, 90%);
-  overflow-y: auto;
+  overflow: hidden;
 }
 .modal2-text-editor {
   background-color: #f5f8fa;
@@ -268,7 +269,7 @@ button2.btn-settings:active {
   border-radius: 10px;
   border: 5px solid #000032;
   box-shadow: 0 0 0 1px hsl(0, 0%, 80%), 0 0 0 2px hsl(0, 0%, 90%);
-  overflow-y: auto;
+  overflow: hidden;
 }
 .modal2-help {
   background-color: #f5f8fa;
@@ -277,11 +278,11 @@ button2.btn-settings:active {
   padding-left: 0 !important;
   position: absolute !important;
   width: 60em;
-  height: 37em;
+  height: 40em;
   border-radius: 10px;
   border: 5px solid #000032;
   box-shadow: 0 0 0 1px hsl(0, 0%, 80%), 0 0 0 2px hsl(0, 0%, 90%);
-  overflow-y: auto;
+  overflow-y: hidden;
 }
 .modal2-dialog {
     margin-right: 0;
@@ -294,6 +295,14 @@ button2.btn-settings:active {
   background-color:#000032;
   color:white;
   position: fixed;
+  z-index: 100;
+  width: 36.5em;
+}
+.modal2-header-std {
+  height: 45px;
+  padding: 20px;
+  background-color:#000032;
+  color:white;
   z-index: 100;
   width: 36.5em;
 }
@@ -440,17 +449,20 @@ button2.btn-settings:active {
   }
 }
 .modal-help {
-  top: 70px;
+  top: -50px;
 }
 #solutionModal {
   padding-left: 0;
 }
 .exhibits-modals {
-  top: 17px;
+  top: -30px;
   left: 155px;
+  .pdf-viewer {
+    height: 1200px;
+  }
 }
 .text-editor-modal-sm {
-  top: 55px;
+  top: 25px;
 }
 .outsidelastpage {
   .submit-btn-title {
@@ -458,7 +470,6 @@ button2.btn-settings:active {
     cursor: not-allowed;
   }
 }
-
 #helpModal {
   .pdf-viewer .scrolling-page {
     margin-top: 4em;
@@ -476,6 +487,9 @@ button2.btn-settings:active {
 .resizemove {
   resize: both;
   overflow: auto;
+}
+.resizemove-sol {
+  resize: both;
 }
 
 
@@ -516,6 +530,11 @@ button2.btn-settings:active {
  }
 }
 
+.modal-inner-scroll {
+  overflow: auto;
+  height: 500px;
+}
+
 .practice-question-V2 {
   display: flex;
   justify-content: center;
@@ -547,9 +566,6 @@ button2.btn-settings:active {
   .pdf-preview-toggle > a.icon > svg {
     position: initial !important;
     margin-top: -7px;
-  }
-  .pdf-zoom > a.icon > svg {
-    margin-left: -15px;
   }
   arrow {
     color: #000032;
@@ -676,7 +692,11 @@ button2.btn-settings:active {
     overflow: hidden;
   }
   .modal2-dialog {
-    overflow: auto;
+    overflow: hidden;
+  }
+  .modal2-body {
+    overflow-y: auto;
+    width: 100%;
   }
   .modal-close-solution {
     position: relative;
@@ -747,7 +767,7 @@ button2.btn-settings:active {
   .tabgroup {
     background-color: #f7f7f7;
     margin-top: 4px;
-    height: 28.9em;
+    height: 32em;
   }
   .tabgroup-pad {
     padding:30px;

--- a/app/javascript/components/practiceQuestions/ExhibitsModal.vue
+++ b/app/javascript/components/practiceQuestions/ExhibitsModal.vue
@@ -4,14 +4,14 @@
             <div class="circle"><span class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">description</i><p v-html="exhibitsObj.name"></p></span>
         </button>
-        <div @click="updateZindex()" :id="'exhibitsModal'+ exhibitsInd" class="modal2-solution fade resizemove exhibits-modals" v-show="modalIsOpen">
+        <div @click="updateZindex()" :id="'exhibitsModal'+ exhibitsInd" class="modal2-solution fade resizemove-sol exhibits-modals" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                 <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close modal-close-solution" data-dismiss="modal" aria-hidden="true">&times;</button>
                   <div class="modal2-header-lg">
                       <h4 v-html="exhibitsObj.name" class="modal2-title"></h4>
                   </div>
-                  <div class="modal2-body">
+                  <div class="modal2-body modal-inner-scroll">
                     <br>
                     <div v-if="exhibitsObj.kind === 'open'">
                       <p v-html="exhibitsObj.content"></p>

--- a/app/javascript/components/practiceQuestions/HelpBtn.vue
+++ b/app/javascript/components/practiceQuestions/HelpBtn.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <button @click="modalIsOpen = !modalIsOpen; updateZindex(); resetModalDims()" href="#helpModal" class="btn btn-settings help-btn-title" title="Help" data-backdrop="false" data-toggle="modal"></button>
-        <div @click="updateZindex()" id="helpModal" class="modal2-help modal-help fade resizemove" v-show="modalIsOpen">
+        <div @click="updateZindex()" id="helpModal" class="modal2-help modal-help fade resizemove-sol" v-show="modalIsOpen">
             <div class="modal2-dialog">
                 <div class="modal2-content">
                   <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -15,6 +15,7 @@
                     </div>
                 </div>
             </div>
+          <div class="draggable-overlay"></div>
         </div>
     </div>
 </template>
@@ -43,7 +44,9 @@ export default {
     })
   },
   mounted() {
-    $('#helpModal').draggable({ handle:'.modal2-header-lg'});
+    this.$nextTick(function () {
+      $('#helpModal').draggable({ handle:'.modal2-header-lg, .draggable-overlay'});
+    })
   },
   methods: {
     handleChange(value) {
@@ -54,7 +57,7 @@ export default {
     },
     resetModalDims() {
       $('#helpModal').css('width', '60em');
-      $('#helpModal').css('height', '37em');
+      $('#helpModal').css('height', '40em');
     },
   },
   watch: {

--- a/app/javascript/components/practiceQuestions/ModalCalculator.vue
+++ b/app/javascript/components/practiceQuestions/ModalCalculator.vue
@@ -5,12 +5,12 @@
             <div class="modal2-dialog">
                 <div class="modal2-content">
                   <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <div class="modal2-header">
+                    <div class="modal2-header-std">
                         <h4 class="modal2-title">Calculator</h4>
 
                     </div>
                     <div class="modal2-body">
-                      <div class="modal2-margin-top">
+                      <div>
                         <Calculator />
                       </div>
                     </div>

--- a/app/javascript/components/practiceQuestions/ModalScratchPad.vue
+++ b/app/javascript/components/practiceQuestions/ModalScratchPad.vue
@@ -5,12 +5,12 @@
             <div class="modal2-dialog">
                 <div class="modal2-content">
                   <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <div class="modal2-header">
+                    <div class="modal2-header-std">
                         <h4 class="modal2-title">Scratch Pad</h4>
 
                     </div>
                     <div class="modal2-body">
-                      <div class="modal2-margin-top">
+                      <div>
                       <editor
                         :api-key="apiKey"
                         :init="{

--- a/app/javascript/components/practiceQuestions/ModalSolution.vue
+++ b/app/javascript/components/practiceQuestions/ModalSolution.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
       <button @click="modalIsOpen = !modalIsOpen; updateZindex(); resetModalDims()" href="#solutionModal" class="btn btn-settings solution-btn-title" data-backdrop="false" data-toggle="modal">Solution</button>
-      <div @click="updateZindex()" id="solutionModal" class="modal2-solution fade resizemove" v-show="modalIsOpen">
+      <div @click="updateZindex()" id="solutionModal" class="modal2-solution fade resizemove-sol" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                 <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close modal-close-solution" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -9,8 +9,8 @@
                       <h4 class="modal2-title">Solution</h4>
 
                   </div>
-                  <div class="modal2-body">
-                    <div>
+                  <div id="modal2-body-id" class="modal2-body" style="overflow-y:scroll">
+                    <div id="modal-solution-v1-inner-content">
                       <h5>Question {{this.indexOfQuestion + 1}}</h5>
                       <div v-if="solutionContent[this.indexOfQuestion].kind === 'open'">
                         <p v-html="solutionContent[this.indexOfQuestion].solution"></p>
@@ -69,6 +69,7 @@ export default {
     this.$nextTick(function () {
         $('#solutionModal').draggable({ handle:'.modal2-header-lg, .draggable-overlay'});
     })
+    this.getModalInnerHeight();
   },
   methods: {
     syncSpreadsheetData(jsonData) {
@@ -83,10 +84,20 @@ export default {
     },
     updateZindex() {
       eventBus.$emit("z-index-click", "solutionModal");
+      this.getModalInnerHeight();
     },
     resetModalDims() {
       $('#solutionModal').css('width', '60em');
       $('#solutionModal').css('height', '37em');
+    },
+    getModalInnerHeight() {
+      let elem = $("#modal-solution-v1-inner-content").height();
+      console.log(`height: ${(elem/2)+20}`);
+      if (elem<100) {
+        document.getElementById('modal2-body-id').style.height = '485px';
+      } else {
+        document.getElementById('modal2-body-id').style.height = `${(elem/2)+20}px`;
+      }
     },
   },
   watch: {

--- a/app/javascript/components/practiceQuestions/ModalSolutionV2.vue
+++ b/app/javascript/components/practiceQuestions/ModalSolutionV2.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
       <button @click="modalIsOpen = !modalIsOpen; updateZindex(); resetModalDims()" href="#solutionModalV2" class="btn btn-settings solution-btn-title" data-backdrop="false" data-toggle="modal">Solution</button>
-      <div @click="updateZindex()" id="solutionModalV2" class="modal2-solution fade resizemove-sol-v2 " v-show="modalIsOpen">
+      <div @click="updateZindex()" id="solutionModalV2" class="modal2-solution fade resizemove-sol" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                   <div class="modal2-header-lg">
@@ -90,7 +90,7 @@ export default {
     },
     resetModalDims() {
       $('#solutionModalV2').css('width', '60em');
-      $('#solutionModalV2').css('height', '37em');
+      $('#solutionModalV2').css('height', '40em');
     },
     instantiateTabs() {
       $('.tabgroup > div').hide();

--- a/app/javascript/components/practiceQuestions/RequirementsModal.vue
+++ b/app/javascript/components/practiceQuestions/RequirementsModal.vue
@@ -4,14 +4,14 @@
             <div class="circle"><span class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">assignment</i><p v-html="requirementsObj.name"></p></span>
         </button>
-        <div @click="updateZindex()" :id="'requirementsModal'+ requirementsInd" class="modal2-solution fade resizemove exhibits-modals" v-show="modalIsOpen">
+        <div @click="updateZindex()" :id="'requirementsModal'+ requirementsInd" class="modal2-solution fade resizemove-sol exhibits-modals" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                 <button @click="modalIsOpen = !modalIsOpen" type="button" class="close modal-close modal-close-solution" data-dismiss="modal" aria-hidden="true">&times;</button>
                   <div class="modal2-header-lg">
                       <h4 v-html="requirementsObj.name" class="modal2-title"></h4>
                   </div>
-                  <div class="modal2-body">
+                  <div class="modal2-body modal-inner-scroll">
                     <br>
                     <div>
                       <p v-html="requirementsObj.description"></p>

--- a/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
+++ b/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
@@ -4,14 +4,14 @@
             <div class="circle"><span class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">table_view</i><p>Spreadsheet</p></span>
         </button>
-        <div @click="updateZindex()" id="spreadsheetModal" class="modal2-solution fade resizemove exhibits-modals" v-show="modalIsOpen">
+        <div @click="updateZindex()" id="spreadsheetModal" class="modal2-solution fade resizemove-sol exhibits-modals" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                 <button @click="modalIsOpen = !modalIsOpen; updateResponse();" type="button" class="close modal-close modal-close-solution" data-dismiss="modal" aria-hidden="true">&times;</button>
                   <div class="modal2-header-lg">
                       <h4 class="modal2-title">Spreadsheet</h4>
                   </div>
-                  <div class="modal2-body">
+                  <div class="modal2-body modal-inner-scroll">
                     <br>
                     <SpreadsheetEditor
                         :initial-data="responseObj.content"
@@ -22,6 +22,7 @@
                 </div>
               </div>
           </div>
+          <div class="draggable-overlay"></div>
         </div>
     </div>
 </template>
@@ -58,7 +59,7 @@ export default {
   },
   mounted() {
     this.$nextTick(function () {
-        $('#spreadsheetModal').draggable({ handle:'.modal2-header-lg'});
+        $('#spreadsheetModal').draggable({ handle:'.modal2-header-lg, .draggable-overlay'});
     })
     //this.convertStr2Obj(this.responseObj)
     this.updateResponse()

--- a/app/javascript/components/practiceQuestions/TextEditorModal.vue
+++ b/app/javascript/components/practiceQuestions/TextEditorModal.vue
@@ -4,14 +4,14 @@
             <div class="circle"><span class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">create</i><p>Word Processor</p></span>
         </button>
-        <div @click="updateZindex()" id="textEditorModal" class="modal2-text-editor fade resizemove text-editor-modal-sm" v-show="modalIsOpen">
+        <div @click="updateZindex()" id="textEditorModal" class="modal2-text-editor fade resizemove-sol text-editor-modal-sm" v-show="modalIsOpen">
           <div class="modal2-dialog">
               <div class="modal2-content">
                 <button @click="modalIsOpen = !modalIsOpen; updateResponse();" type="button" class="close modal-close modal-close-solution" data-dismiss="modal" aria-hidden="true">&times;</button>
                   <div class="modal2-header-lg">
                       <h4 class="modal2-title">Word Processor</h4>
                   </div>
-                  <div class="modal2-body">
+                  <div class="modal2-body modal-inner-scroll">
                     <br>
                     <div>
                         <TinyEditor
@@ -23,6 +23,7 @@
                 </div>
               </div>
           </div>
+          <div class="draggable-overlay"></div>
         </div>
     </div>
 </template>
@@ -59,7 +60,7 @@ export default {
   },
   mounted() {
     this.$nextTick(function () {
-        $('#textEditorModal').draggable({ handle:'.modal2-header-lg'});
+        $('#textEditorModal').draggable({ handle:'.modal2-header-lg, .draggable-overlay'});
     })
     this.updateResponse()
   },


### PR DESCRIPTION
- **What?** On the practice question modals the scroll should be for the inner content div of the modal, not the external.
- **Why?** In the screenshot of the ticket on monday you can see that sometimes it displaces the header and other parts of the modal we do not want to move.
- **How?** changed outer scroll to inner scroll for all types of modals in practice questions.
- **How to test?** Open all of the modals in practice questions, none of the headers should be displaced if you use the scroll wheel.

https://learnsignal-team.monday.com/boards/224818924/pulses/993113184