### PR TITLE
Rails.application.assets comes up undefined in production, changed to…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,6 +87,8 @@ module ApplicationHelper
   def asset_exists?(path)
     if Rails.configuration.assets.compile
       Rails.application.precompiled_assets.include? path
+    elsif Rails.env.production? || Rails.env.staging?
+      Rails.application.assets_manifest.assets[path].present?
     else
       (Rails.application.assets.find_asset path).present?
     end


### PR DESCRIPTION
- **What?** on landing pages the page fails to render because of undefined Rails.application.assets error.
- **Why?** Rails.application.assets failing in production.
- **How?** Rails.application.assets comes up undefined in production, changed to assets_manifest.
- **How to test?** check landing pages on mobile on staging.