### PR TITLE
Gtag config clean up

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -92,9 +92,10 @@ class OrdersController < ApplicationController
   end
 
   def order_complete
-    @order        = Order.find_by(id: params[:order_id])
-    @product      = Product.find_by(id: params[:product_id])
-    @studies_link =
+    @order          = Order.find_by(id: params[:order_id])
+    @product        = Product.find_by(id: params[:product_id])
+    @subscriptions  = Subscription.where(user_id: @order.user_id).not_pending
+    @studies_link   =
       if @product&.lifetime_access?
         student_dashboard_url
       elsif @product&.course_access?

--- a/app/views/layouts/_global_site_tag.html.haml
+++ b/app/views/layouts/_global_site_tag.html.haml
@@ -8,7 +8,11 @@
 
     gtag('config', 'UA-185199057-2', {
       'custom_map': {'dimension1': 'user_type'}
+    },
+    {
+      'send_page_view': false
     });
+
 -elsif Rails.env.production?
   %script{:async => "", :src => "https://www.googletagmanager.com/gtag/js?id=UA-141784351-1"}
   :javascript
@@ -18,6 +22,9 @@
 
     gtag('config', 'UA-141784351-1', {
       'custom_map': {'dimension4': 'user_type'}
+    },
+    {
+      'send_page_view': false
     });
 -else
   :javascript

--- a/app/views/orders/order_complete.html.haml
+++ b/app/views/orders/order_complete.html.haml
@@ -37,7 +37,7 @@
       content_category: "#{@product&.product_type.humanize}"
     });
 
-    if("#{@product&.url_by_type}" == "lifetime") {
+    if("#{@product&.url_by_type}" === "lifetime" && "#{@subscriptions.any?}" === "false") {
       gtag('event', 'purchase', {
         "transaction_id": "#{@order&.id}",
         "affiliation": "products",

--- a/app/views/subscriptions/personal_upgrade_complete.html.haml
+++ b/app/views/subscriptions/personal_upgrade_complete.html.haml
@@ -52,22 +52,24 @@
       content_category: "Subscription"
     });
 
-    gtag('event', 'purchase', {
-      "transaction_id": "#{@subscription&.id}",
-      "affiliation": "subscription",
-      "value": "#{@subscription&.subscription_plan&.price}",
-      "currency": "#{@subscription&.subscription_plan&.currency&.iso_code}",
-      "items": [
-        {
-          "id": "#{@subscription&.subscription_plan&.id}",
-          "name": "#{@subscription&.subscription_plan&.name}",
-          "brand": "Subscription",
-          "category": "#{@subscription&.subscription_plan&.interval_name}",
-          "quantity": 1,
-          "price": "#{@subscription&.subscription_plan&.price}"
-        },
-      ]
-    });
+    if ("#{@subscription.kind}" === 'new_subscription') {
+      gtag('event', 'purchase', {
+        "transaction_id": "#{@subscription&.id}",
+        "affiliation": "subscription",
+        "value": "#{@subscription&.subscription_plan&.price}",
+        "currency": "#{@subscription&.subscription_plan&.currency&.iso_code}",
+        "items": [
+          {
+            "id": "#{@subscription&.subscription_plan&.id}",
+            "name": "#{@subscription&.subscription_plan&.name}",
+            "brand": "Subscription",
+            "category": "#{@subscription&.subscription_plan&.interval_name}",
+            "quantity": 1,
+            "price": "#{@subscription&.subscription_plan&.price}"
+          },
+        ]
+      });
+    }
 
     let banner = "#{@banner.present?.to_s}";
     let preferredExamBodyId = "#{current_user&.preferred_exam_body_id}";


### PR DESCRIPTION
* **What?** Changed the config setting on GA gtag JS and removed the gtag purchase event unless the purchase is for a new subscription.
* **Why?** Resulting from extensive GA and GTM research, it was discovered that GTM and the gtag event scripts were serving the same function thus pageviews were being double-counted. The marketing/product team decided they didn't want to track reactivation and change plan payments on GA.
* **How?** Simple config line addition to gtag. Wrap the gtag purchase event in a conditional depending on it's kind attribute.

