### PR TITLE
darken library header section for better contrast with white font

### DIFF
--- a/app/views/library/group_show.html.haml
+++ b/app/views/library/group_show.html.haml
@@ -1,7 +1,7 @@
 %main
   %article.library-group-show.bg-white.py-5.py-lg-6
     .container
-      %header.hero-section.hero-section-revisions{style: "background-image: url(#{@group.background_image.url});", title: "#{@group.name} Courses banner"}
+      %header.hero-section.hero-section-revisions{style: "background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(#{@group.background_image.url});", title: "#{@group.name} Courses banner"}
         %h1.h1-hero.mb-3.text-white
           =@group.name
           ='Courses'


### PR DESCRIPTION
- **What?** white font gets lost sometimes on bright backgrounds.
- **How?** darken library header section for better contrast with white font.
- **How to test?** Go to library and browse courses.

https://learnsignal-team.monday.com/boards/1197527059/pulses/1408585294