### PR TITLE
added grab icon to calculator and scratchpad

### DIFF
--- a/app/assets/stylesheets/components/practice-questions/_master.scss
+++ b/app/assets/stylesheets/components/practice-questions/_master.scss
@@ -305,6 +305,18 @@ button2.btn-settings:active {
   color:white;
   z-index: 100;
   width: 36.5em;
+  cursor: grab;
+  &:active {
+    cursor: grabbing;
+  }
+}
+#scratchPadModal, #calcModal {
+  .modal2-body {
+    cursor: grab;
+    &:active {
+      cursor: grabbing;
+    }
+  }
 }
 .modal2-header-lg {
   height: 45px;


### PR DESCRIPTION
- **What?** Calculator and scratchpad modals don't indicate that they are draggable in the cursor icon.
- **Why?** No custom cursor was added.
- **How?** added grab icon to calculator and scratchpad on header and body.
- **How to test?** Open scratchpad and calculator modals, make sure the hand grab icon appears when hovering over the header or the borders of the modal.

Note: Scratchpad and calculator can be easily dragged around because they don't have a resizable element. The other modals were trickier so a draggable footer was added. In the case of the calculator and scratchpad modals this was not added since it is not necessary. Since they're in their own corner and don't resize I didn't mind the slight difference. 

https://learnsignal-team.monday.com/boards/224818924/pulses/993110384