### PR TITLE
added sort by date to admin side exercises

### DIFF
--- a/app/controllers/admin/exercises_controller.rb
+++ b/app/controllers/admin/exercises_controller.rb
@@ -18,12 +18,8 @@ module Admin
           @filters[key] = value
         end
 
-        case params[:state]
-        when 'returned', 'all'
-          @exercises = @exercises.order(created_at: :desc)
-        else
-          @exercises = @exercises.order(created_at: :asc)
-        end
+        @exercises = sort_exercises_arr(@exercises, params[:sort_direction])
+
       else
         @exercises = @exercises.with_state(:submitted).order(created_at: :asc)
       end
@@ -163,6 +159,19 @@ module Admin
       params.require(:exercise).permit(
         :correction, :corrector_id, :submission, :product_id, :order_id
       )
+    end
+
+    def sort_exercises_arr(exercises_arr, direction)
+      case params[:sort_by]
+      when 'due_on'
+        exercises_arr.order(submitted_on: direction)
+      when 'corrected_on'
+        exercises_arr.order(corrected_on: direction)
+      when 'returned_on'
+        exercises_arr.order(returned_on: direction)
+      else
+        exercises_arr.order(submitted_on: direction)
+      end
     end
   end
 end

--- a/app/views/admin/exercises/index.html.haml
+++ b/app/views/admin/exercises/index.html.haml
@@ -13,9 +13,13 @@
               .search-container.mb-3.float-right
                 =form_tag(admin_search_exercises_url, role: 'form', class: 'form-inline') do
                   =hidden_field_tag :user_id, @user&.id
+                  =hidden_field_tag :sort_by, params[:sort_by]
+                  =hidden_field_tag :sort_direction, params[:sort_direction]
                   =select_tag :state, options_for_select([['Submitted', 'submitted'], ['Correcting', 'correcting'], ['Returned', 'returned'], ['Pending', 'pending'], ['All', 'all']], @filters['state']), class: 'form-control custom-select filter mr-3'
                   =select_tag :product, options_from_collection_for_select(Product.all_active, 'id', 'name', @filters['product']), prompt: 'All Products', class: 'form-control custom-select filter mr-3'
                   =select_tag :corrector, options_from_collection_for_select(User.joins(:user_group).where(user_groups: { exercise_corrections_access: true }), 'id', 'name', @filters['corrector']), prompt: 'All Correctors', class: 'form-control custom-select filter mr-3'
+                  =select_tag :sort_by, options_for_select([['Due On','due_on'], ['Corrected On','corrected_on'], ['Returned On','returned_on']], params[:sort_by]), class: 'form-control custom-select filter mr-3'
+                  =select_tag :sort_direction, options_for_select([['Descending', :desc], ['Ascending', :asc]], params[:sort_direction]), class: 'form-control custom-select filter mr-3'
                   =text_field_tag :search, @filters['search'], class: 'form-control', placeholder: 'Search term'
                   %button{type: "submit", class: 'ml-3'}
                     %i{:role => "img", class: 'budicon-search-list'}

--- a/spec/controllers/admin/exercises_controller_spec.rb
+++ b/spec/controllers/admin/exercises_controller_spec.rb
@@ -9,6 +9,10 @@ describe Admin::ExercisesController, type: :controller do
   let(:exercise)             { create(:exercise) }
   let(:other_exercise)       { create(:exercise) }
 
+  let!(:exercise_A)           { create(:exercise, state: 'returned', submitted_on: Time.zone.now + 2.days, corrected_on: Time.zone.now + 6.days, returned_on: Time.zone.now + 6.days) }
+  let!(:exercise_B)           { create(:exercise, state: 'returned', submitted_on: Time.zone.now + 4.days, corrected_on: Time.zone.now + 4.days, returned_on: Time.zone.now + 2.days) }
+  let!(:exercise_C)           { create(:exercise, state: 'returned', submitted_on: Time.zone.now + 6.days, corrected_on: Time.zone.now + 2.days, returned_on: Time.zone.now + 4.days) }
+
   context 'Logged in as a normal admin user' do
     before(:each) do
       activate_authlogic
@@ -74,6 +78,39 @@ describe Admin::ExercisesController, type: :controller do
         get :index
         expect(response.status).to eq(200)
         expect(response).to render_template(:index)
+      end
+
+      context 'sort exercises by dates params' do
+        it 'should sort by submitted on ascending when sort_by params equals due_on and sort_direction equals asc' do
+          post :index, params: { sort_by: 'due_on', sort_direction: :asc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
+        it 'should sort by submitted on descending when sort_by params equals due_on and sort_direction equals desc' do
+          post :index, params: { sort_by: 'due_on', sort_direction: :desc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
+        it 'should sort by corrected on ascending when sort_by params equals corrected_on and sort_direction equals asc' do
+          post :index, params: { sort_by: 'corrected_on', sort_direction: :asc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
+        it 'should sort by corrected on descending when sort_by params equals corrected_on and sort_direction equals desc' do
+          post :index, params: { sort_by: 'corrected_on', sort_direction: :desc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
+        it 'should sort by returned on ascending when sort_by params equals returned_on and sort_direction equals asc' do
+          post :index, params: { sort_by: 'returned_on', sort_direction: :asc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
+        it 'should sort by returned on descending when sort_by params equals returned_on and sort_direction equals desc' do
+          post :index, params: { sort_by: 'returned_on', sort_direction: :desc }
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:index)
+        end
       end
     end
 


### PR DESCRIPTION
- **What?** submitted exercises cannot be sorted by dates on admin side.
- **How?** added sort by date to admin side exercises.
- **How to test?** Go to console > exercises and click on the submit button, change the sort_by and sort_direction drop-downs to see if the sorting order acts accordingly.. 

https://learnsignal-team.monday.com/boards/1197527059/pulses/1399456069