### PR TITLE
fixed undefined gtag catch outside on consent callback

### DIFF
--- a/app/views/layouts/_cookie_banner.html.haml
+++ b/app/views/layouts/_cookie_banner.html.haml
@@ -6,6 +6,9 @@
   %script{:async => "", :src => "https://www.googletagmanager.com/gtag/js?id=UA-185199057-2"}
   :javascript
     const gtag_id = 'UA-185199057-2';
+-else
+  :javascript
+    gtag = function (){};
 
 :javascript
   var _iub = _iub || [];
@@ -24,16 +27,12 @@
         });
         var hubspot_accept = document.getElementById("hs-eu-confirmation-button");
         hubspot_accept.click();
-        // Global Site Tag
         if(gtag_id) {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', gtag_id, { 'send_page_view': false });
-        // Global Site Tag
-        } else {
-          gtag = function (){};
-        }
+        } 
       },
       onConsentRejected: function() {
         console.log('Consent Rejected On Load');
@@ -50,6 +49,6 @@
       "position":"float-top-center",
       "textColor":"#ffffff",
       "backgroundColor":"#000032"
-    }};
+  }};
 %script{:src => "//cdn.iubenda.com/cs/tcf/stub-v2.js", :type => "text/javascript"}
 %script{:src => "//cdn.iubenda.com/cs/iubenda_cs.js", :type => "text/javascript"}


### PR DESCRIPTION
**What?** gtag undefined error on console
**Why?** when no banner is present there is no consent callback and no gtag designation, a stub is needed
**How?** fixed undefined gtag catch outside on consent callback by adding stub