### PR TITLE
(HOTFIX) Total score in cbe.

### DIFF
--- a/app/models/cbe.rb
+++ b/app/models/cbe.rb
@@ -80,6 +80,6 @@ class Cbe < ApplicationRecord
   end
 
   def total_score
-    exhibit_scenario? ? requirements.map(&:score).sum : questions.map(&:score).sum
+    exhibit_scenario? ? requirements.map(&:score).sum : questions.where(active: true).map(&:score).sum
   end
 end


### PR DESCRIPTION
What? CBE total score could show an incorrect value;
Why? The total score was getting all questions scores, even the inactives one;
How? Fix total score method to get scores just from the active questions;

![Screenshot 2021-05-26 at 10 07 27](https://user-images.githubusercontent.com/136358/119634367-985b4200-be0a-11eb-8767-f0f6204aa1a8.png)
