### PR TITLE
disclaimer footer for groups

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4424,6 +4424,15 @@ a.card:hover .card-title .card-explanation {
   padding: 0 2rem;
   font-size: .825rem
 }
+.disclaimer-footer {
+  padding: 0;
+  background: #f2f2f2;
+    p, h1, h2, h3, h4, h5 {
+      color: #999999;
+      margin: 0 0 20px 0;
+      font-size: 1.0rem;
+  }
+}
 @media (min-width:576px) {
   .footer {
     padding: 0 0 5rem 0

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -72,8 +72,8 @@ class GroupsController < ApplicationController
     params.require(:group).permit(:name, :name_url, :active, :sorting_order,
                                   :description, :image, :background_image,
                                   :background_colour, :exam_body_id,
-                                  :seo_title, :seo_description,
-                                  :short_description, :onboarding_level_heading,
-                                  :onboarding_level_subheading, :tab_view)
+                                  :seo_title, :seo_description, :short_description,
+                                  :onboarding_level_heading, :onboarding_level_subheading,
+                                  :tab_view, :disclaimer)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -56,6 +56,7 @@ class Group < ApplicationRecord
   validates_attachment_content_type :background_image, content_type: /\Aimage\/.*\Z/
 
   # callbacks
+  before_save :filter_disclaimer_text
   before_destroy :check_dependencies
 
   # scopes
@@ -104,4 +105,9 @@ class Group < ApplicationRecord
     attributes['name'].blank? && attributes['name_url'].blank?
   end
 
+  def filter_disclaimer_text
+    return unless attributes['disclaimer'].blank? || attributes['disclaimer'] == '<p><br></p>'
+
+    self.disclaimer = nil
+  end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -28,6 +28,10 @@
             %label
               =f.check_box :tab_view
               =t('views.groups.form.tab_view')
+        .form-group
+          =f.label :disclaimer, t('views.groups.form.disclaimer')
+          .input-group.input-group-lg
+            =f.text_area :disclaimer, as: :summernote, placeholder: t('views.groups.form.disclaimer_placeholder'), rows: 10, class: 'form-control', id: 'editor'
 
       .col-sm-6
         .form-group
@@ -89,3 +93,10 @@
     .col-sm-12
       =f.submit t('views.general.save'), class: 'btn btn-primary'
       =link_to t('views.general.cancel'), groups_path, class: 'btn btn-secondary'
+
+:javascript
+
+  $('#editor').summernote({
+    disableDragAndDrop: true,
+    height: 300
+  });

--- a/app/views/layouts/_footer_disclaimer.html.haml
+++ b/app/views/layouts/_footer_disclaimer.html.haml
@@ -1,0 +1,6 @@
+%footer.disclaimer-footer.footer-light
+  .container.position-relative.py-6
+    .row
+      = sanitize @group.disclaimer
+
+    

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -107,6 +107,7 @@
         =yield
 
         -if @footer
+          =render partial: 'layouts/footer_disclaimer' if @group&.disclaimer
           =render partial: 'layouts/footer'
 
       -elsif @layout == 'management'
@@ -145,6 +146,7 @@
         -if flash[:success] || flash[:error] || flash[:warning]
           =render partial: 'layouts/flash_messages'
         =yield
+        =render partial: 'layouts/footer_disclaimer' if @group&.disclaimer
         =render partial: 'layouts/footer'
 
 

--- a/app/views/layouts/marketing.html.haml
+++ b/app/views/layouts/marketing.html.haml
@@ -61,6 +61,7 @@
       =yield
 
       -if @footer
+        =render partial: 'layouts/footer_disclaimer' if @group&.disclaimer
         =render partial: 'layouts/footer'
     -else
       =render partial: 'layouts/navbar'
@@ -69,6 +70,7 @@
       -if flash[:success] || flash[:error] || flash[:warning]
         =render partial: 'layouts/flash_messages'
       =yield
+      =render partial: 'layouts/footer_disclaimer' if @group&.disclaimer
       =render partial: 'layouts/footer'
 
 

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -904,6 +904,8 @@ en:
         seo_description_placeholder: SEO Description
         short_description: Short Description
         short_description_placeholder: Subheading Tagline
+        disclaimer: Disclaimer
+        disclaimer_placeholder: Disclaimer text
         onboarding_level_heading: Onboarding Heading
         onboarding_level_heading_placeholder: Onboarding Heading
         onboarding_level_subheading: Onboarding Sub-Heading

--- a/db/migrate/20210624111626_add_disclaimer_to_groups.rb
+++ b/db/migrate/20210624111626_add_disclaimer_to_groups.rb
@@ -1,0 +1,5 @@
+class AddDisclaimerToGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column :groups, :disclaimer, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_24_103851) do
+ActiveRecord::Schema.define(version: 2021_06_24_111626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -918,6 +918,7 @@ ActiveRecord::Schema.define(version: 2021_05_24_103851) do
     t.text "onboarding_level_subheading"
     t.string "onboarding_level_heading"
     t.boolean "tab_view", default: false, null: false
+    t.text "disclaimer"
     t.index ["exam_body_id"], name: "index_groups_on_exam_body_id"
     t.index ["name"], name: "index_groups_on_name"
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -81,6 +81,7 @@ describe Group do
   it { should_not validate_presence_of(:background_image) }
 
   # callbacks
+  it { should callback(:filter_disclaimer_text).before(:save) }
   it { should callback(:check_dependencies).before(:destroy) }
 
   # scopes


### PR DESCRIPTION
- **What?** add disclaimer footer for groups.
- **How?** disclaimer footer for groups.
- **How to test?** On the console side, edit a group and add text to the disclaimer. Then go to that group course in the library and see if the disclaimer shows up as it should on top of the traditional footer. 

https://learnsignal-team.monday.com/boards/1197527059/pulses/1408585294