### PR TITLE
filtered by the scenarios that are active

### DIFF
--- a/app/models/cbe/user_log.rb
+++ b/app/models/cbe/user_log.rb
@@ -53,7 +53,7 @@ class Cbe
     end
 
     def scenarios_in_user_log
-      cbe.scenarios
+      cbe.scenarios.select(&:active)
     end
 
     def exhibits?

--- a/spec/models/cbe/user_log_spec.rb
+++ b/spec/models/cbe/user_log_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Cbe::UserLog, type: :model do
       expect(cbe_user_log.sections_in_user_log).to be_empty
     end
 
+    it '.scenarios_in_user_log' do
+      expect(cbe_user_log.scenarios_in_user_log).to be_empty
+    end
+
     it 'update_exercise_status' do
       private_cbe_user_log.questions.map { |q| q.cbe_question.update(kind: 'multiple_choice') }
       private_cbe_user_log.update(status: 'finished')


### PR DESCRIPTION
- **What?** CBE correction shows additional scenario tabs that should not be there.
- **Why?** Showing all scenarios, should be showing scenarios active for that user.
- **How?** filtered by the scenarios that are active.
- **How to test?** go to a cbe correction and inspect the tabs. The tabs should have a unique name, and when you click on a tab, new information should show up.

https://learnsignal-team.monday.com/boards/964007792/pulses/1100014078