### PR TITLE
added dynamic rows and columns amount to remove excess rows and columns

### DIFF
--- a/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
+++ b/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
@@ -109,6 +109,8 @@
     computed: {
       spreadsheetData: function() {
         if (this.initialData.content && this.initialData.content.data && this.initialData.content.data.data) {
+          if (typeof(this.initialData.content.data.data.dataTable) !== 'undefined') { this.row_data = Object.keys(this.initialData.content.data.data.dataTable).length + 4 }
+          if (typeof(this.initialData.content.data.columns) !== 'undefined') { this.col_data = Object.keys(this.initialData.content.data.columns).length + 1 }
           return this.initialData.content.data;
         } else {
           return null;
@@ -116,7 +118,8 @@
       }
     },
     created() {
-
+      let row_data = null;
+      let col_data = null;
     },
     data() {
       return {
@@ -209,6 +212,11 @@
           spread.suspendPaint();
           this.flex.setDataSource(this.flex.fromJSON(JSON.parse(JSON.stringify(this.spreadsheetData))));
           spread.resumePaint();
+          this.row_data ? this.flex.setRowCount(this.row_data, GC.Spread.Sheets.SheetArea.viewport) : this.flex.setRowCount(this.flex.getRowCount(), GC.Spread.Sheets.SheetArea.viewport);
+          this.col_data ? this.flex.setColumnCount(this.col_data, GC.Spread.Sheets.SheetArea.viewport) : this.flex.setColumnCount(this.flex.getColumnCount(), GC.Spread.Sheets.SheetArea.viewport);
+        } else {
+          this.flex.setRowCount(25, GC.Spread.Sheets.SheetArea.viewport);
+          this.flex.setColumnCount(5, GC.Spread.Sheets.SheetArea.viewport);
         }
         for (var i = 0; i < this.flex.getRowCount(); i++) {
           this.flex.autoFitRow(i);

--- a/app/javascript/components/cbe/AgreementModal.vue
+++ b/app/javascript/components/cbe/AgreementModal.vue
@@ -5,7 +5,7 @@
       :componentName="componentName"
       :window-is-open="true"
       :componentModal="true"
-      :componentHeight="250"
+      :componentHeight="270"
       :componentWidth="500"
       :mainColor="'transparent'"
     >


### PR DESCRIPTION
- **What?** need to increase performance of cbe by reducing size of spreadsheet modals.
- **Why?** cbe modals lag and cause users to refresh page.
- **How?** added dynamic rows and columns amount to remove excess rows and columns.
- **How to test?** Go to a cbe with a spreadsheet modal and verify that the empty rows don't exceed 5, and the columns don't exceed 2. Note: There is a catch for situations where the row or column value might not come through, so sometimes you may see excess rows or columns. You could compare with the admin side, and also create new exhibit spreadsheet modals.
- **Note** The spreadsheet plugin will not allow a copy paste if the amount of rows or columns is less than that of the paste in rows and columns. What I mean is that new rows or cols are not created on paste. If we reduce the size than the admin will have to insert rows and columns (paste insert does not work with this plugin)
- **Note 2** Needs some serious stress testing on my part, would prefer some real scenarios on staging environment. Pay attention to: **Sometimes will hide row with data**

https://learnsignal-team.monday.com/boards/964007792/pulses/1109418292
