### PR TITLE
Add slack notifications in stripe integration.

### DIFF
--- a/app/workers/stripe_api_processor_worker.rb
+++ b/app/workers/stripe_api_processor_worker.rb
@@ -10,5 +10,20 @@ class StripeApiProcessorWorker
                            account_url: account_url)
   rescue ActiveModel::ValidationError, ActiveRecord::RecordInvalid => e
     Rails.logger.error "StripeApiEvent#existing_guid #{e.inspect}"
+    if Rails.env.production?
+      SlackService.new.notify_channel('payments',
+                                      webhook_failed_notification(e, stripe_event_id),
+                                      icon_emoji: 'rotating_light')
+    end
+  end
+
+  private
+
+  def stripe_failed_notification(error, stripe_event_id)
+    [{ fallback: "Stripe webhook ##{stripe_event_id} have failed.",
+       title: "Stripe webhook ##{stripe_event_id} have failed.\nError: #{error.inspect}",
+       title_link: "https://dashboard.stripe.com/events/#{stripe_event_id}",
+       color: '#7CD197',
+       footer: 'Stripe' }]
   end
 end


### PR DESCRIPTION
What? Slack notification in stripe errors.
Why? Some stripe calls are not working and we're not receiving any return from it.
How? Added slack notifications when that error occurs. 

https://learnsignal-team.monday.com/boards/1197527059/pulses/1386719825
