### PR TITLE
Duplicated init on facebook tracking.

### DIFF
--- a/app/views/layouts/_bing_tracking_code.html.haml
+++ b/app/views/layouts/_bing_tracking_code.html.haml
@@ -1,4 +1,5 @@
--# Bing Tracking Code
-:javascript
-  (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"26330570"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");
-  (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"26338753"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");
+-if Rails.env.production?
+  -# Bing Tracking Code
+  :javascript
+    (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"26330570"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");
+    (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"26338753"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");

--- a/app/views/layouts/_facebook_tracking_code.html.haml
+++ b/app/views/layouts/_facebook_tracking_code.html.haml
@@ -1,13 +1,18 @@
-/ Facebook Pixel Code
-:javascript
-  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-  document,'script','https://connect.facebook.net/en_US/fbevents.js');
+-if Rails.env.production?
+  / Facebook Pixel Code
+  :javascript
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
 
-  fbq('init', '560636230988559');
-  fbq('set','agent','tmgoogletagmanager', '560636230988559');
-  fbq('track', "PageView");
-%noscript
-  %img{:height => "1", :src => "https://www.facebook.com/tr?id=560636230988559&ev=PageView&noscript=1", :style => "display:none", :width => "1"}/
+    if (typeof fbq === 'undefined') { fbq('init', '560636230988559'); }
+    fbq('set','agent','tmgoogletagmanager', '560636230988559');
+    fbq('track', "PageView");
+
+  %noscript
+    %img{:height => "1", :src => "https://www.facebook.com/tr?id=560636230988559&ev=PageView&noscript=1", :style => "display:none", :width => "1"}/
+-else
+  :javascript
+    fbq = function (){};


### PR DESCRIPTION
What? A facebook script is duplicating our tracker initiation.
How? Add a check in our init function to see if fbq was already started.
How to test? Open web console and you should not see this message: `fbevents.js:23 [Facebook Pixel] - Duplicate Pixel ID: 560636230988559.`


https://learnsignal-team.monday.com/boards/1197527059/pulses/1211039788

Plus: add some environments checks to load bing and facebook trackers in production env.