### PR TITLE
Add a check to pending 3d secure in invoice before display invoice link.

### DIFF
--- a/app/views/user_accounts/_account_info.html.haml
+++ b/app/views/user_accounts/_account_info.html.haml
@@ -75,7 +75,7 @@
                                 %span{class: invoice.status == 'Paid' ? 'text-success' : 'text-danger'}
                                   =invoice.status
                               %td
-                                -if (subscription.pending_3d_secure? && invoice.requires_3d_secure) || invoice.status == 'Past Due'
+                                -if ((subscription.pending_3d_secure? && invoice.requires_3d_secure) || (invoice.status == 'Past Due' && invoice.requires_3d_secure))
                                   =link_to show_invoice_url(invoice.sca_verification_guid) do
                                     .btn.btn-primary.btn-xs
                                       =invoice.requires_3d_secure ? 'Authenticate' : 'Confirm Payment'


### PR DESCRIPTION
What? Some users can't access account link.
Why? Error when try to create a link to past due invoices
How? Add a new check to pending 3d secure data before display invoice link
How to test? check account of a user with past_due invoice.

[error](https://appsignal.com/learnsignal/sites/5fd7667c14ad662e268478e2/exceptions/incidents/306/samples/5fd7667c14ad662e268478e2-1630746882367908186116141680003)