### PR TITLE
Fix related course step association in course clone.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -137,6 +137,7 @@ class Course < ApplicationRecord
       course_sections: {
         course_lessons: {
           course_steps: [
+            :related_course_step,
             :course_note,
             :video_resource,
             :course_video,


### PR DESCRIPTION
What? Error in clone course
Why? The system was blocking students to do some steps because of a wrong related course step association.
How? Add an attribute during the course clone.
How to test? Clone a course with a step witch was related to another step, the cloned step should not have this association(see data using the console).