### PR TITLE
Product type in order_complete url.

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -77,7 +77,9 @@ class OrdersController < ApplicationController
       flash[:success] =
         I18n.t('controllers.orders.create.flash.mock_exam_success')
       if @order.product.lifetime_access?
-        redirect_to order_complete_url(product_id: @order.product_id, order_id: @order.id)
+        redirect_to order_complete_url(product_id: @order.product_id,
+                                       product_type: @order.product.url_by_type,
+                                       order_id: @order.id)
       else
         redirect_to user_exercises_path(current_user)
       end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -90,6 +90,10 @@ class Product < ApplicationRecord
     end
   end
 
+  def url_by_type
+    lifetime_access? ? 'lifetime' : product_type
+  end
+
   # class methods
   def self.search(search)
     search.present? ? where('name ILIKE ?', "%#{search}%") : all

--- a/app/views/orders/create.json.jbuilder
+++ b/app/views/orders/create.json.jbuilder
@@ -3,4 +3,6 @@
 json.call(@order, :id)
 json.status        @order.state
 json.client_secret @order.stripe_client_secret
-json.url           order_complete_url(product_id: @order.product_id, order_id: @order.id)
+json.url           order_complete_url(product_id: @order.product_id,
+                                      product_type: @order.product.url_by_type,
+                                      order_id: @order.id)

--- a/app/views/orders/order_complete.html.haml
+++ b/app/views/orders/order_complete.html.haml
@@ -37,22 +37,24 @@
       content_category: "#{@product&.product_type.humanize}"
     });
 
-    gtag('event', 'purchase', {
-      "transaction_id": "#{@order&.id}",
-      "affiliation": "products",
-      "value": "#{@product&.price}",
-      "currency": "#{@product&.currency&.iso_code}",
-      "items": [
-        {
-          "id": "#{@product&.id}",
-          "name": "#{@product&.name}",
-          "brand": "#{@product&.product_type}",
-          "category": "#{@product&.product_type.humanize}",
-          "quantity": 1,
-          "price": "#{@product&.price}"
-        },
-      ]
-    });
+    if("#{@product&.url_by_type}" == "lifetime") {
+      gtag('event', 'purchase', {
+        "transaction_id": "#{@order&.id}",
+        "affiliation": "products",
+        "value": "#{@product&.price}",
+        "currency": "#{@product&.currency&.iso_code}",
+        "items": [
+          {
+            "id": "#{@product&.id}",
+            "name": "#{@product&.name}",
+            "brand": "#{@product&.product_type}",
+            "category": "#{@product&.product_type.humanize}",
+            "quantity": 1,
+            "price": "#{@product&.price}"
+          },
+        ]
+      });
+    }
 
     analytics.page('Payment Complete', {
       exam_body_id: "#{@product&.group&.exam_body&.id}",
@@ -64,5 +66,4 @@
       country: "#{current_user&.country&.name}",
       payment_provider: "#{@order&.payment_provider}"
     });
-
   });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,7 +281,7 @@ Rails.application.routes.draw do
       end
     end
     get 'orders/:exam_body_id/lifetime-membership', to: 'orders#new'
-    get 'order_complete/:order_id/product/:product_id', to: 'orders#order_complete', as: :order_complete
+    get 'order_complete/:order_id/:product_type/:product_id', to: 'orders#order_complete', as: :order_complete
     resources :quiz_questions, except: [:index], concerns: :supports_reordering
     resources :refunds
     resources :vat_codes

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -161,7 +161,9 @@ describe OrdersController, type: :controller do
         expect(flash[:success]).not_to be_nil
         expect(flash[:error]).to be_nil
         expect(response.status).to eq(302)
-        expect(response).to redirect_to(order_complete_url(product_id: order_3.product_id, order_id: order_3.id))
+        expect(response).to redirect_to(order_complete_url(product_id: order_3.product_id,
+                                                           product_type: order_3.product.url_by_type,
+                                                           order_id: order_3.id))
       end
 
       it 'should return an error' do
@@ -175,7 +177,8 @@ describe OrdersController, type: :controller do
 
     describe "GET 'order_complete'" do
       it 'should respond OK' do
-        get :order_complete, params: { order_id: order_3.id, product_id: product_1.id }
+        get :order_complete, params: { order_id: order_3.id, product_id: product_1.id, product_type: product_1.url_by_type, }
+
         expect(flash[:success]).to be_nil
         expect(flash[:error]).to be_nil
         expect(response.status).to eq(200)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -179,5 +179,21 @@ describe Product do
         end
       end
     end
+
+    describe '.url_by_type' do
+      context 'for lifetime Products' do
+        it 'returns the name of the CBE' do
+          allow_any_instance_of(Product).to receive(:lifetime_access?).and_return(true)
+
+          expect(order_product.url_by_type).to eq('lifetime')
+        end
+      end
+
+      context 'for non lifetime Procucts' do
+        it 'returns the name of the Product (if there is no MockExam)' do
+          expect(order_product.url_by_type).to eq(order_product.product_type)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
What? Product type in order_complete url.
Why? We need this params to check lifetime product and send those data to our GA account.
How? Creating a new param in url.
How to test? Buy a product, if is a lifetime product type you should see data sent to our GA account.

Commit details: 

- Add product type to order_complete url;
- Add a helper to get correct product type param.
- Add a check to send product purchase just for lifetime access products.