### PR TITLE
New subscription empty exam body error.

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -193,11 +193,16 @@ class SubscriptionsController < ApplicationController
   end
 
   def set_variables
-    @exam_body    = ExamBody.find(params[:exam_body_id])
-    @plans        = get_relevant_subscription_plans
-    @kind         = current_user.subscriptions.for_exam_body(params[:exam_body_id]).where(state: %w[canceled cancelled]).empty? ? :new_subscription : :reactivation
-    @subscription = Subscription.new(user_id: current_user.id,
-                                     subscription_plan_id: filtered_plan&.id)
+    if params[:exam_body_id].present?
+      @exam_body    = ExamBody.find(params[:exam_body_id])
+      @plans        = get_relevant_subscription_plans
+      @kind         = current_user.subscriptions.for_exam_body(params[:exam_body_id]).where(state: %w[canceled cancelled]).empty? ? :new_subscription : :reactivation
+      @subscription = Subscription.new(user_id: current_user.id,
+                                       subscription_plan_id: filtered_plan&.id)
+    else
+      flash[:error] = 'Invalid request, please contact us for assistance!' if flash[:error].nil?
+      redirect_to account_url(anchor: 'account-info')
+    end
   end
 
   def set_flash


### PR DESCRIPTION
What? A check to empty exam_body param
Why? Some requests are coming without the exam body param in URL.
How? Some invalid URL is triggering an error because they are trying to use exam body id.
How to test: Access this wrong URL http://localhost:3000/en/subscriptions/new?exam_body_id=&plan_guid=GvTeEXj0w3

