### PR TITLE
automated year creation and added charts to conversion rate dashboard

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3146,6 +3146,40 @@ cite {
 .tab-content {
   padding-bottom: 1rem
 }
+.dash-tooltip {
+  position: absolute;
+  right: 5%;
+  top: -5%;
+  display: flex !important;
+  padding: .3em;
+  border: 1px solid #e1e8ed;
+  border-radius: 5px;
+  background-color: #ffffff;
+  i {
+    font-size: .5em;
+    color: #e1e8ed;
+  }
+}
+.dash-tooltip:focus {
+  outline: none;
+}
+.dash-tooltip-overlay {
+  display: none;
+  width: 100%;
+  height: 105%;
+  background-color: #303538;
+  position: absolute;
+  top: -1.55em;
+  left: 0;
+  z-index: 1;
+  border-radius: 2px;
+  opacity: 0.95;
+  p {
+    color: #e1e8ed;
+    font-size: .75em;
+    padding: 2em;
+  }
+}
 .navbar {
   -webkit-box-pack: center;
   -webkit-justify-content: center;

--- a/app/controllers/management_consoles_controller.rb
+++ b/app/controllers/management_consoles_controller.rb
@@ -12,45 +12,8 @@ class ManagementConsolesController < ApplicationController
 
   def index
     @verified_users = User.where(email_verified: true)
-
-    @january_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 1).beginning_of_month, Date.new(2018, 1).end_of_month)
-    @february_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 2).beginning_of_month, Date.new(2018, 2).end_of_month)
-    @march_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 3).beginning_of_month, Date.new(2018, 3).end_of_month)
-    @april_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 4).beginning_of_month, Date.new(2018, 4).end_of_month)
-    @may_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 5).beginning_of_month, Date.new(2018, 5).end_of_month)
-    @june_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 6).beginning_of_month, Date.new(2018, 6).end_of_month)
-    @july_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 7).beginning_of_month, Date.new(2018, 7).end_of_month)
-    @august_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 8).beginning_of_month, Date.new(2018, 8).end_of_month)
-    @september_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 9).beginning_of_month, Date.new(2018, 9).end_of_month)
-    @october_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 10).beginning_of_month, Date.new(2018, 10).end_of_month)
-    @november_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 11).beginning_of_month, Date.new(2018, 11).end_of_month)
-    @december_users18 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2018, 12).beginning_of_month, Date.new(2018, 12).end_of_month)
-
-    @january_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 1).beginning_of_month, Date.new(2019, 1).end_of_month)
-    @february_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 2).beginning_of_month, Date.new(2019, 2).end_of_month)
-    @march_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 3).beginning_of_month, Date.new(2019, 3).end_of_month)
-    @april_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 4).beginning_of_month, Date.new(2019, 4).end_of_month)
-    @may_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 5).beginning_of_month, Date.new(2019, 5).end_of_month)
-    @june_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 6).beginning_of_month, Date.new(2019, 6).end_of_month)
-    @july_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 7).beginning_of_month, Date.new(2019, 7).end_of_month)
-    @august_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 8).beginning_of_month, Date.new(2019, 8).end_of_month)
-    @september_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 9).beginning_of_month, Date.new(2019, 9).end_of_month)
-    @october_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 10).beginning_of_month, Date.new(2019, 10).end_of_month)
-    @november_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 11).beginning_of_month, Date.new(2019, 11).end_of_month)
-    @december_users19 = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2019, 12).beginning_of_month, Date.new(2019, 12).end_of_month)
-
-    @january_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 1).beginning_of_month, Date.new(2020, 1).end_of_month)
-    @february_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 2).beginning_of_month, Date.new(2020, 2).end_of_month)
-    @march_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 3).beginning_of_month, Date.new(2020, 3).end_of_month)
-    @april_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 4).beginning_of_month, Date.new(2020, 4).end_of_month)
-    @may_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 5).beginning_of_month, Date.new(2020, 5).end_of_month)
-    @june_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 6).beginning_of_month, Date.new(2020, 6).end_of_month)
-    @july_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 7).beginning_of_month, Date.new(2020, 7).end_of_month)
-    @august_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 8).beginning_of_month, Date.new(2020, 8).end_of_month)
-    @september_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 9).beginning_of_month, Date.new(2020, 9).end_of_month)
-    @october_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 10).beginning_of_month, Date.new(2020, 10).end_of_month)
-    @november_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 11).beginning_of_month, Date.new(2020, 11).end_of_month)
-    @december_users = @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(2020, 12).beginning_of_month, Date.new(2020, 12).end_of_month)
+    total_years_of_data_to_show = 4
+    define_year_month_instance_vars(total_years_of_data_to_show)
   end
 
   def system_requirements
