### PR TITLE
expand other courses on sidenav expand similar to cbe

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6719,7 +6719,7 @@ button.sub-details[aria-expanded="true"]:before{
   display: none;
 }
 
-@media (max-width: 751px) and (max-width:992px) {
+@media (max-width:1023px) {
   #small-screen-overlay {
     display: block;
   }
@@ -6731,28 +6731,11 @@ button.sub-details[aria-expanded="true"]:before{
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding-right: 2em;
+    padding-left: 2em;
     .btn.btn-sm.btn-sm-arrow-left {
       width: 60%;
-      margin-top: 1em;
-    }
-  }
-}
-
-@media (max-width:750px) {
-  #small-screen-overlay {
-    display: block;
-  }
-  .small-screen-overlay-text {
-    position: relative;
-    top: 45%;
-    width: 100%;
-    color: #000032;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    .btn.btn-sm.btn-sm-arrow-left {
-      width: 60%;
-      margin-top: 1em;
+      margin-top: 2em;
     }
   }
 }
@@ -7177,7 +7160,7 @@ button.sub-details[aria-expanded="true"]:before{
   width: 85%;
   margin-left: 15%;
 }
-.cbe-container {
+.courses-container {
   width: 100%;
   padding-right: 15px;
   padding-left: 15px;
@@ -7185,52 +7168,62 @@ button.sub-details[aria-expanded="true"]:before{
   margin-left: auto
 }
 @media (min-width:576px) {
-  .cbe-container {
+  .courses-container {
     max-width: 540px
   }
 }
 @media (min-width:768px) {
-  .cbe-container {
+  .courses-container {
     max-width: 720px
   }
 }
 @media (min-width:992px) {
-  .cbe-container {
+  .courses-container {
     max-width: 960px
   }
 }
+@media (min-width:1080px) {
+  .courses-container {
+    max-width: 1030px
+  }
+}
 @media (min-width:1200px) {
-  .cbe-container {
-    max-width: 1180px
+  .courses-container {
+    max-width: 1150px
   }
 }
 @media (min-width:1300px) {
-  .cbe-container {
-    max-width: 1280px
+  .courses-container {
+    max-width: 1250px
   }
 }
 @media (min-width:1416px) {
-  .cbe-container {
-    max-width: 1450px
+  .courses-container {
+    max-width: 1380px
+  }
+}
+@media (min-width:1500px) {
+  .courses-container {
+    max-width: 1460px
   }
 }
 @media (min-width:1600px) {
-  .cbe-container {
+  .courses-container {
     max-width: 1600px
   }
 }
 @media (min-width:1900px) {
-  .cbe-container {
+  .courses-container {
     max-width: 1800px
   }
 }
 @media (min-width:2000px) {
-  .cbe-container {
+  .courses-container {
     max-width: 1900px
   }
 }
 @media (min-width:2200px) {
-  .cbe-container {
+  .courses-container {
     max-width: 2200px
   }
 }

--- a/app/assets/stylesheets/components/cbes/_cbe-new.scss
+++ b/app/assets/stylesheets/components/cbes/_cbe-new.scss
@@ -1,4 +1,4 @@
-.cbe-container {
+.courses-container {
   width: 100%;
   height: 100vh;
 }

--- a/app/views/admin/cbes/new.html.haml
+++ b/app/views/admin/cbes/new.html.haml
@@ -5,5 +5,5 @@
     %section.pb-7
       .row
         .col-sm-12
-          .cbe-container
+          .courses-container
             #cbes-new-view

--- a/app/views/admin/cbes/show.html.haml
+++ b/app/views/admin/cbes/show.html.haml
@@ -5,5 +5,5 @@
     %section.pb-7
       .row
         .col-sm-12
-          .cbe-container
+          .courses-container
             #cbes-edit-view

--- a/app/views/courses/_constructed_response.html.haml
+++ b/app/views/courses/_constructed_response.html.haml
@@ -1,7 +1,7 @@
 #fade-overlay.load-overlay-blank
 %main.sidebar-right-main
   %article#sidebar-right-content.courses.bg-gray5
-    .cbe-container
+    .courses-container
       %header
         .d-flex.flex-wrap.flex-sm-nowrap.justify-content-between.py-4.py-md-5
           -if @course_step && (@course_step.is_video? || @course_step.is_note? || @course_step.is_quiz? || @course_step.is_practice_question? || @course_step.is_constructed_response?)

--- a/app/views/courses/_show_practice_question.html.haml
+++ b/app/views/courses/_show_practice_question.html.haml
@@ -4,7 +4,7 @@
       #fade-overlay.load-overlay-blank
       #small-screen-overlay.load-overlay
         .small-screen-overlay-text
-          Please use a larger screen device
+          Please use a larger screen device or landscape mode if on a tablet
           =link_to navigation_special_link(@course_step), class: 'btn btn-secondary btn-sm btn-sm-arrow-left mb-3 mb-sm-0' do
             =@course_step.course_lesson.course_section.course.name
 

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -1,7 +1,7 @@
 %main.sidebar-right-main
   =render partial: 'mobile_nav'
   %article#sidebar-right-content.courses.bg-gray5
-    .container
+    .courses-container
       %div.course-show-external-banner#courses-show-external-banner
         =render partial: 'layouts/external_banner'
       %header


### PR DESCRIPTION
- **What?** The screen space on courses view (sidenav) isn't being taken advantage of to the fullest.
- **Why?** A default container class squeezes the content.
- **How?** expand other courses on sidenav expand similar to cbe.
- **How to test?** Compare practice question screen size on monday ticket with a practice quesiton on local.

Note: There was a change to a text that hides a practice question according to screen size. The change was:

**Please use a larger screen device** 
to:
**Please use a larger screen device or landscape mode if on a tablet**

Let me know what you guys think.

https://learnsignal-team.monday.com/boards/224818924/pulses/993116113