### PR TITLE
Add preferred exam body column in users mass invite.

### DIFF
--- a/app/views/users/_csv_import_modal.html.haml
+++ b/app/views/users/_csv_import_modal.html.haml
@@ -25,6 +25,8 @@
                   The second column is for First Name.
                 %li
                   The third column is for Last Name.
+                %li
+                  The fourth column is for Preferred Exam Body.
 
           .row.pt-3
             .col-sm-12

--- a/app/views/users/preview_csv_upload.html.haml
+++ b/app/views/users/preview_csv_upload.html.haml
@@ -25,12 +25,15 @@
                     %th
                       Last Name
                     %th
+                      Preferred Exam Body
+                    %th
                       Errors
                 %tbody
                   -@users.each_with_index do |user, idx|
                     =hidden_field_tag "csvdata[#{idx}][email]",      user.email
                     =hidden_field_tag "csvdata[#{idx}][first_name]", user.first_name
                     =hidden_field_tag "csvdata[#{idx}][last_name]",  user.first_name
+                    =hidden_field_tag "csvdata[#{idx}][preferred_exam_body_id]", user.preferred_exam_body_id
 
                     - errors = preview_csv_user_errors(user.errors)
                     %tr{id: "csvdata-#{idx}"}
@@ -40,6 +43,8 @@
                         =user.first_name
                       %td
                         =user.last_name
+                      %td
+                        =user.preferred_exam_body&.name
                       %td
                         =errors.map { |e| "<p style= 'color: #dc3545;'>#{e}</p>" }.join("\n").html_safe
 

--- a/app/workers/csv_import_user_creation_worker.rb
+++ b/app/workers/csv_import_user_creation_worker.rb
@@ -3,8 +3,7 @@ class CsvImportUserCreationWorker
 
   sidekiq_options queue: 'medium'
 
-  def perform(email, first_name, last_name, user_group_id, root_url)
-    User.create_csv_user(email, first_name, last_name, user_group_id, root_url)
+  def perform(email, first_name, last_name, preferred_exam_body_id, user_group_id, root_url)
+    User.create_csv_user(email, first_name, last_name, preferred_exam_body_id, user_group_id, root_url)
   end
-
 end


### PR DESCRIPTION
What? Preferred exam body in bulk invites;
Why? Users created by bulk invite will be created with a preferred exam body data;
How? Add preferred exam body as an option in the CSV file importer;

https://learnsignal-team.monday.com/boards/1197527059/pulses/1337379614?notification=960840719