### PR TITLE
(HOTFIX) Practice Question Responses

### DIFF
--- a/app/views/api/v1/practice_questions/_practice_question.json.jbuilder
+++ b/app/views/api/v1/practice_questions/_practice_question.json.jbuilder
@@ -33,7 +33,6 @@ json.questions practice_question.questions.order(:sorting_order) do |question|
 end
 
 
-  json.partial! 'responses', locals: { practice_question: practice_question }
+  json.partial! 'responses', locals: { practice_question: practice_question, course_step_log_id: step_log.id }
   json.partial! 'exhibits', locals: { practice_question: practice_question }
   json.partial! 'solutions', locals: { practice_question: practice_question }
-

--- a/app/views/api/v1/practice_questions/_responses.json.jbuilder
+++ b/app/views/api/v1/practice_questions/_responses.json.jbuilder
@@ -1,4 +1,4 @@
-json.responses practice_question.responses.order(:sorting_order) do |response|
+json.responses practice_question.responses.where(course_step_log_id: course_step_log_id).order(:sorting_order) do |response|
   json.id                   response.id
   json.sorting_order        response.sorting_order
   json.kind                 response.kind


### PR DESCRIPTION
What? Filter responses by course step log
Why? Users are seeing others users responses in their practice questions;
How? Add a condition to show just the responses for that specific course step log;
How to test? Open a practice question and check if you see only your responses;