### PR TITLE
removed iubenda btn when on cbes

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -53,9 +53,8 @@
       %meta{name: 'robots', content: 'noindex'}
     =render 'application/favicon'
 
-    -if Rails.env.production?
+    -if Rails.env.production? && controller_name != 'cbes'
       =render partial: 'layouts/cookie_banner'
-
 
   - if controller_name == 'cbes'
     %body.page-light


### PR DESCRIPTION
- **What?** on cbes the iumenda button icon is blocking the **help** button. 
- **Why?** the position of the icon overlays over the button.
- **How?** removed iubenda btn when on cbes.
- **How to test?** You would have to alter the code by negating Rails.env.production? (**!Rails.env.production?**). Then checking that the button shows up on other pages in the site, but not on cbes.

https://learnsignal-team.monday.com/boards/964007792/pulses/1109404549