### PR TITLE
added dynamic width functionality to splitpanes

### DIFF
--- a/app/assets/stylesheets/components/practice-questions/_master.scss
+++ b/app/assets/stylesheets/components/practice-questions/_master.scss
@@ -435,7 +435,6 @@ button2.btn-settings:active-sol {
 .prac-ques-ans-box {
   padding:0;
   .container-fluid {
-    width: 105%;
     padding-right: 0;
     padding-left: 0;
     margin-right: 0;

--- a/app/javascript/components/practiceQuestions/MainView.vue
+++ b/app/javascript/components/practiceQuestions/MainView.vue
@@ -37,6 +37,7 @@
         class="practice-question-theme"
         :style="{ height: '70vh' }"
         :key="stepLogId"
+        @resize="splitResize()"
       >
         <span v-if="practiceQuestion.kind == 'standard'">
           <ScenarioPane :content="practiceQuestion.content" />
@@ -266,6 +267,10 @@ export default {
     },
     refreshSheetLayout() {
       window.dispatchEvent(new Event("resize"));
+    },
+    splitResize() { 
+      var updatedWidth = Number($("#pane_1").width()) + 5;
+      eventBus.$emit('splitpane-resize', updatedWidth.toString()  + "px")
     },
   },
 };

--- a/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
+++ b/app/javascript/components/practiceQuestions/QuestionsAnswersPane.vue
@@ -26,6 +26,7 @@
 
         <div v-else>
           <spreadsheet-editor
+            :style="{ minWidth: this.spreadSheetWidth }"
             :initial-data="convertStr2Obj(questionContent.answer_content)"
             :key="questionContent.id"
             @spreadsheet-updated="syncSpreadsheetData"
@@ -82,6 +83,7 @@ export default {
       questionContent: null,
       fillArr: null,
       lastTimeUpdated: new Date(),
+      spreadSheetWidth: '800px'
     };
   },
   mounted() {
@@ -99,6 +101,9 @@ export default {
   },
   async created() {
     this.questionContent = this.questionContentArray[this.activePage - 1];
+    eventBus.$on("splitpane-resize", (splitWidth) => {
+      this.spreadSheetWidth = splitWidth;
+    })
   },
   methods: {
     handleChange(value) {


### PR DESCRIPTION
- **What?**  spreadsheet editor breaks into an infinite loop of width changes on its canvas when adjusting splitpanes or window size.
- **Why?** the issue is with a dynamic width in %, a fixed width is needed.
- **How?** added fixed width with a dynamic update functionality to splitpanes.
- **How to test?** Go to a practice question with a spreadsheet editor and test the splitpane.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1374627960