### PR TITLE
Allow multiple Vat Rates for Vat Codes

### DIFF
--- a/app/controllers/vat_codes_controller.rb
+++ b/app/controllers/vat_codes_controller.rb
@@ -19,7 +19,9 @@ class VatCodesController < ApplicationController
     @vat_code.vat_rates.build
   end
 
-  def edit; end
+  def edit
+    @vat_code.vat_rates.build
+  end
 
   def create
     @vat_code = VatCode.new(allowed_params)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -324,8 +324,8 @@ class Invoice < ApplicationRecord
     return unless country&.vat_codes&.any?
 
     vat_code = country.vat_codes.first
-    vat_rate_id = VatRate.find_by(vat_code_id: vat_code.id).try(:id)
-    update_attribute(:vat_rate_id, vat_rate_id) if vat_rate_id
+    vat_rate = VatRate.where(vat_code_id: vat_code.id)&.all_in_order&.last
+    update_attribute(:vat_rate, vat_rate) if vat_rate
   end
 
   def set_issued_at

--- a/app/pdfs/invoice_document.rb
+++ b/app/pdfs/invoice_document.rb
@@ -8,7 +8,7 @@ class InvoiceDocument < Prawn::Document
   def initialize(invoice)
     super(top_margin: 70)
     @invoice  = invoice
-    @vat_rate = invoice.vat_rate ? @invoice.vat_rate.percentage_rate.to_s + '%' : '0%'
+    @vat_rate = invoice.vat_rate ? @invoice.vat_rate.percentage_rate.to_s + '%' : 'Na'
 
     logo
     render_headers

--- a/app/views/vat_codes/_form.html.haml
+++ b/app/views/vat_codes/_form.html.haml
@@ -23,28 +23,33 @@
               .input-group.input-group-lg
                 =f.text_field :label, placeholder: t('views.vat_codes.form.label_placeholder'), class: 'form-control'
 
-        .row.pt-4
-          .col-sm-12
-            -#if f.object.id.nil?
-            =f.fields_for :vat_rates do |rate|
-              .form-group
-                =rate.label :percentage_rate, t('views.vat_rates.form.percentage_rate')
-                .input-group.input-group-lg
-                  =rate.text_field :percentage_rate, placeholder: t('views.vat_rates.form.percentage_rate_placeholder'), class: 'form-control'
-              .form-group
-                =rate.label :effective_from, t('views.vat_rates.form.effective_from')
-                .input-group.input-group-lg
-                  =rate.text_field :effective_from, placeholder: t('views.vat_rates.form.effective_from_placeholder'), class: 'form-control date', data: {'date-format' => 'YYYY-MM-DD'}, id: 'datetimepicker1'
+  %hr/
+  %h2='Vat Rates'
+  =f.fields_for :vat_rates do |rate|
+    .box-item.form-box
+      .row.pt-4
+        .col-sm-12
+          -if rate.object.new_record?
+            %h3='New Vat Rate'
+          -else
+            %h3="Edit Vat Rate - ##{rate.object.id}"
+          .form-group
+            =rate.label :percentage_rate, t('views.vat_rates.form.percentage_rate')
+            .input-group.input-group-lg
+              =rate.text_field :percentage_rate, placeholder: t('views.vat_rates.form.percentage_rate_placeholder'), class: 'form-control'
+          .form-group
+            =rate.label :effective_from, t('views.vat_rates.form.effective_from')
+            .input-group.input-group-lg
+              =rate.text_field :effective_from, placeholder: t('views.vat_rates.form.effective_from_placeholder'), class: 'form-control date', data: {'date-format' => 'YYYY-MM-DD'}, id: "datetimepicker#{rate.object.id}"
+
+    :javascript
+      $(function () {
+        $("#datetimepicker#{rate.object.id}").datetimepicker();
+      });
+
+  .row.pt-4
+    .col-md-12
+      =f.submit t('views.general.save'), class: 'btn btn-primary'
+      =link_to t('views.general.cancel'), vat_codes_path, class: 'btn btn-secondary'
 
 
-    .row.pt-4
-      .col-md-12
-        =f.submit t('views.general.save'), class: 'btn btn-primary'
-        =link_to t('views.general.cancel'), vat_codes_path, class: 'btn btn-secondary'
-
-
-:javascript
-
-  $(function () {
-    $('#datetimepicker1').datetimepicker();
-  });


### PR DESCRIPTION
* **What?** Add ability to manage multiple Vat Rates on Vat Codes.

* **Why?** We need to be able to create new Vat Rates for each Vat Code so that historic Invoices stay associated with the Vat Rate at the time they were created.

* **How?** Added looped form_for's to Vat Code form to allow the editing of existing Vat Rates and the creation of new Vat Rates. Updated the Invoice after_create callback to find the correct Vat Rate by using the effective_from datetime.

* **How to test?** 

https://learnsignal-team.monday.com/boards/964007792/pulses/1122844228