### PR TITLE
added thousands separator to local currency method as it was not bein…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,11 +38,11 @@ module ApplicationHelper
   end
 
   def number_in_local_currency(amount, currency)
-    number_to_currency(amount, unit: currency.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.decimal_separator'), precision: 2)
+    number_to_currency(amount, unit: currency.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.thousands_separator'), precision: 2)
   end
 
   def number_in_local_currency_no_precision(amount, currency)
-    number_to_currency(amount, unit: currency.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.decimal_separator'), precision: 0)
+    number_to_currency(amount, unit: currency.leading_symbol, separator: I18n.t('views.general.numbers.decimal_separator'), delimiter: I18n.t('views.general.numbers.thousands_separator'), precision: 0)
   end
 
   def sanitizer(some_text)


### PR DESCRIPTION
- **What?** Foreign currency (indian rupee) separates 1000's with a dot instead of a comma.
- **Why?** Decimal delimiter being applied instead of thousand delimiter.
- **How?** Applied thousand delimiter.
- **How to test?** Go to console > plans + products > Create a new product with a foreign currency, use a big number (1000000 or more) and make it a lifetime membership. Add that foreign currency to a test user. Go to where one would pay for the lifetime membership and verify that the number is separated by commas and not decimal points (example: 1,000,000.00 **not** 1.000.000.00)

https://learnsignal-team.monday.com/boards/224818924/pulses/857439816