### PR TITLE
Practice questions auto save.

### DIFF
--- a/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
+++ b/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
@@ -81,6 +81,7 @@ export default {
       isActive: true,
       questionContent: null,
       fillArr: null,
+      lastTimeUpdated: new Date(),
     };
   },
   mounted() {
@@ -129,6 +130,15 @@ export default {
     syncSpreadsheetData(jsonData) {
       this.questionContent.answer_content = { content: { data: jsonData } };
     },
+    autoUpdateAnswer: function(){
+      const dateNow = new Date();
+
+      // Update answers data if last update is more then 10 seconds.
+      if ((dateNow - this.lastTimeUpdated) > 10000  ) {
+        this.lastTimeUpdated = dateNow;
+        this.updateCurrentAnswer();
+      }
+    },
     updateCurrentAnswer: function() {
       axios
         .patch(
@@ -173,6 +183,8 @@ export default {
     },
     "questionContent.answer_content": {
        handler() {
+        this.autoUpdateAnswer();
+
         this.updateSubmitBtn(this.questionContentArray).then((response) => {
           if (response) {
             eventBus.$emit("active-solution-index", [this.fillArr.every(item => item === 1), this.activePage - 1]);

--- a/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
+++ b/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
@@ -50,6 +50,7 @@ export default {
     return {
       modalIsOpen: false,
       indexOfQuestion: 0,
+      lastTimeUpdated: new Date(),
     };
   },
   created() {
@@ -82,6 +83,15 @@ export default {
       $('#spreadsheetModal').css('width', '60em');
       $('#spreadsheetModal').css('height', '37em');
     },
+    autoUpdateResponse: function(){
+      const dateNow = new Date();
+
+      // Update response data if last update is more then 10 seconds.
+      if ((dateNow - this.lastTimeUpdated) > 10000  ) {
+        this.lastTimeUpdated = dateNow;
+        this.updateResponse();
+      }
+    },
     updateResponse() {
       eventBus.$emit("update-user-response");
     },
@@ -93,6 +103,12 @@ export default {
     modalIsOpen(value) {
       this.$emit("update-close-all", this.modalIsOpen);
     },
+    "responseObj.content": {
+       handler() {
+        this.autoUpdateResponse();
+       },
+      deep: true
+    }
   },
 };
 </script>

--- a/app/javascript/components/practiceQuestions/TextEditorModal.vue
+++ b/app/javascript/components/practiceQuestions/TextEditorModal.vue
@@ -51,6 +51,7 @@ export default {
     return {
       modalIsOpen: false,
       indexOfQuestion: 0,
+      lastTimeUpdated: new Date(),
     };
   },
   created() {
@@ -75,6 +76,15 @@ export default {
       $('#textEditorModal').css('width', '60em');
       $('#textEditorModal').css('height', '30em');
     },
+    autoUpdateResponse: function(){
+      const dateNow = new Date();
+
+      // Update response data if last update is more then 10 seconds.
+      if ((dateNow - this.lastTimeUpdated) > 10000  ) {
+        this.lastTimeUpdated = dateNow;
+        this.updateResponse();
+      }
+    },
     updateResponse() {
       if (this.responseObj.content !== "") {
         eventBus.$emit("show-submit-v2-btn", true);
@@ -94,6 +104,12 @@ export default {
     modalIsOpen(value) {
       this.$emit("update-close-all", this.modalIsOpen);
     },
+    "responseObj.content": {
+       handler() {
+        this.autoUpdateResponse();
+       },
+      deep: true
+    }
   },
 };
 </script>


### PR DESCRIPTION
What? Added callbacks in responses changes, min 10 seconds between api calls.
Why? User responses in practice questions should be auto-saved and not just in submit or between navigation actions.
How? Add a trigger in each Practice Question response to save current data.
How to test? Log In to any student user, find a course that has a practice question and a practice question v2 to reply to it.
Responses data should be saved even if you do not click in questions navigator link, submit button or close modal - the other callbacks triggers. 

A good way to check it without trigger those callbacks is just to type your response and refresh the page.

[Monday task](https://learnsignal-team.monday.com/boards/964007792/pulses/1123429615)