@@ -59,5 +22,30 @@ class ManagementConsolesController < ApplicationController
 
   def public_resources
     @faq_sections = FaqSection.paginate(per_page: 50, page: params[:page]).all_in_order
+  end
+
+  private
+
+  def year_months(last_month)
+    months = [['-', '']]
+    (1..last_month).each { |m| months << [Date::MONTHNAMES[m], m] }
+    months.drop(1)
+  end
+
+  def define_year_month_instance_vars(years_back)
+    @months_to_date = year_months(Time.zone.today.month)
+    @all_months = year_months(12)
+    year_arr = []
+    Array.new(years_back) do |i|
+      year_4_digit = Time.zone.today.year - i
+      year_2_digit = ((Time.zone.today + 6).year - i) % 100
+      year_arr << year_4_digit
+      if i < 1
+        @months_to_date.map { |month, index| instance_variable_set("@#{month.downcase}_users", @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(year_4_digit, index).beginning_of_month, Date.new(year_4_digit, index).end_of_month)) }
+      else
+        @all_months.map { |month, index| instance_variable_set("@#{month.downcase}_users#{year_2_digit}", @verified_users.where('users.created_at > ? AND users.created_at < ?', Date.new(year_4_digit, index).beginning_of_month, Date.new(year_4_digit, index).end_of_month)) }
+      end
+      @year_arr = year_arr.reverse
+    end
   end
 end

--- a/app/views/management_consoles/index.html.haml
+++ b/app/views/management_consoles/index.html.haml
@@ -8,367 +8,217 @@
   %section.pb-3
     %nav.graph-nav
       %ul.nav.nav-tabs{id: 'graphTabs', role: 'tablist'}
-        %li.nav-item
-          %a#tab-2018.nav-link{"aria-controls" => "2018", "aria-selected" => "false", "data-toggle" => "tab", :href => "#tab-1", :role => "tab"}
-            2018
-        %li.nav-item
-          %a#tab-2019.nav-link{"aria-controls" => "2019", "aria-selected" => "false", "data-toggle" => "tab", :href => "#tab-2", :role => "tab"}
-            2019
-        %li.nav-item
-          %a#tab-2020.nav-link.active{"aria-controls" => "2020", "aria-selected" => "true", "data-toggle" => "tab", :href => "#tab-3", :role => "tab"}
-            2020
-
+        - @year_arr.each_with_index do |year, index|
+          %li.nav-item
+            %a.nav-link{:id => "tab-#{year}", :class => ("active" if index == (@year_arr.length - 1)), "aria-controls" => "#{year}", "aria-selected" => "false", "data-toggle" => "tab", :href => "#tab-#{index+1}", :role => "tab"}
+              =year
 
     #graphTabsContent.tab-content
