### PR TITLE
CBE - save every question data in navigation

### DIFF
--- a/app/javascript/store/modules/userCbe.js
+++ b/app/javascript/store/modules/userCbe.js
@@ -89,7 +89,9 @@ const mutations = {
     state.user_cbe_data.user_agreement = data.agreed;
     state.user_cbe_data.current_state = data.current_state;
     state.user_cbe_data.scratch_pad = data.scratch_pad;
-    state.user_cbe_data.exam_pages = data.pages_state;
+    if(data.pages_state !== null){
+      state.user_cbe_data.exam_pages = data.pages_state;
+    }
 
     data.user_questions.forEach(question => {
       state.user_cbe_data.questions[question.cbe_question_id] = question;


### PR DESCRIPTION
Save answers data in navegation and no just when user submitt the cbe;
Add eventBus to trigger api call;
Add eventBus call in each answer component;
Return a new node in spreadsheet json data;
CbeUserLog created at start;
Agreement action now save this information in db and check before show window modal;
Load previous state of CBE if exists;
Fix the problem between write data in CBE obj and database;
Saving pages states save;
Adding missing cbe specs;