### PR TITLE
swapped old static modal for newer cbe modal on course resources page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1745,9 +1745,11 @@ textarea.form-control {
 .alert-error .alert-link {
   color: #fff
 }
-
-
-
+.resource-modal-window {
+  position: fixed;
+  top: 30%;
+  left: -10%;
+}
 .modal-dialog {
   position: relative;
   width: auto;

--- a/app/javascript/components/pdf/ModalViewer.vue
+++ b/app/javascript/components/pdf/ModalViewer.vue
@@ -1,6 +1,9 @@
 <template>
-  <div id="cbe-modals" class="col-sm-6">
-    <div class="card card-horizontal card-horizontal-sm flex-row"  @click="modalOpen">
+  <div id="cbe-modals" class="col-sm-6" :style="{ zIndex: modalPos }">
+    <div
+      class="card card-horizontal card-horizontal-sm flex-row"
+      @click="modalIsOpen = !modalIsOpen; zPos()"
+    >
       <div
         class="card-header bg-white d-flex align-items-center justify-content-center"
       >
@@ -14,35 +17,35 @@
         </h5>
       </a>
     </div>
-
-    <div ref="resourcesModal" class="modal" v-show="modalIsOpen">
-      <div class="modal-content resources-modal">
-        <div class="modal-header bg-cbe-gray">
-          <span class="title help-icon">
-            {{ this.pdfFileName }}
-          </span>
-
-          <span class="close" @click="modalIsOpen = false">
-            &times;
-          </span>
-        </div>
-
-        <div class="modal-internal-content">
-          <div id="resourceTabs">
-            <PDFCourseViewer :file-url="pdfFileUrl" :file-download="pdfFileDownload" :file-type="pdfFileType" @update-pages="updateViewedPages"/>
-          </div>
+    <VueWindow
+      v-if="modalIsOpen"
+      :window-header="pdfFileName"
+      :window-width="700"
+      :window-height="300"
+      :isResizable="true"
+      :window-is-open="modalIsOpen"
+      @updateWindowClose="handleChange"
+      class="resource-modal-window"
+    >
+      <div
+        slot="body"
+      >
+        <div id="resourceTabs">
+          <PDFCourseViewer :file-url="pdfFileUrl" :file-download="pdfFileDownload" :file-type="pdfFileType" @update-pages="updateViewedPages"/>
         </div>
       </div>
-    </div>
+    </VueWindow>
   </div>
 </template>
 
 <script>
 import PDFCourseViewer from "../../lib/PDFCourseViewer/index.vue";
+import VueWindow from 'components/VueWindow.vue'
 
 export default {
   components: {
-    PDFCourseViewer
+    PDFCourseViewer,
+    VueWindow
   },
   data() {
     return {
@@ -54,6 +57,8 @@ export default {
       fileType: 'PDF File',
       allowed: true,
       modalIsOpen: false,
+      modalPos: 1,
+      modalIndex: this.$parent.modalIndex,
       pdfCourseName: this.$parent.courseName,
       pdfCourseId: this.$parent.courseId,
       pdfExamBodyName: this.$parent.examBodyName,
@@ -68,6 +73,13 @@ export default {
     modalOpen(data) {
       this.modalIsOpen = true;
       courseResourceClick({preferredExamBodyId: this.preferredExamBodyId, preferredExamBody: this.preferredExamBodyName, banner: this.banner, onboarding: this.onboarding, resourceName: this.pdfFileName, resourceId: this.pdfFileId, courseName: this.pdfCourseName, courseId: this.pdfCourseId, examBodyName: this.pdfExamBodyName, examBodyId: this.pdfExamBodyId, resourceType: this.fileType, allowDownloadFile: this.allowed});
+    },
+    zPos() {
+      this.modalPos = 2;
+    },
+    handleChange(value) {
+      this.modalPos = 1;
+      this.modalIsOpen = value
     },
     updateViewedPages(data) {
       const total   = data.totalPages;

--- a/app/javascript/packs/pdf_viewer.js
+++ b/app/javascript/packs/pdf_viewer.js
@@ -1,9 +1,16 @@
 import Vue from 'vue';
-import fullscreen from 'vue-fullscreen'
+import fullscreen from 'vue-fullscreen';
+import BootstrapVue from 'bootstrap-vue';
+import * as VueWindow from '@hscmap/vue-window';
+import Loading from 'vue-loading-overlay';
+import 'vue-loading-overlay/dist/vue-loading.css';
 import ModalViewer from '../components/pdf/ModalViewer.vue';
 import NotesViewer from '../components/pdf/NotesViewer.vue';
 
+Vue.use(BootstrapVue);
 Vue.use(fullscreen)
+Vue.use(Loading);
+Vue.use(VueWindow);
 
 const mountViewerElement = (element, data, component) =>
 new Vue({


### PR DESCRIPTION
- **What?** on course resources an older modal version is being used that cannot be moved or resized.
- **How?** swapped old static modal for newer cbe modal on course resources page.
- **How to test?** Go to a course resource that has a pdf that is not an external url. 

https://learnsignal-team.monday.com/boards/964007792/pulses/1168298002