### PR TITLE
created vue method to trigger windows resize event when adjuting spli…

### DIFF
--- a/app/javascript/components/practiceQuestions/MainView.vue
+++ b/app/javascript/components/practiceQuestions/MainView.vue
@@ -15,7 +15,7 @@
         </span>
       </div>
     </div>
-    <div class="questions">
+    <div class="questions" v-on:click="refreshSheetLayout()">
       <splitpanes class="practice-question-theme" :style="{ height: '70vh' }">
         <span v-if="practiceQuestion.kind == 'standard'">
           <ScenarioPane :content="practiceQuestion.content" />
@@ -210,6 +210,9 @@ export default {
         container: this.fullPage ? null : this.$refs.formContainer,
       });
     },
+    refreshSheetLayout() {
+      window.dispatchEvent(new Event('resize'));
+    }
   },
 };
 </script>


### PR DESCRIPTION
- **What?** when adjusting splitpanes some spreadsheet tables go blank and become unusable. 
- **Why?** an issue with the third party editor that gets fixed when adjusting window size.
- **How?** created vue method to trigger windows resize event when adjuting splitpanes.
- **How to test?** Go to a practice question with a spreadsheet and adjust the vertical bar that splits both panes. Before a big white block would appear at the right of the spreadsheet. Now it should not appear, or only flicker before dissapearing.

https://learnsignal-team.monday.com/boards/964007792/pulses/1109341179