### PR TITLE
(AP-66)(AP-70) Update user and change password endpoints.

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -19,8 +19,8 @@ module Api
         return if JwtBlockedToken.find_by(token: token_header).present?
         return unless decoded_token
 
-        user_id = decoded_token[0]['user_id']
-        @user = User.find_by(id: user_id)
+        user_id       = decoded_token[0]['user_id']
+        @current_user = User.find_by(id: user_id)
       end
 
       def logged_in?

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,10 @@
 module Api
   module V1
     class UsersController < Api::V1::ApiController
-      before_action :set_user, only: :show
+      before_action :set_user, only: %i[show update change_password]
+      before_action :set_user_id, only: %i[update change_password]
+      before_action :authorize_user, only: %i[update change_password]
+      before_action :same_user?, only: %i[update change_password]
 
       def show
         render 'api/v1/users/show.json'
@@ -33,18 +36,48 @@ module Api
         json_response(response[:json], response[:status])
       end
 
+      def update
+        if @user.update(user_params)
+          render 'api/v1/users/show.json', status: :ok
+        else
+          json_response({ error: @user.errors }, :unprocessable_entity)
+        end
+      end
+
+      def change_password
+        if @user.change_the_password(change_password_params)
+          json_response({ message: I18n.t('controllers.users.change_password.flash.success') }, :ok)
+        else
+          json_response({ message: I18n.t('controllers.users.change_password.flash.error') }, :unprocessable_entity)
+        end
+      end
+
       private
 
       def set_user
-        @user = User.find(params[:id])
+        @user = User.find(params[:id] || params[:user_id])
+      end
+
+      def set_user_id
+        @user_id = (params[:id] || params[:user_id]).to_i
+      end
+
+      def same_user?
+        return if @current_user.id == @user_id
+
+        json_response({ error: 'You are not allowed to update this user.' }, :unauthorized)
       end
 
       def user_params
         params.require(:user).permit(
           :email, :first_name, :last_name, :preferred_exam_body_id, :country_id,
           :locale, :password, :password_confirmation, :terms_and_conditions,
-          :communication_approval, :home_page_id
+          :communication_approval, :home_page_id, :date_of_birth
         )
+      end
+
+      def change_password_params
+        params.require(:user).permit(:current_password, :password, :password_confirmation)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,8 @@ Rails.application.routes.draw do
       resources :practice_questions, only: :index
       resources :uploads, only: :create
 
-      resources :users, only: %i[show create] do
+      resources :users, only: %i[show create update] do
+        post 'change_password'
         get 'forgot_password', on: :collection
       end
     end

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     user_id { 1 }
     course_id { 1 }
     course_log_id { 11 }
-    exam_date { (Date.today + 2.years).strftime("%Y-%m-%d") }
+    exam_date { (Date.today + 1.years).strftime("%Y-%m-%d") }
     exam_body_id { 1 }
     expired { false }
     paused { false }

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Api::V1::UsersController', type: :request do
+RSpec.describe Api::V1::UsersController, type: :request do
   let!(:exam_body)       { create(:exam_body) }
   let!(:user_group)      { create(:student_user_group) }
   let!(:active_bearer)   { create(:bearer, :active) }
@@ -234,6 +234,140 @@ RSpec.describe 'Api::V1::UsersController', type: :request do
         body = JSON.parse(response.body)
 
         expect(body['message']).to eq('Invalid email format.')
