### PR TITLE
(AP-69) API Logout.

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -13,6 +13,7 @@ module Api
       before_action :authenticate
 
       def logged_in_user
+        return if JwtBlockedToken.find_by(token: token_header).present?
         return unless decoded_token
 
         user_id = decoded_token[0]['user_id']
@@ -47,14 +48,12 @@ module Api
         JWT.decode(token_header, secret, true, algorithm: 'HS256') if token_header.present?
       end
 
-      # TODO(giordano) work in expiration time in logout implementation
-      # IE:
-      # exp = Time.now.to_i + (valid_for_minutes*60)
-      # { exp: exp,
-      #   user_name: @user.name,
-      #   user_id: @user.id }
-      def payload(user, _valid_for_minutes = 5)
-        { user_name: user.name,
+      def payload(user, days = 14)
+        valid_for_days = days * 24 * 60 * 60
+        exp            = Time.now.to_i + valid_for_days
+
+        { exp: exp,
+          user_name: user.name,
           user_id: user.id }
       end
 

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -8,6 +8,14 @@ module Api
       include ActionController::HttpAuthentication::Token::ControllerMethods
       include ExceptionHandler
       include Response
+
+      def current_user
+        @current_user ||= current_user_session&.record
+      end
+
+      def current_user_session
+        @current_user_session ||= UserSession.find
+      end
     end
   end
 end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class AuthController < Api::V1::ApiController
       before_action :set_user, only: :login
+      before_action :authorize_user, only: :logout
 
       def login
         return json_response({ error: 'No user registered with this email.' }, :not_found) unless @user
@@ -20,7 +21,17 @@ module Api
         end
       end
 
-      def logout; end
+      def logout
+        jwt_blocked_token = JwtBlockedToken.new(token: token_header)
+
+        jwt_blocked_token.transaction do
+          if jwt_blocked_token.save && current_user_session&.destroy
+            json_response({ message: 'You have successfully logged out.' }, :ok)
+          else
+            json_response({ error: 'Unsuccessfull attempt to logout.' }, :unprocessable_entity)
+          end
+        end
+      end
 
       private
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class UsersController < Api::V1::ApiController
-      # before_action :authorize_user, only: :show
       before_action :set_user, only: :show
 
       def show

--- a/app/models/jwt_blocked_token.rb
+++ b/app/models/jwt_blocked_token.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class JwtBlockedToken < ApplicationRecord
+  validates :token, presence: true
+end

--- a/db/migrate/20210816075325_create_jwt_blocked_tokens.rb
+++ b/db/migrate/20210816075325_create_jwt_blocked_tokens.rb
@@ -1,0 +1,9 @@
+class CreateJwtBlockedTokens < ActiveRecord::Migration[5.2]
+  def change
+    create_table :jwt_blocked_tokens do |t|
+      t.string  :token, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_111805) do
+ActiveRecord::Schema.define(version: 2021_08_16_075325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -455,9 +455,9 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "cme_count", default: 0
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.integer "course_id"
     t.float "video_duration", default: 0.0
@@ -649,9 +649,9 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.boolean "is_video", default: false, null: false
     t.boolean "is_quiz", default: false, null: false
     t.boolean "active", default: true, null: false
-    t.string "seo_description", limit: 255
-    t.boolean "seo_no_index", default: false
     t.datetime "destroyed_at"
+    t.string "seo_description"
+    t.boolean "seo_no_index", default: false
     t.integer "number_of_questions", default: 0
     t.float "duration", default: 0.0
     t.string "temporary_label"
@@ -778,7 +778,6 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.string "logo_image"
     t.string "registration_form_heading"
     t.string "login_form_heading"
-    t.string "audience_guid"
     t.string "landing_page_h1"
     t.text "landing_page_paragraph"
     t.boolean "has_products", default: false
@@ -802,7 +801,6 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.string "student_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "subscription_type"
     t.index ["exam_body_id"], name: "index_exam_body_user_details_on_exam_body_id"
     t.index ["user_id"], name: "index_exam_body_user_details_on_user_id"
   end
@@ -921,8 +919,8 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.string "background_image_content_type"
     t.integer "background_image_file_size"
     t.datetime "background_image_updated_at"
-    t.string "background_colour"
     t.bigint "exam_body_id"
+    t.string "background_colour"
     t.string "seo_title"
     t.string "seo_description"
     t.string "short_description"
@@ -1063,6 +1061,12 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["country_id"], name: "index_ip_addresses_on_country_id"
+  end
+
+  create_table "jwt_blocked_tokens", force: :cascade do |t|
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "levels", force: :cascade do |t|
@@ -1253,6 +1257,7 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
 
   create_table "products", id: :serial, force: :cascade do |t|
     t.string "name"
+    t.integer "course_id"
     t.integer "mock_exam_id"
     t.string "stripe_guid"
     t.boolean "live_mode", default: false
@@ -1262,7 +1267,6 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.integer "currency_id"
     t.decimal "price"
     t.string "stripe_sku_guid"
-    t.integer "course_id"
     t.integer "sorting_order"
     t.integer "product_type", default: 0
     t.integer "correction_pack_count"
@@ -1273,6 +1277,7 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.text "payment_description"
     t.string "savings_label"
     t.index ["cbe_id"], name: "index_products_on_cbe_id"
+    t.index ["course_id"], name: "index_products_on_course_id"
     t.index ["currency_id"], name: "index_products_on_currency_id"
     t.index ["group_id"], name: "index_products_on_group_id"
     t.index ["mock_exam_id"], name: "index_products_on_mock_exam_id"
@@ -1567,10 +1572,8 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.string "cancellation_reason"
     t.text "cancellation_note"
     t.bigint "changed_from_id"
-    t.string "temp_guid"
     t.string "completion_guid"
     t.uuid "ahoy_visit_id"
-    t.integer "exam_body_user_detail_id"
     t.bigint "cancelled_by_id"
     t.integer "kind"
     t.integer "paypal_retry_count", default: 0
@@ -1665,9 +1668,9 @@ ActiveRecord::Schema.define(version: 2021_07_09_111805) do
     t.bigint "currency_id"
     t.string "tutor_link"
     t.integer "video_player", default: 0, null: false
-    t.integer "home_page_id"
     t.decimal "subscriptions_revenue", default: "0.0"
     t.decimal "orders_revenue", default: "0.0"
+    t.integer "home_page_id"
     t.index ["country_id"], name: "index_users_on_country_id"
     t.index ["currency_id"], name: "index_users_on_currency_id"
     t.index ["preferred_exam_body_id"], name: "index_users_on_preferred_exam_body_id"

--- a/spec/factories/jwt_blocked_token.rb
+++ b/spec/factories/jwt_blocked_token.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :jwt_blocked_token do
+    token { Faker::Crypto.md5 }
+  end
+end

--- a/spec/models/jwt_blocked_token.rb
+++ b/spec/models/jwt_blocked_token.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JwtBlockedToken, type: :model do
+  before { create(:bearer) }
+
+  let(:bearer) { build(:jwt_blocked_token) }
+
+  describe 'Should Respond' do
+    it { should respond_to(:token) }
+    it { should respond_to(:created_at) }
+    it { should respond_to(:updated_at) }
+  end
+
+  describe 'Validations' do
+    it { should validate_presence_of(:token) }
+  end
+end

--- a/spec/requests/api/v1/auth_controller_spec.rb
+++ b/spec/requests/api/v1/auth_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Api::V1::AuthController', type: :request do
+RSpec.describe Api::V1::AuthController, type: :request do
   let!(:user)          { create(:user) }
   let!(:active_bearer) { create(:bearer, :active) }
 
@@ -95,6 +95,74 @@ RSpec.describe 'Api::V1::AuthController', type: :request do
         body = JSON.parse(response.body)
 
         expect(body['error']).to eq('Invalid password.')
+      end
+    end
+  end
+
+  # logout
+  describe 'post /api/v1/auth/logout' do
+    context 'logout a valid user' do
+      before do
+        allow_any_instance_of(described_class).to receive(:current_user_session).and_return(user)
+        allow_any_instance_of(User).to receive(:destroy).and_return(true)
+
+        payload = described_class.new.send(:payload, user)
+        token   = described_class.new.send(:encode_token, payload)
+
+        post api_v1_auth_logout_path,
+               headers: { Authorization: "Bearer #{active_bearer.api_key}", token: token }
+      end
+
+      it 'returns HTTP status 200' do
+        expect(response).to have_http_status 200
+      end
+
+      it 'returns success json message' do
+        body = JSON.parse(response.body)
+
+        expect(body['message']).to eq('You have successfully logged out.')
+      end
+    end
+
+    context 'try to logout a invalid user_session' do
+      before do
+        allow_any_instance_of(described_class).to receive(:current_user_session).and_return(user)
+        allow_any_instance_of(User).to receive(:destroy).and_return(false)
+
+        payload = described_class.new.send(:payload, user)
+        token   = described_class.new.send(:encode_token, payload)
+
+        post api_v1_auth_logout_path,
+               headers: { Authorization: "Bearer #{active_bearer.api_key}", token: token }
+      end
+
+      it 'returns HTTP status 422' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'returns success json message' do
+        body = JSON.parse(response.body)
+
+        expect(body['error']).to eq('Unsuccessfull attempt to logout.')
+      end
+    end
+
+    context 'try to logout a witn a blocked token' do
+      let(:blocked_token) { create(:jwt_blocked_token) }
+
+      before do
+         post api_v1_auth_logout_path,
+               headers: { Authorization: "Bearer #{active_bearer.api_key}", token: blocked_token.token }
+      end
+
+      it 'returns HTTP status 401' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'returns error message data' do
+        body = JSON.parse(response.body)
+
+        expect(body['message']).to eq('User not logged in. Please log in.')
       end
     end
   end


### PR DESCRIPTION
What? Logoutendpoint.
How? api call to block jwt token and destroy the user session.
How to test?

POST request to `http://localhost:3000/api/v1/auth/logout`

Use Bearer Token authentication and add your API key as a value.
User token returned in login/register call as header param

![Screenshot 2021-08-16 at 16 29 26](https://user-images.githubusercontent.com/136358/129589037-b24a2f70-e8f3-4ef2-8b42-dab31a9787d8.png)
