### PR TITLE
removed validations for solutions to add questions that do not come w…

### DIFF
--- a/app/javascript/components/practiceQuestions/ModalSolution.vue
+++ b/app/javascript/components/practiceQuestions/ModalSolution.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="solutionContent[this.indexOfQuestion]">
       <button id="modal-solution-v1" @click="show('modal-solution-v1')" href="#solutionModal" class="btn btn-settings solution-btn-title components-sidebar-links">Solution</button>
       <button v-if="loading" class="btn btn-settings solution-btn-title"><div class="vue-loader vue-loader-alt"></div></button>
         <VueModal

--- a/app/models/course_practice_question.rb
+++ b/app/models/course_practice_question.rb
@@ -52,11 +52,7 @@ class CoursePracticeQuestion < ApplicationRecord
   validates_attachment_presence :document
   validates_attachment_content_type :document, content_type: %w[application/pdf]
 
-  accepts_nested_attributes_for :questions, reject_if: ->(attributes) { question_is_blank?(attributes) }
-
-  def self.question_is_blank?(attributes)
-    attributes['solution'].blank?
-  end
+  accepts_nested_attributes_for :questions
 
   def duplicate
     new_cme_practice_question = deep_clone include: [

--- a/app/models/practice_question/question.rb
+++ b/app/models/practice_question/question.rb
@@ -33,7 +33,6 @@ module PracticeQuestion
     # validations
     validates :course_practice_question_id, presence: true, on: :update
     validates :name, presence: true
-    validates :solution, presence: true
 
     # callbacks
 

--- a/spec/models/course_practice_question_spec.rb
+++ b/spec/models/course_practice_question_spec.rb
@@ -44,16 +44,4 @@ describe CoursePracticeQuestion do
   describe 'Concern' do
     it_behaves_like 'archivable'
   end
-
-  describe 'Methods' do
-    describe '#question_is_blank?' do
-      context 'should return true' do
-        it { expect(described_class.question_is_blank?(practice_question_attributes)).to be_truthy }
-      end
-
-      context 'should return false' do
-        it { expect(described_class.question_is_blank?(practice_question_with_questions_attributes[:questions].first)).to be_falsey }
-      end
-    end
-  end
 end


### PR DESCRIPTION
- **What?** can't create questions on the admin side of practice questions when there is no solution present.
- **Why?** validations on solution prevented question creation.
- **How?** removed validations for solutions to add questions that do not come with solutions.
- **How to test?** Go to a practice question on console as an admin and create a new question leaving the solution template empty. 

https://learnsignal-team.monday.com/boards/1197527059/pulses/1298824351