-      .tab-pane{id: 'tab-1', class: "", "aria-labelledby" => 'tab-2018', :role => 'tabpanel'}
-        .box-item
-          %h3 2018
-          .row
-            .col-sm-12
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @january_users18.count.to_f
-                        - members = @january_users18.paid_that_month(Date.new(2018, 1)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        January
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @february_users18.count.to_f
-                        - members = @february_users18.paid_that_month(Date.new(2018, 2)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        February
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @march_users18.count.to_f
-                        - members = @march_users18.paid_that_month(Date.new(2018, 3)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        March
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @april_users18.count.to_f
-                        - members = @april_users18.paid_that_month(Date.new(2018, 4)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        April
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @may_users18.count.to_f
-                        - members = @may_users18.paid_that_month(Date.new(2018, 5)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        May
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @june_users18.count.to_f
-                        - members = @june_users18.paid_that_month(Date.new(2018, 6)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        June
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @july_users18.count.to_f
-                        - members = @july_users18.paid_that_month(Date.new(2018, 7)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        July
+      - @year_arr.each_with_index do |year, index|
+        .tab-pane{id: "tab-#{index+1}", :class => ("active show " if index == (@year_arr.length - 1)), "aria-labelledby" => "tab-#{index+1}", :role => 'tabpanel'}
+          .box-item
+            %h3
+              =year
+            .row
+              .col-sm-12
+                .row
+                  .col-lg-6
+                    %div.dash-tooltip-overlay
+                      %p
+                        The observer is meant to come away with months where members were trending up and leads down, or vice versa. To better understand historical marketing campaigns and student retention.
+                    %button.material-icons.dash-tooltip{ :title => "Monthly Conversion Rate Tooltip", :value => 1 }
+                      %i.fa.fa-question
+                    %canvas{:id => "chart-1-#{year}", :height => "200", :width => "200", :value => 1 }
+                  .col-lg-6
+                    %div.dash-tooltip-overlay
+                      %p
+                        Meant to inform the observer of the best and worst performing months (in terms of conversion rate) at a quick glance.
+                    %button.material-icons.dash-tooltip{ :title => "Ev. of Members vs Ev. of Leads Tooltip" }
+                      %i.fa.fa-question
+                    %canvas{:id => "chart-2-#{year}", :height => "200", :width => "200", :value => 2 }
+                %br
+                .row
+                  - if index == (@year_arr.length - 1)
+                    - year_str = ""
+                    - months_var = @months_to_date
+                  - else
+                    - year_str = "#{year % 100}"
+                    - months_var = @all_months
+                  - months_var.each_with_index do |month, index|
+                    .col-sm-3
+                      .stats-box
+                        .stats-box-inner
+                          .h3
+                            - leads = instance_variable_get("@#{month[0].downcase}_users#{year_str}").count.to_f
+                            - members = instance_variable_get("@#{month[0].downcase}_users#{year_str}").paid_that_month(Date.new(year, month[1])).count.to_f
+                            =((members/leads) * 100).round(2).to_s + '%'
+                          .p{:id => "leads-#{month[0].downcase}-#{year}", :style => "display:none"}
+                            =leads
+                          .p{:id => "members-#{month[0].downcase}-#{year}", :style => "display:none"}
+                            =members
+                          .p
+                            =month[0]
 
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @august_users18.count.to_f
-                        - members = @august_users18.paid_that_month(Date.new(2018, 8)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        August
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @september_users18.count.to_f
-                        - members = @september_users18.paid_that_month(Date.new(2018, 9)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        September
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @october_users18.count.to_f
-                        - members = @october_users18.paid_that_month(Date.new(2018, 10)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        October
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @november_users18.count.to_f
-                        - members = @november_users18.paid_that_month(Date.new(2018, 11)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        November
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @december_users18.count.to_f
-                        - members = @december_users18.paid_that_month(Date.new(2018, 12)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        December
+    :javascript
 
+      $(".dash-tooltip").click(function (e) {
+        var index = $(".dash-tooltip").index(this);
+        $(".dash-tooltip-overlay").eq(index).css("display","block");
 
+      });
 
-      .tab-pane{id: 'tab-2', class: "", "aria-labelledby" => 'tab-2019', :role => 'tabpanel'}
-        .box-item
-          %h3 2019
-          .row
-            .col-sm-12
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @january_users19.count.to_f
-                        - members = @january_users19.paid_that_month(Date.new(2019, 1)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        January
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @february_users19.count.to_f
-                        - members = @february_users19.paid_that_month(Date.new(2019, 2)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        February
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @march_users19.count.to_f
-                        - members = @march_users19.paid_that_month(Date.new(2019, 3)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        March
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @april_users19.count.to_f
-                        - members = @april_users19.paid_that_month(Date.new(2019, 4)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        April
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @may_users19.count.to_f
-                        - members = @may_users19.paid_that_month(Date.new(2019, 5)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        May
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @june_users19.count.to_f
-                        - members = @june_users19.paid_that_month(Date.new(2019, 6)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        June
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @july_users19.count.to_f
-                        - members = @july_users19.paid_that_month(Date.new(2019, 7)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        July
+      $(document).ready(function() {
+        $(".dash-tooltip-overlay").each(function() {
+          $(this)
+            .mouseleave(function() {
+              $(this).css( "display", "none" );
+            });
+        })
+      });
 
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @august_users19.count.to_f
-                        - members = @august_users19.paid_that_month(Date.new(2019, 8)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        August
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @september_users19.count.to_f
-                        - members = @september_users19.paid_that_month(Date.new(2019, 9)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        September
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @october_users19.count.to_f
-                        - members = @october_users19.paid_that_month(Date.new(2019, 10)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        October
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @november_users19.count.to_f
-                        - members = @november_users19.paid_that_month(Date.new(2019, 11)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        November
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @december_users19.count.to_f
-                        - members = @december_users19.paid_that_month(Date.new(2019, 12)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        December
+      var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      var years = '#{@year_arr}'.replace(/[\[\]']+/g,'').split(", ");
+      var chartArr = ['1', '2'];
+      years.forEach(function(year){
+        var leads_per_month = [];
+        var members_per_month = [];
+        var conversion_rate = [];
+        months.forEach(function(month) {
+          if(document.getElementById('leads-' + month.toLowerCase() + '-' + year)) {
+            leads_per_month.push(parseInt(document.getElementById('leads-' + month.toLowerCase() + '-' + year).innerText));
+            members_per_month.push(parseInt(document.getElementById('members-' + month.toLowerCase() + '-' + year).innerText));
+            conversion_rate.push(Math.round(((parseInt(document.getElementById('members-' + month.toLowerCase() + '-' + year).innerText)/parseInt(document.getElementById('leads-' + month.toLowerCase() + '-' + year).innerText))*100+ Number.EPSILON) * 100) / 100);
+          }
+        });
+        leads_per_month = leads_per_month.filter( Number );
+        members_per_month = members_per_month.filter( Number );
+        conversion_rate = conversion_rate.filter( Number );
+        chartArr.forEach(function(chartInd) {
+          switch(chartInd) {
+            case '1':
+              getChartData('Monthly Conversion Rate', 'horizontalBar', chartInd, year, conversion_rate, months, 'Conversion Rate (%)', ['rgba(54, 162, 235, 0.2)', 'rgba(54, 162, 235, 1)'],'%');
+              break;
+            case '2':
+              getMixedChartData('Evolution of Members vs Evolution of Leads', chartInd, year, members_per_month, leads_per_month, months, '# of Leads', '# of Members', ['rgba(54, 162, 235, 0.2)', 'rgba(54, 162, 235, 1)'],'');
+              break;
+            default:
+              getChartData('Monthly Conversion Rate', 'horizontalBar', chartInd, year, conversion_rate, months, 'Conversion Rate (%)', ['rgba(54, 162, 235, 0.2)', 'rgba(54, 162, 235, 1)'],'%');
+          }
+        });
+      });
 
-      .tab-pane{id: 'tab-3', class: 'active show ', "aria-labelledby" => 'tab-2020', :role => 'tabpanel'}
-        .box-item
-          %h3 2020
-          .row
-            .col-sm-12
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @january_users.count.to_f
-                        - members = @january_users.paid_that_month(Date.new(2020, 1)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        January
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @february_users.count.to_f
-                        - members = @february_users.paid_that_month(Date.new(2020, 2)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        February
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @march_users.count.to_f
-                        - members = @march_users.paid_that_month(Date.new(2020, 3)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        March
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @april_users.count.to_f
-                        - members = @april_users.paid_that_month(Date.new(2020, 4)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        April
-              .row
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @may_users.count.to_f
-                        - members = @may_users.paid_that_month(Date.new(2020, 5)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        May
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @june_users.count.to_f
-                        - members = @june_users.paid_that_month(Date.new(2020, 6)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        June
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @july_users.count.to_f
-                        - members = @july_users.paid_that_month(Date.new(2020, 7)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        July
+      function getChartData(chart_title, chartType, chartIndex, year, eval_per_month, months, chart_legend, chart_colors, percent_show) {
+        var ctx = document.getElementById('chart-' + chartIndex + '-' + year);
+        var myChart = new Chart(ctx, {
+            type: chartType,
+            data: {
+                labels: months,
+                datasets: [{
+                    label: chart_legend,
+                    data: eval_per_month,
+                    backgroundColor: chart_colors[0],
+                    borderColor: chart_colors[1],
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                title: {
+                    display: true,
+                    text: chart_title
+                },
+                legend: {
+                    display: true,
+                    position: 'bottom',
+                },
+                tooltips: {
+                  callbacks: {
+                    label: function(tooltipItem, data) {
+                      return data['labels'][tooltipItem['index']] + ': ' + data['datasets'][0]['data'][tooltipItem['index']] + percent_show;
+                    }
+                  }
+                },
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true
+                        }
+                    }]
+                }
+            }
+        });
+      }
 
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @august_users.count.to_f
-                        - members = @august_users.paid_that_month(Date.new(2020, 8)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        August
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @september_users.count.to_f
-                        - members = @september_users.paid_that_month(Date.new(2020, 9)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        September
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @october_users.count.to_f
-                        - members = @october_users.paid_that_month(Date.new(2020, 10)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        October
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @november_users.count.to_f
-                        - members = @november_users.paid_that_month(Date.new(2020, 11)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        November
-                .col-sm-3
-                  .stats-box
-                    .stats-box-inner
-                      .h3
-                        - leads = @december_users.count.to_f
-                        - members = @december_users.paid_that_month(Date.new(2020, 12)).count.to_f
-                        =((members/leads) * 100).round(2).to_s + '%'
-                      .p
-                        December
+      function getMixedChartData(chart_title, chartIndex, year, eval_per_month1, eval_per_month2, months, chart_legend1, chart_legend2, chart_colors, percent_show) {
+        var ctx = document.getElementById('chart-' + chartIndex + '-' + year);
+        var max_val_1 = Math.max.apply(null, eval_per_month1);
+        var max_val_2 = Math.max.apply(null, eval_per_month2);
+        var chart_axis1 = chart_legend1.replace('# of ','');
+        var chart_axis2 = chart_legend2.replace('# of ','');
+
+        var myChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: months,
+              datasets: [{
+                  label: chart_legend1,
+                  type: "line",
+                  borderColor: "#8e5ea2",
+                  data: eval_per_month2,
+                  yAxisID: "id1-line",
+                  backgroundColor: 'rgba(153, 102, 255, 0.1)',
+                  fill: true
+                }, {
+                  label: chart_legend2,
+                  type: "bar",
+                  yAxisID: "id2-bar",
+                  data: eval_per_month1,
+                  backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                  borderColor: 'rgba(75, 192, 192, 1)',
+                  borderWidth: 1
+                }
+              ]
+            },
+            options: {
+              title: {
+                display: true,
+                text: chart_title
+              },
+              scales: {
+                yAxes: [{
+                    display: true,
+                    id: "id2-bar",
+                    position: 'left',
+                    ticks: {
+                      suggestedMin: 0,
+                      suggestedMax: max_val_1
+                    },
+                    scaleLabel: {
+                      display: true,
+                      beginAtZero: true,
+                      labelString: chart_axis2
+                    },
+                  },{
+                    display: true,
+                    position: 'right',
+                    gridLines: {
+                        display: false
+                    },
+                    ticks: {
+                      suggestedMin: 0,
+                      suggestedMax: max_val_2
+                    },
+                    scaleLabel: {
+                      display: true,
+                      beginAtZero: true,
+                      labelString: chart_axis1
+                    },
+                    id: "id1-line"
+                }]
+              },
+              legend: {
+                display: true,
+                position: 'bottom'
+              }
+            }
+        });
+      }


### PR DESCRIPTION
- **What?** need to add extra year to conversion rate, and it should update automatically every year.
- **Why?** to avoid manually updating code.
- **How?** automated year creation and added charts to conversion rate dashboard.
- **How to test?** Go to console and verify that the kpis still have the same values they did on the staging branch. Also lookover the charts and see if anything seems out of place or difficult to understand.

https://learnsignal-team.monday.com/boards/964007792/pulses/1085524975