### PR TITLE
added respond_to like that in home method to prevent strangely format…

### DIFF
--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -69,7 +69,11 @@ class StudentSignUpsController < ApplicationController
 
         referral_code = ReferralCode.find_by(code: request.params[:ref_code]) if params[:ref_code]
         drop_referral_code_cookie(referral_code) if params[:ref_code] && referral_code
-        # This is for sticky sub plans
+        # Added respond block to stop the missing template errors with image, text, json types
+        respond_to do |format|
+          format.html
+          format.all { redirect_to(missing_page_url) }
+        end
       end
 
       seo_title_maker(@home_page.seo_title, @home_page.seo_description, @home_page.seo_no_index)


### PR DESCRIPTION
- **What?** StudentSignUpsController#landing is missing a template for the request formats: ["image/gif", "image/x-bitmap", "image/jpeg", "image/pjpeg"]
- **Why?** Undesired request, only want html to pass.
- **How?** added respond_to like that in home method to prevent strangely formatted requests.
- **How to test?** check landing pages are still accessed like they should be.