### PR TITLE
Accredible error handler.

### DIFF
--- a/app/services/accredible/groups.rb
+++ b/app/services/accredible/groups.rb
@@ -13,10 +13,7 @@ module Accredible
     def service(path, method)
       response = response(path: path, method: method)
 
-      if response.code != '200'
-        Airbrake::AirbrakeLogger.new(Logger.new(STDOUT)).error response.body
-        Appsignal.send_error(Exception.new(response.body), {}, 'services')
-      end
+      return { error: response.body, status: response.code } if response.code != '200'
 
       JSON.parse(response.body).merge(status: response.code).with_indifferent_access
     end

--- a/app/views/admin/courses/_form.html.haml
+++ b/app/views/admin/courses/_form.html.haml
@@ -152,25 +152,26 @@
 
 
     $('#course_accredible_group_id').blur(function() {
-      $.ajax({
-        url: '#{admin_check_accredible_group_path}',
-        method: 'post',
-        dataType: 'json',
-        contentType: 'application/json; charset=utf-8',
-        data: JSON.stringify({ 'group_id': this.value }),
-        success: function(data,status,xhr){
-          $('.accredible_group_check_return').html("#{t('views.courses.form.accredible_group_id')}")
-          $('.accredible_group_check_return').removeAttr('style');
-        },
-        error: function(xhr,status,error){
-          $('.accredible_group_check_return').html(
-            "#{t('views.courses.form.accredible_group_id')} *" + error
-          )
-          $('.accredible_group_check_return').css('color', 'red');
-        }
-      });
+      if (this.value) {
+        $.ajax({
+          url: '#{admin_check_accredible_group_path}',
+          method: 'post',
+          dataType: 'json',
+          contentType: 'application/json; charset=utf-8',
+          data: JSON.stringify({ 'group_id': this.value }),
+          success: function(data,status,xhr){
+            $('.accredible_group_check_return').html("#{t('views.courses.form.accredible_group_id')}")
+            $('.accredible_group_check_return').removeAttr('style');
+          },
+          error: function(xhr,status,error){
+            $('.accredible_group_check_return').html(
+              "#{t('views.courses.form.accredible_group_id')} *" + error
+            )
+            $('.accredible_group_check_return').css('color', 'red');
+          }
+        });
+      }
     });
-
 
     $('#course_exam_body_id').change(function() {
       show_accredible_group();


### PR DESCRIPTION
What? Check for a value before try to use Accredible api
Why? We was checking every blur trigger in field, even with empty value
How? Add a check to group id value before user Accredible api, also remove appsignal and airbrake integration as we're already showing it(error) to admin users.
How to test? Go to new course page in admin, choose CPD as exam body and test invalids values in Accredible field.

[task link](https://learnsignal-team.monday.com/boards/964007792/pulses/1055889609)