### PR TITLE
Check for a subscription in invoice file.

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -7,7 +7,7 @@ class InvoicesController < ApplicationController
   before_action :set_invoice, except: :index
 
   def index
-    @invoices = current_user.invoices.order(created_at: :desc)
+    @invoices = current_user.invoices.valids.order(created_at: :desc)
   end
 
   def show

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -81,6 +81,7 @@ class Invoice < ApplicationRecord
   scope :all_in_order,     -> { order(user_id: :asc, id: :desc) }
   scope :subscriptions,    -> { where.not(subscription_id: nil) }
   scope :orders,           -> { where.not(order_id: nil) }
+  scope :valids,           -> { where('subscription_id IS NOT NULL OR order_id IS NOT NULL') }
   scope :from_year_start,  -> { where("DATE(created_at) >= ?", Date.today.beginning_of_year) }
   scope :from_yesterday,   -> { where("DATE(created_at) = ?", Date.today - 1) }
 

--- a/app/views/invoices/index.html.haml
+++ b/app/views/invoices/index.html.haml
@@ -37,7 +37,7 @@
                                   =link_to pdf_invoice_path(invoice.id, format: 'pdf'), target: '_blank' do
                                     .btn.btn-link.btn-xs
                                       View
-                                -elsif (invoice&.subscription.pending_3d_secure? && invoice.requires_3d_secure) || (invoice.status == 'Past Due' && invoice.sca_verification_guid.present?)
+                                -elsif (invoice&.subscription&.pending_3d_secure? && invoice.requires_3d_secure) || (invoice.status == 'Past Due' && invoice.sca_verification_guid.present?)
                                   =link_to show_invoice_url(invoice.sca_verification_guid) do
                                     .btn.btn-primary.btn-xs
                                       =invoice.requires_3d_secure ? 'Authenticate' : 'Confirm Payment'

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -100,6 +100,7 @@ describe Invoice do
   it { expect(Invoice).to respond_to(:all_in_order) }
   it { expect(Invoice).to respond_to(:subscriptions) }
   it { expect(Invoice).to respond_to(:orders) }
+  it { expect(Invoice).to respond_to(:valids) }
 
   # class methods
   it { expect(Invoice).to respond_to(:to_csv) }


### PR DESCRIPTION
What? A fix to invoices list
Why? A error happened to some user when they try to check invoices page
How? Add a check to hide incorrect invoices;
How to test? Go to user account with incorrect invoices(empty order_id and subscription_id)and check all invoices.
