### PR TITLE
added paste as text to text editor tinymce

### DIFF
--- a/app/javascript/components/TinyEditor.vue
+++ b/app/javascript/components/TinyEditor.vue
@@ -16,6 +16,7 @@
         images_upload_handler: imageUploadHandler,
         image_advtab: true,
         skin: 'custom',
+        paste_as_text: true
       }"
       @input="$emit('update:fieldModel', localFieldModel)"
     />


### PR DESCRIPTION
- **What?**  sometimes things break when student pastes from one element to another.
- **Why?** content pasted in by the student is sometimes dragging css stylings.
- **How?** added paste as text to text editor tinymce.
- **How to test?** Go to anywhere that has tinymce text editor and paste in styled content, it should paste as plain text.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1306601752