### PR TITLE
Commented out the display flex on quiz content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7420,7 +7420,7 @@ button.sub-details[aria-expanded="true"]:before{
     font-size: .95rem;
   }
   .quiz-solution-ans {
-    display: flex;
+    //display: flex;
     justify-content: flex-start;
     p {
       margin-bottom:1em;


### PR DESCRIPTION
**What?** Any formatted text in the quiz text editors is not rendering correctly.
**Why?** New designs have added a flex layout to the quiz content.
**How?** Commented out the CSS flex style.
**How to test?** Format the quiz solution text content into a table. On the student quiz results page does the solution render correctly in a table and do elements wrap to the next line correctly.
**Note:** Still investigating if this will break anything else with the quiz designs, but since this could be anything it's best to let students report any issues rather than hunting for something that may not exist.

https://learnsignal-team.monday.com/boards/224818924/pulses/1014725770