### PR TITLE
(AP-67) API::User - Forgot Password.

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -9,7 +9,10 @@
 # Add Token your_api_key_here in Authorization header;
 module Api
   module V1
-    class ApiController < Api::V1::ApplicationController
+    class ApiController < ApplicationController
+      include ExceptionHandler
+      include Response
+
       before_action :authenticate
 
       def logged_in_user

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -28,6 +28,12 @@ module Api
         end
       end
 
+      def forgot_password
+        response = User.start_password_reset_process(params[:email])
+
+        json_response(response[:json], response[:status])
+      end
+
       private
 
       def set_user

--- a/app/controllers/user_passwords_controller.rb
+++ b/app/controllers/user_passwords_controller.rb
@@ -12,9 +12,10 @@ class UserPasswordsController < ApplicationController
   end
 
   def create
-    User.start_password_reset_process(params[:email_address].to_s, root_url)
+    @response = User.start_password_reset_process(params[:email_address].to_s)
+
     seo_title_maker('Password Reset Email Sent | LearnSignal',
-                    "Check your mailbox for further instructions. If you don't receive an email from learnsignal within a couple of minutes, check your spam folder.",
+                    @response[:json][:message],
                     nil)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,21 +187,39 @@ class User < ApplicationRecord
     user.verify(country_id)
   end
 
-  def self.start_password_reset_process(the_email_address, root_url)
-    return unless the_email_address.to_s.length > 5 # a@b.co
+  def self.start_password_reset_process(email)
+    return { json: { message: 'Invalid email format.' }, status: :unprocessable_entity } unless email.match(/\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i)
 
-    user = User.find_by(email: the_email_address.to_s)
-    if user&.email_verified && !user.password_change_required?
-      user.update_attributes(password_reset_requested_at: proc { Time.zone.now }.call, password_reset_token: ApplicationController.generate_random_code(20))
+    user = User.find_by(email: email.to_s)
+    return { json: { message: 'No registered user using this email.' }, status: :not_found } if user.nil?
+
+    if user.email_verified.nil?
+      status  = :unprocessable_entity
+      message = 'User not yet verified, please check your email.'
+    elsif !user.password_change_required?
+      user.update(password_reset_requested_at: proc { Time.zone.now }.call, password_reset_token: ApplicationController.generate_random_code(20))
+
       # Send reset password email from Mandrill
-      Message.create(process_at: Time.zone.now, user_id: user&.id, kind: :account, template: 'password_reset_email',
-                     template_params: { url: UrlHelper.instance.reset_password_url(id: user.password_reset_token, host: LEARNSIGNAL_HOST) })
-    elsif user&.email_verified && user&.password_change_required?
+      send_reset_password_email(user, 'password_reset_email')
+
+      status  = :ok
+      message = "Check your mailbox for further instructions. If you don't receive an email from learnsignal within a couple of minutes, check your spam folder."
+    elsif user.password_change_required?
+      user.update(:password_reset_token, ApplicationController.generate_random_code(20))
+
       # This is for users that received invite verification emails, clicked on the link which verified their account but they did not enter a PW. Now they are trying to access their account by trying to reset their PW so we send them a link for the set pw form instead of the reset pw form.
-      user.update_attribute(:password_reset_token, ApplicationController.generate_random_code(20))
-      Message.create(process_at: Time.zone.now, user_id: user&.id, kind: :account, template: 'send_set_password_email',
-                     template_params: { url: UrlHelper.instance.set_password_url(id: user.password_reset_token, host: LEARNSIGNAL_HOST) })
+      send_reset_password_email(user, 'send_set_password_email')
+
+      status  = :ok
+      message = "Check your mailbox for further instructions. If you don't receive an email from learnsignal within a couple of minutes, check your spam folder."
     end
+
+    { json: { message: message }, status: status }
+  end
+
+  def self.send_reset_password_email(user, template)
+    Message.create(process_at: Time.zone.now, user_id: user&.id, kind: :account, template: template,
+                   template_params: { url: UrlHelper.instance.set_password_url(id: user.password_reset_token, host: LEARNSIGNAL_HOST) })
   end
 
   def self.resend_pw_reset_email(user_id, _)

--- a/app/views/user_passwords/create.html.haml
+++ b/app/views/user_passwords/create.html.haml
@@ -3,12 +3,14 @@
     .container
       %header.hero-section
         %h1.h1-hero.mb-3
-          Check Your Email
+          -if @response[:status] == :ok
+            Check Your Email
+          -else
+            Please check your information and try again.
 
 
       %section.pb-md-6.pb-5
         .forgot-password-section.mb-7
           .form-box.text-center
             %p.p-hero.px-lg-8
-              If you don't receive an email within a couple of minutes, check your spam folder.
-
+              =@response[:json][:message]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,10 @@ Rails.application.routes.draw do
       resources :exam_bodies, only: :index
       resources :practice_questions, only: :index
       resources :uploads, only: :create
-      resources :users, only: %i[show create]
+
+      resources :users, only: %i[show create] do
+        get 'forgot_password', on: :collection
+      end
     end
   end
 


### PR DESCRIPTION
What? Forgot password endpoin.
How? api call to trigger reset password email.
How to test?

API call: I did add a user register test(not working yet, but you can test the API authentication using it.)
GET request to http://localhost:3000/api/v1/users?email=valid-email-here

Use Bearer Token authentication and add your API key as a value.