### PR TITLE
Added & to Segment user traits calls

### DIFF
--- a/app/services/segment_service.rb
+++ b/app/services/segment_service.rb
@@ -9,8 +9,7 @@ class SegmentService
       traits: user_traits(user)
     )
   rescue StandardError => e
-    Rails.logger.error "SegmentService#create_user - #{e.inspect}"
-    # ApplicationController.log_in_airbrake("Segment: Create User #{user.id}: #{e.message}")
+    Rails.logger.error "SegmentService#create_user - Error: #{e.inspect} - User Id #{user&.id}"
   end
 
   def track_verification_event(user)
@@ -31,28 +30,28 @@ class SegmentService
 
   def user_traits(user)
     {
-      name: user.full_name,
-      email: user.email,
-      first_name: user.first_name,
-      last_name: user.last_name,
-      created_at: user.created_at.to_time.iso8601,
-      user_group: user.user_group.name,
-      stripe_customer_id: user.stripe_customer_id,
-      email_verified: user.email_verified,
-      email_verified_at: user.email_verified_at.to_time.iso8601,
-      preferred_exam_body: user.preferred_exam_body.name,
-      date_of_birth: user.date_of_birth,
-      video_player_preference: user.video_player,
-      currency: user.currency.name,
-      onboarding_status: user.onboarding_state
+      name: user&.full_name,
+      email: user&.email,
+      first_name: user&.first_name,
+      last_name: user&.last_name,
+      created_at: user&.created_at&.to_time&.iso8601,
+      user_group: user&.user_group&.name,
+      stripe_customer_id: user&.stripe_customer_id,
+      email_verified: user&.email_verified,
+      email_verified_at: user&.email_verified_at&.to_time&.iso8601,
+      preferred_exam_body: user&.preferred_exam_body&.name,
+      date_of_birth: user&.date_of_birth,
+      video_player_preference: user&.video_player,
+      currency: user&.currency&.name,
+      onboarding_status: user&.onboarding_state
     }
   end
 
   def verification_properties(user)
     {
-      email_verified_at: user.email_verified_at.to_time.iso8601,
-      exam_body_id: user.preferred_exam_body_id,
-      exam_body_name: user.preferred_exam_body.name
+      email_verified_at: user&.email_verified_at&.to_time&.iso8601,
+      exam_body_id: user&.preferred_exam_body_id,
+      exam_body_name: user&.preferred_exam_body&.name
     }
   end
 end


### PR DESCRIPTION
* **What?** Fix Segment Identify Crashes
* **Why?** Post verification and User/Subscription updates it is necessary to update the user on MixPanel. Segment identify calls were crashing for some users resulting in them not being created in Segment or MixPanel.
* **How?** Added ampersands to the user traits method in the Segment service as it was crashing for users that did not have a currency preset.
* **How to test?** Log in as any student user and update the record to not have a Currency Id assigned. I find the easiest way to trigger a user model update is to update the name or DOB on the students' account page. Check the Segment Ruby Dev source debugger section, you should see the Identify event in the logs. The advanced button allows you to filter the logs to specific calls which may help to find your identity call.


https://learnsignal-team.monday.com/boards/964007792/pulses/1100154690