### PR TITLE
changed class to block for formatting on the admin side + top padding…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6703,6 +6703,9 @@ button.sub-details[aria-expanded="true"]:before{
       opacity: 0.75;
       line-height: 1.5;
     }
+    .titlebar {
+      display: block;
+    }
   }
 }
 .cbe-content-template {

--- a/app/javascript/views/cbes/Questions.vue
+++ b/app/javascript/views/cbes/Questions.vue
@@ -14,7 +14,7 @@
           v-html="questionData.scenario.content"
         />
         <span>
-          <section v-html="questionData.content" />
+          <section class="cbe-content-template" v-html="questionData.content" />
 
           <QuestionAnswers
             :answers-data="questionData.answers"


### PR DESCRIPTION
- **What?** formatting breaks in cbe user response on admin side + top of question padding missing.
- **Why?** related to pasted styling from vue component.
- **How?** changed class to block for formatting on the admin side + top padding question content.
- **How to test?** found the format issue very difficult to replicate, when this happened before I replicated it by pasting from our third party editors text and spreadsheet. Know this works from changing html on production. As far as the top padding, added it to a component that is missing it.