### PR TITLE
added paste as plain text to spreadsheet editor

### DIFF
--- a/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
+++ b/app/javascript/components/SpreadsheetEditor/SpreadsheetEditor.vue
@@ -205,6 +205,7 @@
         const fbx = new GC.Spread.Sheets.FormulaTextBox.FormulaTextBox(this.$refs.fbxRef);
         fbx.workbook(spread);
         this.flex = spread.getSheet(0);
+        this.flex.options.clipBoardOptions = GC.Spread.Sheets.ClipboardPasteOptions.values;
         if (this.spreadsheetData) {
           spread.suspendPaint();
           this.flex.setDataSource(this.flex.fromJSON(JSON.parse(JSON.stringify(this.spreadsheetData))));


### PR DESCRIPTION
- **What?**  sometimes things break when student pastes from one element to another.
- **Why?** content pasted in by the student is sometimes dragging css stylings.
- **How?** added paste as plain text to spreadsheet editor.
- **How to test?** Go to anywhere that uses spreadsheet editor and paste in some styled content.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1306604969