### PR TITLE
GA Double PageLoad Issue

### DIFF
--- a/app/views/layouts/_global_site_tag.html.haml
+++ b/app/views/layouts/_global_site_tag.html.haml
@@ -1,8 +1,5 @@
--if Rails.env.development?
-  :javascript
-    gtag = function (){};
+// Global site tag (gtag.js) - Google Analytics
 -if Rails.env.staging?
-  // Global site tag (gtag.js) - Google Analytics
   %script{:async => "", :src => "https://www.googletagmanager.com/gtag/js?id=UA-185199057-2"}
   :javascript
     window.dataLayer = window.dataLayer || [];
@@ -12,9 +9,7 @@
     gtag('config', 'UA-185199057-2', {
       'custom_map': {'dimension1': 'user_type'}
     });
-
--if Rails.env.production?
-  // Global site tag (gtag.js) - Google Analytics
+-elsif Rails.env.production?
   %script{:async => "", :src => "https://www.googletagmanager.com/gtag/js?id=UA-141784351-1"}
   :javascript
     window.dataLayer = window.dataLayer || [];
@@ -24,3 +19,7 @@
     gtag('config', 'UA-141784351-1', {
       'custom_map': {'dimension4': 'user_type'}
     });
+-else
+  :javascript
+    gtag = function (){};
+// End Global site tag (gtag.js) - Google Analytics

--- a/app/views/layouts/_google_tag_manager.html.haml
+++ b/app/views/layouts/_google_tag_manager.html.haml
@@ -1,13 +1,13 @@
 -# Google Tag Manager
--if Rails.env.development?
-  :javascript
-    dataLayer = [];
 -if Rails.env.staging?
   :javascript
     dataLayer = [];
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'}); var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:''; j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5FSHL9J');
--else
+-elsif Rails.env.production?
   :javascript
     dataLayer = [];
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'}); var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:''; j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5SC76S');
+-else
+  :javascript
+    dataLayer = [];
 -# End Google Tag Manager

--- a/app/views/layouts/_google_tag_manager_body.html.haml
+++ b/app/views/layouts/_google_tag_manager_body.html.haml
@@ -2,7 +2,7 @@
 -if Rails.env.staging?
   %noscript
     %iframe{src: '//www.googletagmanager.com/ns.html?id=GTM-5FSHL9J', height: 0, width: 0, style: 'display:none;visibility:hidden'}
--else
+-elsif Rails.env.production?
   %noscript
     %iframe{src: '//www.googletagmanager.com/ns.html?id=GTM-5SC76S', height: 0, width: 0, style: 'display:none;visibility:hidden'}
 -# End Google Tag Manager Body

--- a/app/views/layouts/marketing.html.haml
+++ b/app/views/layouts/marketing.html.haml
@@ -42,9 +42,7 @@
 
   %body{class: (controller_name == 'student_sign_ups' && action_name != 'new') ? 'page-light' : (action_name == 'account_verified') ? 'page-gray' : ''}
 
-    %noscript
-      %iframe{src: '//www.googletagmanager.com/ns.html?id=GTM-5SC76S', height: 0, width: 0, style: 'display:none;visibility:hidden'}
-
+    =render partial: 'layouts/google_tag_manager_body'
     =render partial: 'layouts/facebook_tracking_code'
     -if @layout == 'standard'
       -if @navbar


### PR DESCRIPTION
* **What?** Removed the old GA iframe from being called in for all environments, and therefore being double called in production.
* **Why?** Reported issue on production GA of double page views since early March, was causing reporting issues.
* **How?** Removed the old iframe tag manager in marketing.html and replaced it with the new partial containing environment conditionals for different accounts.
* **How to test?** Don't worry about it as it can only really be tested on the production GA account.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1240805090