### PR TITLE
(GA) Back purchase event tracker

### DIFF
--- a/app/views/orders/order_complete.html.haml
+++ b/app/views/orders/order_complete.html.haml
@@ -37,22 +37,22 @@
       content_category: "#{@product&.product_type.humanize}"
     });
 
-    //dataLayer.push({
-    //  'ecommerce': {
-    //    'purchase': {
-    //      'actionField': {
-    //        'id': "#{@product&.id}",
-    //        'revenue': "#{@product&.price}"
-    //      },
-    //      'products': [{
-    //        'name': "#{@product&.name}",
-    //        'price': "#{@product&.price}",
-    //        'brand': "#{@product&.product_type}",
-    //        'category': "#{@product&.product_type.humanize}",
-    //        'quantity': 1
-    //        }]
-    //    }
-     // },
-    //'event':'ecomSuccess'}
-    //);
+    dataLayer.push({
+      'ecommerce': {
+        'purchase': {
+          'actionField': {
+            'id': "#{@product&.id}",
+            'revenue': "#{@product&.price}"
+          },
+          'products': [{
+            'name': "#{@product&.name}",
+            'price': "#{@product&.price}",
+            'brand': "#{@product&.product_type}",
+            'category': "#{@product&.product_type.humanize}",
+            'quantity': 1
+          }]
+        }
+      },
+      'event':'ecomSuccess'}
+    );
   });

--- a/app/views/subscriptions/personal_upgrade_complete.html.haml
+++ b/app/views/subscriptions/personal_upgrade_complete.html.haml
@@ -52,24 +52,24 @@
       content_category: "Subscription"
     });
 
-    //dataLayer.push({
-    //  'ecommerce': {
-    //    'purchase': {
-    //      'actionField': {
-    //        'id': "#{@subscription&.id}",
-    //        'revenue': "#{@subscription&.subscription_plan&.price}"
-    //      },
-    //      'products': [{
-    //        'name': "#{@subscription&.subscription_plan&.name}",
-    //        'id': "#{@subscription&.subscription_plan&.id}",
-    //        'price': "#{@subscription&.subscription_plan&.price}",
-    //        'brand': "#{@subscription&.subscription_plan&.exam_body&.name}",
-    //        'subscription_interval': "#{@subscription&.subscription_plan&.interval_name}",
-    //        'category': "Subscription",
-    //        'quantity': 1
-    //        }]
-    //    }
-    //  },
-    //'event':'ecomSuccess'}
-    //);
+    dataLayer.push({
+      'ecommerce': {
+        'purchase': {
+          'actionField': {
+            'id': "#{@subscription&.id}",
+            'revenue': "#{@subscription&.subscription_plan&.price}"
+          },
+          'products': [{
+            'name': "#{@subscription&.subscription_plan&.name}",
+            'id': "#{@subscription&.subscription_plan&.id}",
+            'price': "#{@subscription&.subscription_plan&.price}",
+            'brand': "#{@subscription&.subscription_plan&.exam_body&.name}",
+            'subscription_interval': "#{@subscription&.subscription_plan&.interval_name}",
+            'category': "Subscription",
+            'quantity': 1
+          }]
+        }
+      },
+    'event':'ecomSuccess'}
+    );
   });


### PR DESCRIPTION
What? Add back google analytics purchase tracker;
Why? marketing team is needing it again;
How? Uncomment tracker code;
How to test? Purchase a subscription or product and check if purchase event was triggered. You can use an [addon](https://chrome.google.com/webstore/detail/datalayer-checker/ffljdddodmkedhkcjhpmdajhjdbkogke?hl=en) to it.