### PR TITLE
CBE - save every question data in navigation

### DIFF
--- a/app/javascript/components/cbe/CbeResponseOptionsModal.vue
+++ b/app/javascript/components/cbe/CbeResponseOptionsModal.vue
@@ -184,6 +184,9 @@ export default {
         eventBus.$emit("update-question-answer", data);
       }
     },
+    show () {
+      this.$modal.show("cbe-response-modal-"+this.responseOptionType+"-"+this.responseOptionId);
+    },
     hide () {
       this.$modal.hide("cbe-response-modal-"+this.responseOptionType+"-"+this.responseOptionId);
     }


### PR DESCRIPTION
Save answers data in navegation and no just when user submitt the cbe;
Add eventBus to trigger api call;
Add eventBus call in each answer component;
Return a new node in spreadsheet json data;
CbeUserLog created at start;
Agreement action now save this information in db and check before show window modal;
Load previous state of CBE if exists;
Fix the problem between write data in CBE obj and database;
Saving pages states save;
Adding missing cbe specs;