### PR TITLE
(HOTFIX) Add a default order to sort_exercises_arr.

### DIFF
--- a/app/controllers/admin/exercises_controller.rb
+++ b/app/controllers/admin/exercises_controller.rb
@@ -162,6 +162,8 @@ module Admin
     end
 
     def sort_exercises_arr(exercises_arr, direction)
+      direction ||= 'desc'
+
       case params[:sort_by]
       when 'due_on'
         exercises_arr.order(submitted_on: direction)


### PR DESCRIPTION
Fix for: https://learnsignal.airbrake.io/projects/107826/groups/3095954718775780293?tab=overview