### PR TITLE
Slack notifications - stripe webhooks.

### DIFF
--- a/app/controllers/api/stripe_webhooks_controller.rb
+++ b/app/controllers/api/stripe_webhooks_controller.rb
@@ -9,6 +9,9 @@ module Api
       record_webhook(@event_json) if @event_json && StripeApiEvent.should_process?(@event_json)
       head :no_content
     rescue StandardError => e
+      slack = SlackService.new
+
+      slack.notify_channel('payments', webhook_failed_notification(e, @event_json), icon_emoji: 'rotating_light') if Rails.env.production?
       Rails.logger.error('ERROR: Api/StripeWebhooks#Create: Error: ' \
                          "#{e.inspect}\nEvent: #{@event_json['id']}")
       head :not_found
@@ -25,6 +28,15 @@ module Api
         StripeApiEvent.processing_delay(event_json['type']),
         event_json['id'], event_json['api_version'], account_url
       )
+    end
+
+    def webhook_failed_notification(error, event_json)
+      [{ fallback: "Stripe webhook ##{event_json['id']} have failed.",
+         title: "Stripe webhook ##{event_json['id']} have failed.\nError: #{error.inspect}",
+         title_link: "https://dashboard.stripe.com/events/#{event_json['id']}",
+         color: '#7CD197',
+         footer: 'Stripe',
+         ts: event_json['created'] }]
     end
   end
 end


### PR DESCRIPTION
What? Add aslack notification in fail stripe webhooks.
Why? To be notified every time a stripe webhook fails.
How to test? You need to send a locally post request to `http://localhost:3000/api/stripe_webhooks`

Pass this json as body param:
```
{
  "id": "evt_0IYXt0CU7JSVN1HWOsmJWse9",
  "object": "event",
  "api_version": "2019-05-16",
  "created": 1616596842,
  "data": {
    "object": {
      "id": "in_0IYXt0CU7JSVN1HW6PrbRQ78",
      "object": "invoice",
      "account_country": "IE",
      "account_name": "Learnsignal",
      "account_tax_ids": null,
      "amount_due": 4999,
      "amount_paid": 0,
      "amount_remaining": 4999,
      "attempt_count": 0,
      "attempted": false,
      "auto_advance": true,
      "billing": "charge_automatically",
      "billing_reason": "subscription_cycle",
      "charge": null,
      "collection_method": "charge_automatically",
      "created": 1616596842,
      "currency": "eur",
      "custom_fields": null,
      "customer": "cus_J0MZLMq8ep9T5s",
      "customer_address": null,
      "customer_email": "katestaunton89@hotmail.com",
      "customer_name": null,
      "customer_phone": null,
      "customer_shipping": null,
      "customer_tax_exempt": "none",
      "customer_tax_ids": [
      ],
      "default_payment_method": null,
      "default_source": null,
      "default_tax_rates": [
      ],
      "description": "",
      "discount": null,
      "discounts": [
      ],
      "due_date": null,
      "ending_balance": null,
      "footer": null,
      "hosted_invoice_url": null,
      "invoice_pdf": null,
      "last_finalization_error": null,
      "lines": {
        "object": "list",
        "data": [
          {
            "id": "sli_8ef36942f0a7a8",
            "object": "line_item",
            "amount": 4999,
            "currency": "eur",
            "description": "1 × LearnSignal FIA_monthly_eur (at €49.99 / month)",
            "discount_amounts": [
            ],
            "discountable": true,
            "discounts": [
            ],
            "livemode": true,
            "metadata": {
            },
            "period": {
              "end": 1619275241,
              "start": 1616596841
            },
            "plan": {
              "id": "production-hbhtqx4pkPQcpCQyI12h",
              "object": "plan",
              "active": true,
              "aggregate_usage": null,
              "amount": 4999,
              "amount_decimal": "4999",
              "billing_scheme": "per_unit",
              "created": 1595856358,
              "currency": "eur",
              "interval": "month",
              "interval_count": 1,
              "livemode": true,
              "metadata": {
              },
              "nickname": null,
              "product": "prod_HiyHgPVNeyy5Jw",
              "tiers": null,
              "tiers_mode": null,
              "transform_usage": null,
              "trial_period_days": null,
              "usage_type": "licensed"
            },
            "price": {
              "id": "production-hbhtqx4pkPQcpCQyI12h",
              "object": "price",
              "active": true,
              "billing_scheme": "per_unit",
              "created": 1595856358,
              "currency": "eur",
              "livemode": true,
              "lookup_key": null,
              "metadata": {
              },
              "nickname": null,
              "product": "prod_HiyHgPVNeyy5Jw",
              "recurring": {
                "aggregate_usage": null,
                "interval": "month",
                "interval_count": 1,
                "trial_period_days": null,
                "usage_type": "licensed"
              },
              "tiers_mode": null,
              "transform_quantity": null,
              "type": "recurring",
              "unit_amount": 4999,
              "unit_amount_decimal": "4999"
            },
            "proration": false,
            "quantity": 1,
            "subscription": "sub_J0PMaSZnbusB8K",
            "subscription_item": "si_J0PMtId9a72HrC",
            "tax_amounts": [
            ],
            "tax_rates": [
            ],
            "type": "subscription",
            "unique_id": "il_0IYXt0CU7JSVN1HWMIdFhfpO"
          }
        ],
        "has_more": false,
        "total_count": 1,
        "url": "/v1/invoices/in_0IYXt0CU7JSVN1HW6PrbRQ78/lines"
      },
      "livemode": true,
      "metadata": {
      },
      "next_payment_attempt": 1616600442,
      "number": "DD504C12-0002",
      "on_behalf_of": null,
      "paid": false,
      "payment_intent": null,
      "payment_settings": {
        "payment_method_options": null,
        "payment_method_types": null
      },
      "period_end": 1616596841,
      "period_start": 1614177641,
      "post_payment_credit_notes_amount": 0,
      "pre_payment_credit_notes_amount": 0,
      "receipt_number": null,
      "starting_balance": 0,
      "statement_descriptor": null,
      "status": "draft",
      "status_transitions": {
        "finalized_at": null,
        "marked_uncollectible_at": null,
        "paid_at": null,
        "voided_at": null
      },
      "subscription": "sub_J0PMaSZnbusB8K",
      "subtotal": 4999,
      "tax": null,
      "tax_percent": null,
      "total": 4999,
      "total_discount_amounts": [
      ],
      "total_tax_amounts": [
      ],
      "transfer_data": null,
      "webhooks_delivered_at": null,
      "application_fee_amount": null
    }
  },
  "livemode": true,
  "pending_webhooks": 3,
  "request": {
    "id": null,
    "idempotency_key": null
  },
  "type": "invoice.created"
}
```

Add a `raise any_text` direct in StripeWebhooksController [create method](https://github.com/SignalEducation/version1/blob/cdcdd0768ba1f5275a14a246a87012f9dc679cf9/app/controllers/api/stripe_webhooks_controller.rb#L8) to trigger the rescue and slack notification.

Check slack payments channel to see this any_text error coming. 

https://learnsignal-team.monday.com/boards/964007792/pulses/1175964358