### PR TITLE
changed icon from template styling to class

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5347,6 +5347,14 @@ a.list-group-item {
   height: 550px;
 }
 
+.side-nav-material-icons {
+  background-color: #000032;
+  color: #ffffff;
+  padding: 0em 0.4em 1.2em 0em;
+  border-radius: 5px;
+  width: 100%;
+}
+
 .sidenav-section {
   min-height: 100px;
 }

--- a/app/views/library/_student_side_navbar.html.haml
+++ b/app/views/library/_student_side_navbar.html.haml
@@ -15,7 +15,7 @@
                 .step{data: {course_step: step.name}, :class => sidepanel_border_radius(@course_step_index,index,@course_lesson.active_children.length.to_i) }
                   .step-part
                     %div
-                      %i.material-icons.icon-bg-round{"aria-label" => "failed", :role => "img", :style => "background-color: #000032;\n    color: #ffffff;\n    padding: 0em 0.4em 1.2em 0em;\n    border-radius: 5px;\n    width: 100%;"}
+                      %i.material-icons.icon-bg-round.side-nav-material-icons
                         -if @course_log
                           %span{class: @course_log && @course_log.course_step_logs && @course_log.course_step_logs.map(&:course_step_id).include?(step.id) ? (@course_log.course_step_logs.all_completed.map(&:course_step_id).include?(step.id) ? 'small-dot' : 'small-dot-alt') : 'small-dot-neutral'}
                         -else
@@ -72,7 +72,7 @@
                 .step{data: {course_step: step.name}, class: sidepanel_border_radius(@course_step_index,index,@course_lesson.active_children.length.to_i) }
                   .step-part
                     %div
-                      %i.material-icons.icon-bg-round{"aria-label" => "failed", :role => "img", :style => "background-color: #000032;\n    color: #ffffff;\n    padding: 0em 0.4em 1.2em 0em;\n    border-radius: 5px;\n    width: 100%;"}
+                      %i.material-icons.icon-bg-round.side-nav-material-icons
                         -if @course_log
                           %span{class: @course_log && @course_log.course_step_logs && @course_log.course_step_logs.map(&:course_step_id).include?(step.id) ? (@course_log.course_step_logs.all_completed.map(&:course_step_id).include?(step.id) ? 'small-dot' : 'small-dot-alt') : 'small-dot-neutral'}
                         -else


### PR DESCRIPTION
- **What?** On ios devices sidenav icons reject styling that works for windows and android.
- **Why?** might have to do with some rails specific styling on the html template.
- **How?** Turned it into a class and removed the styling on the html.
- **How to test?** Go to any view that has the sidenav courses on any ios device

https://learnsignal-team.monday.com/boards/224818924/pulses/960291678