### PR TITLE
Check currency locked before list products and subscription plans.

### DIFF
--- a/app/controllers/footer_pages_controller.rb
+++ b/app/controllers/footer_pages_controller.rb
@@ -100,6 +100,8 @@ class FooterPagesController < ApplicationController
 
   def user_currency_id
     if current_user
+      return current_user.currency_id if current_user.currency_locked?
+
       country = IpAddress.get_country(request.remote_ip) || current_user.country
       currency = current_user.get_currency(country)
       currency_id = currency.id

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -163,8 +163,13 @@ class SubscriptionsController < ApplicationController
   end
 
   def get_relevant_subscription_plans
-    country   = IpAddress.get_country(request.remote_ip) || current_user.country
-    @currency = current_user.get_currency(country)
+    @currency =
+      if current_user.currency_locked?
+        current_user.currency_id
+      else
+        country = IpAddress.get_country(request.remote_ip) || current_user.country
+        current_user.get_currency(country)
+      end
 
     if params[:plan_guid]
       SubscriptionPlan.includes(:exam_body, :currency).

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,8 +346,8 @@ class User < ApplicationRecord
 
   def currency_locked?
     subscriptions.where.not(stripe_guid: nil).any? ||
-        orders.where.not(stripe_customer_id: nil).any? ||
-        subscription_payment_cards.any?
+      orders.where.not(stripe_customer_id: nil).any? ||
+      subscription_payment_cards.any?
   end
 
   def name


### PR DESCRIPTION
What? Check for currency locked before list products and subscriptions plans.
Why? This will avoid showing products and plans with another currency.
How? Add a check before getting currency_id.
How to test? Locally you can add a debugger after the added checks and this should not be triggered to users with currency locked. After we deploy to staging we can change our origin country(using hola).


https://learnsignal-team.monday.com/boards/964007792/pulses/1189390711


