### PR TITLE
Fix SegmentService LogError Call

### DIFF
--- a/app/services/segment_service.rb
+++ b/app/services/segment_service.rb
@@ -10,7 +10,7 @@ class SegmentService
     )
   rescue StandardError => e
     Rails.logger.error "SegmentService#create_user - #{e.inspect}"
-    log_in_airbrake("Segment: Create User #{user.id}: #{e.message}")
+    ApplicationController.log_in_airbrake("Segment: Create User #{user.id}: #{e.message}")
   end
 
   # PRIVATE ====================================================================


### PR DESCRIPTION
* **What?** Fix bug calling the Segment Service rescue
* **Why?** The segment service has a built in rescue to gracefully handle any error connection with their API
* **How?** Prefixed the log error method with ApplicationController
* **How to test?** To test locally just add typo to the segment Analytics.identify call, this should trigger the rescue and appear under the local/development view on AppSignal
