### PR TITLE
added condional logic for when answer spreadhsheet data is empty

### DIFF
--- a/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
+++ b/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
@@ -108,7 +108,7 @@ export default {
       this.activePage = num;
     },
     convertStr2Obj(str) {
-      if (typeof str === 'object' && str !== null) {
+      if ((typeof str === 'object' && str !== null) || jQuery.isEmptyObject(str)) {
         return str;
       } else {
         return JSON.parse(str);
@@ -147,14 +147,14 @@ export default {
         return new Promise((resolve) => {
           resolve(pageArr);
         }).then((data) => {
-          let origDataLength;
-          let userChangedDataLength;
+          let origDataLength = {};
+          let userChangedDataLength = {};
           if (data.kind == 'spreadsheet') {
-            origDataLength =  Object.keys(data.content.content.data.data.dataTable).length;
-            userChangedDataLength = Object.keys(data.answer_content.content.data.data.dataTable).length;
+            if (data.content.content) { origDataLength =  Object.keys(data.content.content.data.data.dataTable).length; }
+            if (data.answer_content.content) { origDataLength =  Object.keys(data.answer_content.content.data.data.dataTable).length; }
           } else {
-            origDataLength = data.content.length;
-            userChangedDataLength = data.answer_content.length;
+            if (data.content) { origDataLength = data.content.length; }
+            if (data.answer_content) { userChangedDataLength = data.answer_content.length; }
           }
           if (origDataLength != userChangedDataLength) {
             this.fillArr[index] = 1;


### PR DESCRIPTION
- **What?** when loading an empty answer template on practice questions the navigation stays hidden.
- **Why?** it attempts to return an object attribute that doesn't exist.
- **How?** added condional logic for when answer spreadhsheet data is empty.
- **How to test?** Make a new practice question question with kind set as spreadsheet and an empty answer template, then another question with content on the answer template. The navigation should work, the solutions should for both questions should appear (if they have content)