### PR TITLE
updated subscription completion guid on change plan to show the curre…

### DIFF
--- a/app/controllers/subscriptions/plan_changes_controller.rb
+++ b/app/controllers/subscriptions/plan_changes_controller.rb
@@ -50,6 +50,7 @@ module Subscriptions
       @subscription, data = sub_service.change_plan(coupon, plan_id)
 
       if data[:status] == :ok
+        data[:completion_guid] = @subscription.completion_guid
         retrieved_subscription = StripeSubscriptionService.new(@subscription).retrieve_subscription
         @subscription.un_cancel if retrieved_subscription[:cancel_at_period_end]
         @subscription.update(kind: kind)

--- a/app/views/subscriptions/plan_changes/new.html.haml
+++ b/app/views/subscriptions/plan_changes/new.html.haml
@@ -168,6 +168,7 @@
     var displayCardError = $('#card-errors');
     let clientSecret, subscriptionId;
     let statusArray = ['active', 'succeeded'];
+    let current_completion_guid = '';
     displayError.text('');
     displayCardError.text('');
     var stripe = Stripe('#{ENV['LEARNSIGNAL_V3_STRIPE_PUBLIC_KEY']}');
@@ -215,11 +216,12 @@
         data: $(form).serialize(),
         dataType: 'json',
         success: function(data, status, xhr){
+          current_completion_guid = data.completion_guid
           if (['incomplete', 'past_due'].includes(data.status)) {
-            handleStripeAction(data.client_secret, data.subscription_id)
+            handleStripeAction(data.client_secret, data.subscription_id, current_completion_guid)
           } else if(data.status == 'active') {
-            // TODO: This url is incorrect as @subscription is the old sub not the new sub
-            window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+            const upgrade_url = '#{personal_upgrade_complete_url()}/' + current_completion_guid;
+            window.location.replace(upgrade_url);
           }
         },
         error: function(request, status, error){
@@ -232,7 +234,7 @@
       });
     }
 
-    function handleStripeAction(client_secret, subscription_id){
+    function handleStripeAction(client_secret, subscription_id, completion_guid){
       let intentStatus = '';
       stripe.handleCardPayment(client_secret).then(function(result) {
         if (result.error) {
@@ -251,8 +253,8 @@
             dataType: 'json',
             success: function(data,status,xhr){
               if ($.inArray(intentStatus, statusArray) !== -1){
-                // TODO: This url is incorrect as @subscription is the old sub not the new sub
-                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+                const upgrade_url = '#{personal_upgrade_complete_url()}/' + completion_guid;
+                window.location.replace(upgrade_url);
               }
             },
             error: function(xhr,status,error){
@@ -299,8 +301,12 @@
             dataType: 'json',
             success: function(data,status,xhr){
               if( $.inArray(intentStatus, statusArray) !== -1){
-                // TODO: This url is incorrect as @subscription is the old sub not the new sub
-                window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+                if( current_completion_guid == ''){
+                  window.location.replace("#{personal_upgrade_complete_url(@subscription.completion_guid)}");
+                } else {
+                  const upgrade_url = '#{personal_upgrade_complete_url()}/' + current_completion_guid;
+                  window.location.replace(upgrade_url);
+                }
               }
             },
             error: function(xhr,status,error){


### PR DESCRIPTION
- **What?** when changing plans a user receives a confirmation showing their previous plan, not the recently updated one.
- **Why?** the previous subscription completion guid is being passed to the view url instead of the current one.
- **How?** updated subscription completion guid on change plan to show the current not previous plan in the view.
- **How to test?** Change plans for a user, confirm that the plan you changed is the one that shows up on the message. Example: if you are changing from the quarterly to the yearly, the message should read: 
'You have subscribed to the Yearly Subscription Plan." and **NOT** 'You have subscribed to the Quarterly Subscription Plan." 

https://learnsignal-team.monday.com/boards/224818924/pulses/983584879