### PR TITLE
created a purchase order show page that allows student to cancel thei…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7170,6 +7170,29 @@ button.sub-details[aria-expanded="true"]:before{
 #next-lesson-modal {
   z-index: 1;
 }
+.cancellation-form-center {
+  display: flex;
+  justify-content: center;
+  textarea {
+    width: 85%;
+  }
+}
+.cancellation-form-header {
+  justify-content: end;
+}
+.cancellation-form-product-type {
+  margin-left: .35em;
+  color: #00b67b;
+}
+.cancellation-form-btn {
+  color: #00b67b;
+}
+.cancellation-form-btn:hover {
+  color: #ffffff;
+}
+#attempt_order_cancellation {
+  margin-left: 1.5em;
+}
 .practice-ques-navigation {
   .sidebar-nav-btn-left {
     width: 1em;

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,6 +8,7 @@ class DashboardController < ApplicationController
     @default_group = current_user&.preferred_exam_body&.group || Group.all_active.first
     @enrollments = current_user.valid_enrollments_in_sitting_order
     @sculs = current_user.course_logs.includes(:enrollments).where(enrollments: { id: nil })
+    @cancelled_orders_id = filter_cancelled_orders(current_user&.orders)
   end
 
   protected
@@ -15,5 +16,9 @@ class DashboardController < ApplicationController
   def get_variables
     @courses = Course.all_active.all_in_order
     seo_title_maker('Dashboard', 'Progress through all your courses will be recorded here.', false)
+  end
+
+  def filter_cancelled_orders(user_orders)
+    (user_orders.map { |order| order.state == 'cancelled' ? order.id : nil }).compact
   end
 end

--- a/app/controllers/order_management_controller.rb
+++ b/app/controllers/order_management_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class OrderManagementController < ApplicationController
+  before_action :logged_in_required
+  before_action { ensure_user_has_access_rights(%w[user_management_access]) }
+  before_action :management_layout
+
+  def show
+    @order = Order.find(params[:id])
+    @user = @order.user
+    @product = Product.find(@order.product_id)
+    @admin_user = User.find(@order.cancelled_by_id) if @order.cancelled_by_id
+  end
+
+  def cancel_order
+    @order = Order.find(params[:order_management_id])
+    return if @order.cancelled?
+
+    @order.update(
+      state: 'cancelled',
+      cancelled_by_id: params[:order][:cancelled_by_id],
+      cancellation_note: params[:order][:cancellation_note]
+    )
+    redirect_to order_management_path(@order.id)
+  end
+
+  def un_cancel_order
+    @order = Order.find(params[:order_management_id])
+    return unless @order.cancelled?
+
+    @order.complete!
+    redirect_to order_management_path(@order.id)
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -47,6 +47,10 @@ module OrdersHelper
     end
   end
 
+  def order_cancelled_status?(order)
+    order.cancelled?
+  end
+
   private
 
   def exercise_path_by_state(exercise)

--- a/app/views/dashboard/_exercises.html.haml
+++ b/app/views/dashboard/_exercises.html.haml
@@ -2,49 +2,53 @@
 
   -if current_user.exercises.with_states([:submitted, :correcting]).any?
     -current_user.exercises.with_states([:submitted, :correcting]).each do |exercise|
-      .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
-        .card-body.d-flex.flex-column.justify-content-center
-          %small.card-category.mb-2{style: 'color: #5e90ef'}
-            =exercise.product.name_by_type
+      - if @cancelled_orders_id.exclude? exercise.order_id
+        .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
+          .card-body.d-flex.flex-column.justify-content-center
+            %small.card-category.mb-2{style: 'color: #5e90ef'}
+              =exercise.product.name_by_type
+              =exercise.product.id
 
-          %h5.card-title.mb-1
-            %span.mr-1
-              -if exercise.correcting?
-                Your work is currently being corrected by our team
-              -else
-                Your work is submitted and awaiting correction
-        .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
-          =link_to 'View Exercise', exercise, class: 'btn btn-primary'
+            %h5.card-title.mb-1
+              %span.mr-1
+                -if exercise.correcting?
+                  Your work is currently being corrected by our team
+                -else
+                  Your work is submitted and awaiting correction
+          .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
+            =link_to 'View Exercise', exercise, class: 'btn btn-primary'
 
   -if current_user.exercises.with_state(:pending).any?
     -current_user.exercises.with_state(:pending).each do |exercise|
-      .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
-        .card-body.d-flex.flex-column.justify-content-center
-          %small.card-category.mb-2{style: 'color: #5e90ef'}
-            =exercise.product.name_by_type
-          %h5.card-title.mb-1
-            %span.mr-1
-              =pending_exercise_message(exercise)
-        .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
-          -if exercise.product.cbe?
-            =link_to 'Begin CBE', exercise_cbes_path(id: exercise.product.cbe.id, exercise_id: exercise.id), class: 'btn btn-primary'
-          -else
-            =link_to 'Begin Exercise', edit_exercise_path(exercise), class: 'btn btn-primary'
+      - if @cancelled_orders_id.exclude? exercise.order_id
+        .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
+          .card-body.d-flex.flex-column.justify-content-center
+            %small.card-category.mb-2{style: 'color: #5e90ef'}
+              =exercise.product.name_by_type
+            %h5.card-title.mb-1
+              %span.mr-1
+                =pending_exercise_message(exercise)
+          .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
+            -if exercise.product.cbe?
+              =link_to 'Begin CBE', exercise_cbes_path(id: exercise.product.cbe.id, exercise_id: exercise.id), class: 'btn btn-primary'
+            -else
+              =link_to 'Begin Exercise', edit_exercise_path(exercise), class: 'btn btn-primary'
 
   -if current_user.exercises.with_states(:returned).any?
     -current_user.exercises.with_states(:returned).each do |exercise|
-      .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
-        .card-body.d-flex.flex-column.justify-content-center
-          %small.card-category.mb-2{style: 'color: #5e90ef'}
-            =exercise.product.name_by_type
+      - if @cancelled_orders_id.exclude? exercise.order_id
+        .card.card-horizontal.flex-md-row{style: 'margin-bottom: 1.5rem;'}
+          .card-body.d-flex.flex-column.justify-content-center
+            %small.card-category.mb-2{style: 'color: #5e90ef'}
+              =exercise.product.name_by_type
 
-          %h5.card-title.mb-1
-            %span.mr-1
-              Your work has been corrected
-        .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
-          =link_to 'View Response', exercise_path(exercise), class: 'btn btn-primary'
-          -if exercise.product.cbe?
-            =link_to 'Rerun CBE', exercise_cbes_path(id: exercise.product.cbe.id, exercise_id: exercise.id), class: 'btn btn-warning'
+            %h5.card-title.mb-1
+              %span.mr-1
+                Your work has been corrected
+          .card-footer.d-flex.justify-content-center.align-items-center{style: 'background-color: #fff; border-top: none;'}
+            =link_to 'View Response', exercise_path(exercise), class: 'btn btn-primary'
+            -if exercise.product.cbe?
+              =link_to 'Rerun CBE', exercise_cbes_path(id: exercise.product.cbe.id, exercise_id: exercise.id), class: 'btn btn-warning'
 
 -else
   .row.row-lg

--- a/app/views/order_management/_confirm_cancellation_modal.html.haml
+++ b/app/views/order_management/_confirm_cancellation_modal.html.haml
@@ -1,0 +1,28 @@
+.modal.fade{id: 'confirm-order-cancellation-modal', tabindex: '-1', role: 'dialog', 'aria-labelledby': 'confirmOrderCancellationModal', 'aria-hidden': 'true'}
+  .modal-dialog{role: 'document'}
+    .modal-content
+      %button.btn.btn-icon.modal-close{'data-dismiss': 'modal'}
+        %i.material-icons.ml-1{'aria-hidden': 'true'}
+          close
+      .modal-header.cancellation-form-header
+        %h4{id: 'confirmOrderCancellationModal'}
+          Cancel Order of
+          %h4{class: 'cancellation-form-product-type'}#{@product.product_type}
+
+      .modal-body
+        .row
+        .col-md-12
+          =render partial: 'layouts/error_messages', locals: {thing: @order, message: t('views.users.upgrade_subscription.error_panel_caption')}
+          .modal-body
+            =render partial: 'layouts/error_messages', locals: {thing: @order, message: t('views.users.upgrade_subscription.error_panel_caption')}
+
+      .row.l-margin-top{style: 'text-align: left;'}
+        =form_for @order, url: order_management_cancel_order_path(@order.id), method: :post, html: { id: 'attempt_order_cancellation', class: 'input-group-lg' } do |f|
+          =f.hidden_field(:cancelled_by_id, value: current_user.id)
+          .form-group.cancellation-reason#cancellation-order-reason-error
+            =f.label :cancellation_note, 'Why does the student want to cancel the order?', class: 'block-label h5'
+            #cancellation-order-note.cancellation-form-center
+              =f.text_area :cancellation_note, cols:2, rows:7, class:'form-control', placeholder:'Please state reason for cancelling'
+          .row.l-margin-top.cancellation-form-center
+            .btn.btn-secondary.btn-xs
+              =f.submit 'Cancel Order', id: 'confirm_cancellation_button', class: 'btn btn-red full-width l-margin-bottom cancellation-form-btn', data: { confirm: "Are you sure you want to permanently delete the order of #{@product.product_type} for #{@user.full_name}?" }

--- a/app/views/order_management/show.html.haml
+++ b/app/views/order_management/show.html.haml
@@ -1,0 +1,68 @@
+.container
+  %header.management-console-section
+    %h1
+      =@order.user.full_name
+    %p.p-hero.px-lg-8
+      ='Order ID:'
+      =@order.id
+
+  %section.pb-7
+    =render partial: 'users/user_tabs'
+
+    .row
+      .col-sm-12
+        .box-item
+          .row
+            .col-sm-9
+              .row.pt-3
+                .col-sm-4
+                  .h3
+                    Order Status
+                  .h6
+                    =@order.state
+                .col-sm-4
+                  .h3
+                    Order Created
+                  .h6
+                    =humanize_datetime(@order.created_at)
+                .col-sm-4
+                  .h3
+                    Coupon Code
+                  .h6
+                    =@order.coupon_code
+              .row.pt-3
+                .col-sm-4
+                  .h3
+                    Product Name
+                  .h6
+                    =@product.name
+                .col-sm-4
+                  .h3
+                    Product Type
+                  .h6
+                    =@product.product_type
+                .col-sm-4
+                  .h3
+                    Product Price
+                  .h6
+                    =number_in_local_currency(@product.price, @product.currency)
+              .row.pt-3
+                .col-sm-4
+                  .h3
+                    Payment
+                  .h6
+                    =@order.stripe? ? 'Stripe' : 'PayPal'
+                -if order_cancelled_status?(@order)
+                  .col-sm-4
+                    .h3
+                      Cancelled by
+                    .h6
+                      =@admin_user&.email
+            .col-sm-3
+              -if order_cancelled_status?(@order)
+                =link_to 'Reactivate Order', order_management_un_cancel_order_url(@order.id), method: :put, class: 'btn btn-primary mb-3', data: {confirm: 'Are you sure you want to reactivate this order?'}
+              - else
+                .btn.btn-primary.mb-3{data: {target: '#confirm-order-cancellation-modal', toggle: 'modal', href: '#'}}
+                  Cancel Order
+
+=render partial: 'confirm_cancellation_modal'

--- a/app/views/users/user_purchases_details.html.haml
+++ b/app/views/users/user_purchases_details.html.haml
@@ -30,6 +30,8 @@
                 %th
                   =t('views.invoices.form.line_total_inc_vat')
                 %th
+                  Active
+                %th
             %tbody
               -@orders.each do |order|
                 %tr
@@ -42,10 +44,20 @@
                   %td
                     =number_in_local_currency(order.product.price, order.product.currency)
                   %td
+                    - if order.state == 'cancelled'
+                      =tick_or_cross(false)
+                    - else
+                      =tick_or_cross(true)
+                  %td
+                    .pull-right
                     -if order.product && order.product.mock_exam
                       =link_to order.product.mock_exam.file.url, target: '_blank' do
-                        .btn.btn-secondary.btn-xs
-                          View
+                        .btn.btn-primary.btn-xs
+                          PDF
+                    =link_to order_management_url(order.id), style: 'padding-left: 5px;' do
+                      .btn.btn-secondary.btn-xs
+                        View
+
     .row
       .col-md-12
         .box-item.table-box#invoices-panel

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,12 +158,19 @@ Rails.application.routes.draw do
 
     resources :subscription_management do
       get '/invoice/:invoice_id',            action: :invoice,                 as: :invoice
+      get '/order/:order_id',                action: :order,                   as: :order
       get '/pdf_invoice/:invoice_id',        action: :pdf_invoice,             as: :pdf_invoice
       get '/invoice/:invoice_id/charge/:id', action: :charge,                  as: :invoice_charge
       get '/cancellation',                   action: :cancellation,            as: :admin_cancellations
       post '/cancel',                        action: :cancel_subscription,     as: :cancel_subscription
       put '/un_cancel',                      action: :un_cancel_subscription,  as: :un_cancel_subscription
       put '/reactivate',                     action: :reactivate_subscription, as: :reactivate_subscription
+    end
+
+    resources :order_management do
+      get '/order/:id',                      action: :order,                               as: :order
+      post '/cancel',                        action: :cancel_order,                        as: :cancel_order
+      put '/un_cancel',                      action: :un_cancel_order,                     as: :un_cancel_order
     end
 
     resources :subscription_payment_cards, only: %i[create update destroy]

--- a/db/migrate/20210330101237_add_field_to_orders.rb
+++ b/db/migrate/20210330101237_add_field_to_orders.rb
@@ -1,0 +1,5 @@
+class AddFieldToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :cancellation_note, :text
+  end
+end

--- a/db/migrate/20210331140015_add_cancelled_id_to_orders.rb
+++ b/db/migrate/20210331140015_add_cancelled_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddCancelledIdToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :cancelled_by_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_13_095345) do
+ActiveRecord::Schema.define(version: 2021_03_31_140015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1144,6 +1144,8 @@ ActiveRecord::Schema.define(version: 2020_12_13_095345) do
     t.string "stripe_payment_method_id"
     t.string "stripe_payment_intent_id"
     t.uuid "ahoy_visit_id"
+    t.text "cancellation_note"
+    t.bigint "cancelled_by_id"
     t.index ["ahoy_visit_id"], name: "index_orders_on_ahoy_visit_id"
     t.index ["course_id"], name: "index_orders_on_course_id"
     t.index ["mock_exam_id"], name: "index_orders_on_mock_exam_id"

--- a/spec/controllers/order_management_controller_spec.rb
+++ b/spec/controllers/order_management_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OrderManagementController, type: :controller do
+  let(:user_management_user_group)     { create(:user_management_user_group) }
+  let(:user_management_user)           { create(:user_management_user, user_group_id: user_management_user_group.id) }
+  let!(:active_order)                  { create(:order, id: rand(100_000), state: 'completed') }
+  let!(:cancelled_order)               { create(:order, id: rand(100_000), state: 'cancelled') }
+
+  context 'Logged in as a user_management_user: ' do
+    before(:each) do
+      activate_authlogic
+      UserSession.create!(user_management_user)
+    end
+
+    describe "GET 'show'" do
+      it 'should see active_order' do
+        get :show, params: { id: active_order.id }
+        expect(flash[:success]).to be_nil
+        expect(flash[:error]).to be_nil
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'cancel order' do
+      it 'should update to cancelled' do
+        put :cancel_order, params: { order_management_id: active_order.id, order: { cancelled_by_id: user_management_user.id, cancellation_note: 'no longer needs product' } }
+      end
+    end
+
+    describe 'reactivate order' do
+      it 'should update to completed' do
+        put :un_cancel_order, params: { order_management_id: cancelled_order.id }
+      end
+    end
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -102,4 +102,12 @@ describe OrdersHelper, type: :helper do
       end
     end
   end
+
+  describe 'order is currently cancelled' do
+    let(:order) { build_stubbed(:order, state: 'cancelled') }
+
+    it 'returns true if order is cancelled' do
+      expect(order_cancelled_status?(order)).to be_truthy
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -20,6 +20,8 @@
 #  paypal_guid               :string
 #  paypal_status             :string
 #  state                     :string
+#  cancelled_by_id           :bigint
+#  cancellation_note         :text
 #  stripe_payment_method_id  :string
 #  stripe_payment_intent_id  :string
 #  ahoy_visit_id             :uuid


### PR DESCRIPTION
- **What?** need to add functionality to admin to cancel orders and to reactivate those cancelled orders.
- **Why?** Specifically brought up because users who request refunds for lifetime access do not lose their access rights. Allows better control for all orders.
- **How?** created a purchase order show page that allows admin to view students product order and to cancel/reactivate said order.
- **How to test?** With a student user that does not have a valid subscription. Purchase the lifetime access product. Verify that the user has access to all course steps for the lesson which grants the user lifetime access rights. With an admin user go to **console >> users >> _view for specific user_ >> purchases _<view for lifetime product>_** and click on cancel order. Give a reason for the cancellation and click ok when prompted. Go back to the student user and verify that when they attempt to click on a step, that cannot be accessible with a trial account, you get a valid subscription required popup warning.Then with your admin user click on reactivate order and the step should now be visible for the student user. 

https://learnsignal-team.monday.com/boards/964007792/pulses/1160514287