### PR TITLE
added styling to make course name text selectable so user can copy th…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7157,6 +7157,7 @@ button.sub-details[aria-expanded="true"]:before{
     overflow: hidden;
     line-height: 2;
     color: #000032;
+    position: relative;
   }
 }
 .course-right-show-content {


### PR DESCRIPTION
- **What?** students cant copy course name title.
- **Why?** other css elements are overlapping that don't allow the user to select the text..
- **How?** added styling to make course name text selectable so user can copy the text.
- **How to test?** enter any course and try to select and copy the title of that specific course.

https://learnsignal-team.monday.com/boards/964007792/pulses/1055884787