### PR TITLE
Check email to ASCII only content before check format

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -98,6 +98,7 @@ class LibraryController < ApplicationController
     else
       flash[:error] = 'Your submission was not successful. Please try again.'
     end
+
     redirect_to request.referer || root_url
   end
 
@@ -108,7 +109,7 @@ class LibraryController < ApplicationController
   end
 
   def invalid_email_format?(email)
-    !email.match(RFC822::EMAIL_REGEXP_WHOLE)
+    email.ascii_only? || !email.match(RFC822::EMAIL_REGEXP_WHOLE)
   end
 
   protected


### PR DESCRIPTION
What? Check email encode before format.
Why? The format checker will not work on all encodes.
How? Add an ascii_only? method check before using the email format check.
How to test? use email boris@президент.рф in the contact form and add a debug inside `user_contact_form` method. this should trigger` if invalid_email_format?(params[:email_address])` check.

https://learnsignal-team.monday.com/boards/964007792/pulses/1138781674