### PR TITLE
Remove the helper skip witch came when we did master -> staging merge.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,8 +85,6 @@ module ApplicationHelper
   end
 
   def asset_exists?(path)
-    return false
-
     if Rails.configuration.assets.compile
       Rails.application.precompiled_assets.include? path
     elsif Rails.env.production? || Rails.env.staging?


### PR DESCRIPTION
What? remove the return true from application helper
Why? this change back from staging as we didn't merge master in staging as soon the hotfix was deployed to production;
How? Removing the return from method.
How to test? Check landing page in staging using mobile device.