### PR TITLE
modify cbe class for editing pasted user response

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6699,6 +6699,16 @@ button.sub-details[aria-expanded="true"]:before{
   z-index: 1;
 }
 
+#questionTabsContent > div > div.col-sm-12 {
+  .tab-content {
+    .textLayer {
+      position: inherit;
+      opacity: 0.75;
+      line-height: 1.5;
+    }
+  }
+}
+
 .load-overlay {
   z-index: 1030;
   position: fixed;


### PR DESCRIPTION
- **What?** CBE correction formatting Issue.
- **Why?** Inherits class when user pastes question content from requirements modal.
- **How?** modify cbe class for editing pasted user response.
- **How to test?** On the console side, edit a cbe to have a section with a type of exhibits scenario. Add a requirement text. Bold some part of the text for extra measure. Add an open user response. On the student side, when filling out the cbe paste from requirements. back on the console side it should be in a clear and legible format. 

https://learnsignal-team.monday.com/boards/964007792/pulses/1059382983