### PR TITLE
added sort_by sorting_order attr when updating practice question ques…

### DIFF
--- a/app/controllers/admin/course_steps_controller.rb
+++ b/app/controllers/admin/course_steps_controller.rb
@@ -72,6 +72,7 @@ module Admin
           @course_step.course_quiz.add_an_empty_question
           @quiz_questions = @course_step&.course_quiz&.quiz_questions&.sort_by { |q| q.sorting_order || 0 }
         elsif @course_step.is_practice_question
+          @course_step&.course_practice_question&.questions&.sort_by { |q| q.sorting_order || 0 }
           @course_step.course_practice_question.questions.build
         elsif @course_step.is_video
           @course_step.build_video_resource unless @course_step.video_resource

--- a/spec/controllers/admin/course_steps_controller_spec.rb
+++ b/spec/controllers/admin/course_steps_controller_spec.rb
@@ -86,6 +86,11 @@ describe Admin::CourseStepsController, type: :controller do
         get :edit, params: { id: course_step_4.id }
         expect_edit_success_with_model('course_step', course_step_4.id)
       end
+
+      it 'should respond OK with course_step_6 - practice question' do
+        get :edit, params: { id: course_step_6.id }
+        expect_edit_success_with_model('course_step', course_step_6.id)
+      end
     end
 
     describe "POST 'create'" do


### PR DESCRIPTION
- **What?** Practice Questions Edit mode order of questions is wrong.
- **Why?** questions not being sorted according to sorting_order attribute.
- **How?** sorted questions according to sorting_order attribute.
- **How to test?** Go to a practice question (kind = standard, with at least two questions) on the admin side and update the sorting order of the questions. The questions should be in the order in which they were set. 

https://learnsignal-team.monday.com/boards/964007792/pulses/1055755520