### PR TITLE
added a redirect to admin courses if course id is inaccesible

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -23,7 +23,11 @@ module Admin
         end
     end
 
-    def show; end
+    def show
+      return if @course
+
+      redirect_to admin_courses_path
+    end
 
     def new
       @course = Course.new(sorting_order: 1)

--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -76,6 +76,11 @@ describe Admin::CoursesController, type: :controller do
         get :show, params: { id: course_2.id }
         expect_show_success_with_model('course', course_2.id)
       end
+
+      it 'should go back to admin courses index' do
+        get :show, params: { id: 999999999999 }
+        expect(response).to redirect_to(admin_courses_path)
+      end
     end
 
     describe "GET 'new'" do


### PR DESCRIPTION
- **What?** undefined method `name' for nil:NilClass for admin course show.
- **Why?** if course id doesn't exist there is no redirect back to courses.
- **How?** added a redirect to admin courses if course id is inaccesible.
- **How to test?** if you have a recent prod db you can compare the existing course: http://localhost:3000/en/admin/courses/89
with the nil course giving the error:
http://localhost:3000/en/admin/courses/4905512

The first should redirect to the course show, and the second to the courses index.
https://learnsignal-team.monday.com/boards/964007792/pulses/1055889523