### PR TITLE
added api accesibility to registration confirmation page, deploy to prod

### DIFF
--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StudentSignUpsController < ApplicationController
-  before_action :check_logged_in_status, except: %i[landing group pricing new_landing]
+  before_action :check_logged_in_status, except: %i[show landing group pricing new_landing]
   before_action :get_variables
   before_action :create_user_object, only: %i[new sign_in_or_register sign_in_checkout landing new_landing]
   before_action :create_user_session_object, only: %i[sign_in_or_register sign_in_checkout landing]

--- a/spec/controllers/student_sign_ups_controller_spec.rb
+++ b/spec/controllers/student_sign_ups_controller_spec.rb
@@ -263,8 +263,8 @@ RSpec.describe StudentSignUpsController, type: :controller do
       it 'should bounce as signed in' do
         get :show, params: { account_activation_code: unverified_user.account_activation_code }
         expect(flash[:success]).to be_nil
-        expect(response.status).to eq(302)
-        expect(response).to redirect_to(student_dashboard_url)
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:show)
       end
     end
 


### PR DESCRIPTION
**What?** let's us access this from webflow as a user registration confirmation page.
**Note:** This is a temporary fix.

Straight to production