### PR TITLE
(HOTFIX) CBE Navigator redirect

### DIFF
--- a/app/assets/stylesheets/components/cbes/_cbe-new.scss
+++ b/app/assets/stylesheets/components/cbes/_cbe-new.scss
@@ -486,6 +486,24 @@ button.flagged{
   }
 }
 
+.cbe-navigator-modal {
+  .vm--overlay { display: none }
+  .vm--container {
+    width: 0;
+    height: 0;
+  }
+  .ls-overlay {
+    position: fixed;
+    box-sizing: border-box;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.2);
+    opacity: 1;
+  }
+}
+
 // CBE Exhibits
 
 .exhibits-sidebar {

--- a/app/javascript/components/VueModal.vue
+++ b/app/javascript/components/VueModal.vue
@@ -115,6 +115,7 @@ export default {
     },
     hide () {
       $('.latent-modal').removeClass('active-modal');
+      eventBus.$emit("close-active-overlay", false);
       this.$modal.hide("modal-"+this.componentType+"-"+this.componentName);
     },
     normalizeId (id) {

--- a/app/javascript/components/cbe/CbeNavigator.vue
+++ b/app/javascript/components/cbe/CbeNavigator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="cbe-modals">
+  <div id="cbe-modals" class="cbe-navigator-modal">
     <section
       class="components-sidebar-links navigation-icon"
       @click="show($event)"
@@ -16,6 +16,7 @@
       <CbeReview :cbe_id="cbeId" />
     </div>
     </VueModal>
+    <div v-show="activeOverlay" class="ls-overlay" @click="hide()"></div>
   </div>
 </template>
 
@@ -31,7 +32,7 @@ export default {
   },
   data() {
     return {
-      modalIsOpen: false
+      activeOverlay: false
     };
   },
   props: {
@@ -46,17 +47,19 @@ export default {
     },
   },
   created() {
-    eventBus.$on("close-modal",(status)=>{
-      this.modalIsOpen = status;
+    eventBus.$on("close-active-overlay",(status)=>{
+      this.activeOverlay = status;
     })
   },
   methods: {
     show (event) {
       this.$modal.show("modal-"+this.componentType+"-"+this.componentName);
+      this.activeOverlay = true;
       $('.components-sidebar .components div').removeClass('active-modal');
       eventBus.$emit("update-modal-z-index", `modal-${this.componentType}-${this.componentName}`);
     },
     hide (event) {
+      this.activeOverlay = false;
       $('.latent-modal').removeClass('active-modal');
       this.$modal.hide("modal-"+this.componentType+"-"+this.componentName);
     },


### PR DESCRIPTION
@dsbonnelly changes but creating from master branch.

What? on outside click of the cbe navigator modal the user is directed to a missing page.
Why? the third party plugin is propagating a click event that triggers an autogenerated href that cannot be accessed.
How? disabled third party overlay due to click event propagation error and replaced with custom overlay.
How to test? Go to a cbe and open and close the navigator modal, as well as use the internal navigation and the next and previous buttons.


https://learnsignal-team.monday.com/boards/1197527059/pulses/1349821477