### PR TITLE
Redirect corrector in pending cbe.

### DIFF
--- a/app/controllers/admin/exercises_controller.rb
+++ b/app/controllers/admin/exercises_controller.rb
@@ -66,7 +66,13 @@ module Admin
 
     # CBE Exercise
     def correct_cbe
-      @exercise      = Exercise.includes(cbe_user_log: [questions: [:cbe_question]]).find(params[:id])
+      @exercise = Exercise.includes(cbe_user_log: [questions: [:cbe_question]]).find(params[:id])
+
+      if @exercise.pending?
+        flash[:error] = I18n.t('controllers.exercises.correction.flash.pending_cbe')
+        redirect_to(admin_exercises_path) && return
+      end
+
       @cbe_user_log  = @exercise.cbe_user_log
       @cbe           = @cbe_user_log.cbe
       @total_score   = @cbe.total_score

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -215,6 +215,9 @@ en:
       update:
         flash:
           success: Exercise corrections successfully updated
+      correction:
+        flash:
+          pending_cbe: You can't view a pending cbe exercise.
 
     external_banners:
       create:


### PR DESCRIPTION
What? Redirect admin if CBE is pending.
Why? CBE is not ready to correct if exercise is pending yet.
How? Add a redirect condition.
How to test? Go to exercises and try to view any CBE with a pending condition.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1274115511