### PR TITLE
Fix practice questions edit.

### DIFF
--- a/app/javascript/components/general/Spreadsheet.vue
+++ b/app/javascript/components/general/Spreadsheet.vue
@@ -26,6 +26,7 @@ export default {
   },
   mounted() {
     try {
+      this.hiddenFormData = JSON.stringify(JSON.parse(this.$parent.content));
       this.spreadsheetData = JSON.parse(this.$parent.content);
     } catch (error) {
       console.log(error)

--- a/app/views/api/v1/practice_questions/_practice_question.json.jbuilder
+++ b/app/views/api/v1/practice_questions/_practice_question.json.jbuilder
@@ -32,7 +32,6 @@ json.questions practice_question.questions.order(:sorting_order) do |question|
   end
 end
 
-
-  json.partial! 'responses', locals: { practice_question: practice_question, course_step_log_id: step_log.id }
-  json.partial! 'exhibits', locals: { practice_question: practice_question }
-  json.partial! 'solutions', locals: { practice_question: practice_question }
+json.partial! 'responses', locals: { practice_question: practice_question, course_step_log_id: step_log.id }
+json.partial! 'exhibits', locals: { practice_question: practice_question }
+json.partial! 'solutions', locals: { practice_question: practice_question }


### PR DESCRIPTION
What? Edit mode doesn't works when spreadsheet is loading.
Why? Spreadsheet data is sent to a hidden field from vue component when this component is updated, if we not update this component, spreadsheet data goes empty and break update method.
How? Load spreadsheet data as soon page is loaded.
How to test? Edit any spreadsheet question in practice question.