### PR TITLE
added loading animation to cbe modals

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8177,9 +8177,9 @@ button.sub-details[aria-expanded="true"]:before{
 }
 .vue-loader{
   position: absolute;
-  top: 50%;   left: 50%;
+  top: 50%;   left: 6%;
   transform: translate(-50%,-50%);
-  width: 50px;  height: 50px;
+  width: 25px;  height: 25px;
   border: 3px solid #fff;
   border-color: #00B67B transparent #00B67B transparent;
   border-radius: 50%;
@@ -8190,7 +8190,7 @@ button.sub-details[aria-expanded="true"]:before{
   position: absolute;
   top: 50%;   left: 50%;
   transform: translate(-50%,-50%);
-  border: 3px solid #fff;
+  border: 2px solid #fff;
   border-radius: 50%;
   animation: animate 1.8s infinite linear;
 }
@@ -8217,8 +8217,9 @@ button.sub-details[aria-expanded="true"]:before{
   width: 30px;
   height: 30px;
   top: 14px;
+  left: 50%;
+  background-color: transparent;
 }
-
 .step-bar {
   counter-reset: step;
 }
@@ -8285,4 +8286,9 @@ button.sub-details[aria-expanded="true"]:before{
 .partner-logos {
   display: flex;
   justify-content: center;
+}
+.vue-loader-cbe {
+  position: relative;
+  left: 10%;
+  top: 6px;
 }

--- a/app/javascript/components/cbe/CbeExhibitsModal.vue
+++ b/app/javascript/components/cbe/CbeExhibitsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <section @click="show($event)" class="components-sidebar-links" :class="componentIcon">
-      {{ componentName }}
+    <section :id="'cbe-exhibit-modal-'+componentInd" @click="show('cbe-exhibit-modal-'+componentInd)" class="components-sidebar-links" :class="componentIcon">
+      <div>{{ componentName }}<button v-if="loading" class="vue-loader vue-loader-cbe"></button></div>
     </section>
     <div>
       <VueModal
@@ -90,6 +90,10 @@ export default {
       type: String,
       default: "",
     },
+    componentInd: {
+      type: String,
+      default: "",
+    },
     componentModal: {
       type: Boolean,
       default: false,
@@ -123,6 +127,7 @@ export default {
       errors: [],
       scale: "page-width",
       showModal: this.componentModal,
+      loading: false
     };
   },
   computed: {
@@ -207,10 +212,14 @@ export default {
     findPos(obj) {
       return obj.offsetTop;
     },
-    show (event) {
+    show (id) {
+      this.loading = true;
+      setTimeout(() => {
+      this.loading = false;
       this.$modal.show("modal-"+this.componentType+"-"+this.componentName);
       $('.components-sidebar .components div').removeClass('active-modal');
       eventBus.$emit("update-modal-z-index", `modal-${this.componentType}-${this.componentName}`);
+      }, 10);
     },
     hide (event) {
       $('.latent-modal').removeClass('active-modal');

--- a/app/javascript/components/cbe/CbeResponseOptionsModal.vue
+++ b/app/javascript/components/cbe/CbeResponseOptionsModal.vue
@@ -1,10 +1,11 @@
 <template>
   <div>
     <section
+      :id="'cbe-response-modal-'+responseOptionId"
       :class="`exhibits-sidebar-links ${responseOptionType}-icon`"
-      @click="show()"
+      @click="show('cbe-response-modal-'+responseOptionId)"
     >
-      {{ responseOptionName }}
+    <div>{{ responseOptionName }}<button v-if="loading" class="vue-loader vue-loader-cbe"></button></div>
     </section>
     <div>
       <VueModal
@@ -99,6 +100,7 @@ export default {
       multipleResponseOption: this.getInitialMultipleValue(
         this.responseOptionQuantity
       ),
+      loading: false
     };
   },
   watch: {
@@ -183,8 +185,14 @@ export default {
         eventBus.$emit("update-question-answer", data);
       }
     },
-    show () {
-      this.$modal.show("modal-"+this.responseOptionType+"-"+this.responseOptionName);
+    show (id) {
+      this.loading = true;
+      setTimeout(() => {
+        this.loading = false;
+        this.$modal.show("modal-"+this.responseOptionType+"-"+this.responseOptionName);
+        $('.components-sidebar .components div').removeClass('active-modal');
+        eventBus.$emit("update-modal-z-index", `modal-${this.responseOptionType}-${this.responseOptionName}`);
+      }, 10);
     },
     hide () {
       this.$modal.hide("modal-"+this.responseOptionType+"-"+this.responseOptionName);

--- a/app/javascript/components/practiceQuestions/RequirementsModal.vue
+++ b/app/javascript/components/practiceQuestions/RequirementsModal.vue
@@ -1,10 +1,9 @@
 <template>
     <div>
         <button :id="'requirementsModal'+ requirementsInd" @click="show('requirementsModal'+ requirementsInd)" class="learn-more components-sidebar-links">
-            <div class="circle"><span class="icon arrow"></span></div>
+            <div class="circle"><span v-if="loading" class="vue-loader"></span><span v-if="!loading" class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">assignment</i><p v-html="requirementsObj.name"></p></span>
         </button>
-        <button v-if="loading" class="vue-loader"></button>
         <VueModal
           :componentType="componentType"
           :componentName="requirementsObj.name"
@@ -103,10 +102,8 @@ export default {
     },
     show (id) {
       this.loading = true;
-      $("#"+id).css("display","none");
       setTimeout(() => {
         this.loading = false;
-        $("#"+id).css("display","block");
         this.$modal.show("modal-"+this.componentType+"-"+this.requirementsObj.name);
         $('.components-sidebar .components div').removeClass('active-modal');
         eventBus.$emit("update-modal-z-index", `modal-${this.componentType}-${this.requirementsObj.name}`);

--- a/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
+++ b/app/javascript/components/practiceQuestions/ResponseSpreadsheetModal.vue
@@ -1,10 +1,9 @@
 <template>
     <div>
         <button id="modal-response-spreadsheet" @click="show('modal-response-spreadsheet')" class="learn-more components-sidebar-links">
-            <div class="circle"><span class="icon arrow"></span></div>
+            <div class="circle"><span v-if="loading" class="vue-loader"></span><span v-if="!loading" class="icon arrow"></span></div>
             <span class="button-text"><i class="material-icons exhibits-icon">table_view</i><p>Spreadsheet</p></span>
         </button>
-        <button v-if="loading" class="vue-loader"></button>
         <VueModal
           :componentType="componentType"
           :componentName="componentName"
@@ -96,10 +95,8 @@ export default {
     },
     show (id) {
       this.loading = true;
-      $("#"+id).css("display","none");
       setTimeout(() => {
         this.loading = false;
-        $("#"+id).css("display","block");
         this.$modal.show("modal-"+this.componentType+"-"+this.componentName);
         $('.components-sidebar .components div').removeClass('active-modal');
         eventBus.$emit("update-modal-z-index", `modal-${this.componentType}-${this.componentName}`);

--- a/app/javascript/views/cbes/ExhibitScenarios.vue
+++ b/app/javascript/views/cbes/ExhibitScenarios.vue
@@ -16,6 +16,7 @@
               <CbeExhibitsModal
                 v-for="exhibit in scenarioData.exhibits"
                 :key="exhibit.id"
+                :componentInd="exhibit.id"
                 :componentType="exhibit.kind"
                 :componentName="exhibit.name"
                 :componentModal="exhibit.modal"


### PR DESCRIPTION
- **What?** spreadsheet modals take a moment to open causing users to click on the open modal btn multiple times.
- **Why?** lag due to the spreadsheet editors loading time.
- **How?** added loading animation to cbe modals.
- **How to test?** Go to a cbe with a spreadsheet modal and click on it, a loading icon should appear in the time it takes from the user's click to the opning of the modal. 

