### PR TITLE
Fix video player and onboarding properties

### DIFF
--- a/app/assets/javascripts/event_tracking.js
+++ b/app/assets/javascripts/event_tracking.js
@@ -29,11 +29,13 @@ function courseStepLoaded(type) {
 function videoStepLoaded() {
   let videoLesson = $("#video-player-window"),
     stepData = videoLesson.data(),
-    playerType = (stepData.hasOwnProperty('vimeoInitialized'))? 'Vimeo' : 'DaCast',
+    playerType = (typeof player !== 'undefined')? 'Vimeo' : 'DaCast',
     videoData = { 'stepType': 'Video', 'player': playerType};
   let properties = $.extend({}, stepData, videoData);
 
-  analytics.track('Course Step Loaded', properties);
+  if (typeof analytics !== 'undefined') {
+    analytics.track('Course Step Loaded', properties);
+  }
 }
 
 function quizStepLoaded() {
@@ -42,7 +44,9 @@ function quizStepLoaded() {
     quizData = { 'stepType': 'Quiz' };
   let properties = $.extend({}, lessonData, quizData);
 
-  analytics.track('Course Step Loaded', properties);
+  if (typeof analytics !== 'undefined') {
+    analytics.track('Course Step Loaded', properties);
+  }
 }
 
 function noteStepLoaded() {
@@ -51,7 +55,9 @@ function noteStepLoaded() {
     noteData = { 'stepType': 'Note'};
   let properties = $.extend({}, lessonData, noteData);
 
-  analytics.track('Course Step Loaded', properties);
+  if (typeof analytics !== 'undefined') {
+    analytics.track('Course Step Loaded', properties);
+  }
 }
 
 function constructedResponseLoaded() {
@@ -78,7 +84,7 @@ function practiceQuestionStepLoaded() {
 function videoPlayEvent() {
   let videoLesson = $("#video-player-window"),
     stepData = videoLesson.data(),
-    playerType = (stepData.hasOwnProperty('vimeoInitialized'))? 'Vimeo' : 'DaCast',
+    playerType = (typeof player !== 'undefined')? 'Vimeo' : 'DaCast',
     videoData = { 'stepType': 'Video', 'player': playerType };
   let properties = $.extend({}, stepData, videoData);
 
@@ -90,7 +96,7 @@ function videoPlayEvent() {
 function videoFinishedEvent(autoPlay, playbackRate) {
   let videoLesson = $("#video-player-window"),
     stepData = videoLesson.data(),
-    playerType = (stepData.hasOwnProperty('vimeoInitialized'))? 'Vimeo' : 'DaCast',
+    playerType = (typeof player !== 'undefined')? 'Vimeo' : 'DaCast',
     videoData = { 'stepType': 'Video', 'player': playerType, 'playBackRate': playbackRate , 'autoPlay': autoPlay };
   let properties = $.extend({}, stepData, videoData);
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -645,7 +645,13 @@ class User < ApplicationRecord
   end
 
   def analytics_onboarding_valid?
-    analytics_onboarding_state == 'Active'
+    if onboarding_process
+      analytics_onboarding_state == 'Active'
+    else
+      # This is to ensure that the first course step analytics events (loaded & started)
+      # have onboarding set to true because the OnboardingProcess record does not exist yet
+      course_step_logs.none?
+    end
   end
 
   def preferred_group_id


### PR DESCRIPTION
* **What?** Fix playerType property to work with new Course Step Loaded event and onboarding boolean property to true if no course logs exist for the user.
* **Why?** For playerType we can use the vimeoInitialized as it's not available until the video plays so the new Course Step Loaded event does not know which player. The onboarding standard boolean property is set for all events but since this relies on the OnboardingProccess model and course log models existing all events before the creation of the first CourseStepLog were getting onboarding set to false.
* **How?** Changed the event js to detect the Vimeo player variable instead. Added a fallback to the analytics_onboarding_valid? method to return true if no course logs exist for the user.
* **How to test?** As a newly verified user, click through the level/course selection and start the first video. Check that all the events have onboarding set to true and that the CourseStepLoaded and CourseStepStarted events detect the correct video player.