### PR TITLE
Google Tag Manager - Marketing layout file.

### DIFF
--- a/app/views/layouts/marketing.html.haml
+++ b/app/views/layouts/marketing.html.haml
@@ -14,6 +14,7 @@
     =javascript_include_tag 'application', modernizr: :true
 
     =render partial: 'layouts/global_site_tag'
+    =render partial: 'layouts/google_tag_manager'
 
     =yield :head
 


### PR DESCRIPTION
What? Add gtm partial back to marketing layout file.
Why? marketing team still to use it to some conversions.
How? add gtm partial back to marketing file application.
How to test? Run and inspect code to confirm if GTM is there.