### PR TITLE
Add slack notification in paypal cron cancel method.

### DIFF
--- a/spec/services/paypal/subscription_validation_spec.rb
+++ b/spec/services/paypal/subscription_validation_spec.rb
@@ -211,6 +211,7 @@ describe Paypal::SubscriptionValidation, type: :service do
 
     it 'returns nil if there are no scheduled workers' do
       allow_any_instance_of(Sidekiq::ScheduledSet).to receive(:select).and_return([1])
+      allow_any_instance_of(SlackService).to receive(:notify_channel).and_return(false)
 
       expect(target_instance.send(:check_scheduled_cancellation_worker)).to be nil
     end


### PR DESCRIPTION
- **What?** Send a slack notification after paypal cron file trigger a cancel_billing_agreement_immediately method.
- **Why?**  We'd some subscriptions cancelled before the job schedulled triggers it.
- **How?** Add a method to notify slack.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1387321345