### PR TITLE
added props to exercises exhibits modal

### DIFF
--- a/app/javascript/components/exercises/ExhibitsModal.vue
+++ b/app/javascript/components/exercises/ExhibitsModal.vue
@@ -24,6 +24,40 @@ export default {
   components: {
     VueModal
   },
+  props: {
+    componentType: {
+      type: String,
+      default: "",
+    },
+    componentName: {
+      type: String,
+      default: "",
+    },
+    componentModal: {
+      type: Boolean,
+      default: false,
+    },
+    componentSpreadsheetData: {
+      type: Object,
+      default: () => ({}),
+    },
+    currentFile: {
+      type: Object,
+      default: () => ({}),
+    },
+    componentIcon: {
+      type: String,
+      default: "",
+    },
+    mainColor: {
+      type: String,
+      default: "#F2F2F2",
+    },
+    textColor: {
+      type: String,
+      default: "#000000",
+    },
+  },
   data() {
     return {
       cbeId: this.$parent.cbeId,


### PR DESCRIPTION
- **What?** errant modal shows on admin exercise correction.
- **Why?** not a reproducible error, likely due to no props being passed on vue component.
- **How?** added props to exercises exhibits modal.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1291086648