+      end
+    end
+  end
+
+  # update
+  describe 'patch get /api/v1/users/:id' do
+    context 'update a user' do
+      let!(:user) { create(:user) }
+      let!(:update_params) { attributes_for(:user, first_name: 'Updated name', preferred_exam_body_id: exam_body.id) }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:authorize_user).and_return(true)
+        allow_any_instance_of(described_class).to receive(:same_user?).and_return(true)
+
+        patch "/api/v1/users/#{user.id}",
+          params: { user: update_params },
+          headers: { Authorization: "Bearer #{active_bearer.api_key}" }
+      end
+
+      it 'returns HTTP status 200' do
+        expect(response).to have_http_status 200
+      end
+
+      it 'returns user json data' do
+        body = JSON.parse(response.body)
+
+        expect(body['first_name']).to eq(update_params[:first_name])
+        expect(body['last_name']).to eq(update_params[:last_name])
+        expect(body['email']).to eq(update_params[:email])
+        expect([body.keys]).to contain_exactly(%w[id
+                                                  name
+                                                  first_name
+                                                  last_name
+                                                  email
+                                                  active
+                                                  address
+                                                  user_group
+                                                  guid
+                                                  email_verification_code
+                                                  email_verified_at
+                                                  email_verified
+                                                  free_trial
+                                                  terms_and_conditions
+                                                  date_of_birth
+                                                  description
+                                                  analytics_guid
+                                                  student_number
+                                                  unsubscribed_from_emails
+                                                  communication_approval
+                                                  communication_approval_datetime
+                                                  preferred_exam_body_id
+                                                  currency_id
+                                                  video_player
+                                                  profile_image_file_name
+                                                  profile_image_content_type
+                                                  profile_image_file_size
+                                                  profile_image_updated_at
+                                                  country
+                                                  currency
+                                                  subscription_plan_category])
+      end
+    end
+
+    context 'try to update a user with invalid details' do
+      let!(:user) { create(:user) }
+      let!(:update_params) { attributes_for(:user, first_name: '', preferred_exam_body_id: exam_body.id) }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:authorize_user).and_return(true)
+        allow_any_instance_of(described_class).to receive(:same_user?).and_return(true)
+
+        patch "/api/v1/users/#{user.id}",
+          params: { user: update_params },
+          headers: { Authorization: "Bearer #{active_bearer.api_key}" }
+      end
+
+      it 'returns HTTP status 422' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'returns empty data' do
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('first_name' => ['can\'t be blank', 'is too short (minimum is 2 characters)'])
+      end
+    end
+  end
+
+  # change_password
+  describe 'post get /api/v1/users/:user_id/change_password' do
+    context 'change user password' do
+      let!(:user)            { create(:user) }
+      let!(:password_params) { { current_password: '123123123', password: 'new_pass', password_confirmation: 'new_pass' } }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:authorize_user).and_return(true)
+        allow_any_instance_of(described_class).to receive(:same_user?).and_return(true)
+
+        post "/api/v1/users/#{user.id}/change_password",
+          params: { user: password_params },
+          headers: { Authorization: "Bearer #{active_bearer.api_key}" }
+      end
+
+      it 'returns HTTP status 200' do
+        expect(response).to have_http_status 200
+      end
+
+      it 'returns success json message' do
+        body = JSON.parse(response.body)
+
+        expect(body['message']).to eq(I18n.t('controllers.users.change_password.flash.success'))
+      end
+    end
+
+    context 'fail in change user password' do
+      let!(:user)            { create(:user) }
+      let!(:password_params) { { current_password: 'no_passs', password: 'new_pass', password_confirmation: 'new_pass' } }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:authorize_user).and_return(true)
+        allow_any_instance_of(described_class).to receive(:same_user?).and_return(true)
+
+        post "/api/v1/users/#{user.id}/change_password",
+          params: { user: password_params },
+          headers: { Authorization: "Bearer #{active_bearer.api_key}" }
+      end
+
+      it 'returns HTTP status 422' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'returns error json message' do
+        body = JSON.parse(response.body)
+
+        expect(body['message']).to eq(I18n.t('controllers.users.change_password.flash.error'))
       end
     end
   end


### PR DESCRIPTION
What? Update User and Change Password endpoints.

How to test?

Update User:

API call: I did add a user register test(not working yet, but you can test the API authentication using it.)
PATCH request to **http://localhost:3000/api/v1/users/:user_id**
```json
{
    "user": {
        "first_name": "New First Name",
        "last_name": "Last Name Updated",
        "email": "login_user_06@test.com",
        "date_of_birth": "2012-08-07"
    }
}

```


Change Password:

API call: I did add a user register test(not working yet, but you can test the API authentication using it.)
POST request to **http://localhost:3000/api/v1/users/:user_id/change_password**
```json
{
    "user": {
        "current_password": "1234567890",
        "password": "12341234",
        "password_confirmation": "12341234"
    }
}
