### PR TITLE
Fix for course_step_rspec

### DIFF
--- a/spec/models/course_step_spec.rb
+++ b/spec/models/course_step_spec.rb
@@ -323,19 +323,18 @@ describe CourseStep do
         expect(course_step_01.available_to_user(user, nil)).to eq(view: false, reason: 'verification-required')
       end
 
-      # Commenting for now @gio to help fix this.
-      # it 'for comp_user it returns true' do
-      #   user = build(:comp_user)
+      it 'for comp_user it returns true' do
+        user = build_stubbed(:comp_user)
 
-      #   expect(course_step_01.available_to_user(user, nil)).to eq(view: true, reason: nil)
-      # end
+        expect(course_step_01.available_to_user(user, nil)).to eq(view: true, reason: nil)
+      end
 
-      # it 'for standard_student_user it returns false and invalid-subscription' do
-      #   user        = build(:active_student_user)
-      #   course_step = build(:course_step, available_on_trial: false)
+      it 'for standard_student_user it returns false and invalid-subscription' do
+        user        = build_stubbed(:active_student_user)
+        course_step = build(:course_step, available_on_trial: false)
 
-      #   expect(course_step.available_to_user(user, nil)).to eq(view: false, reason: 'invalid-subscription')
-      # end
+        expect(course_step.available_to_user(user, nil)).to eq(view: false, reason: 'invalid-subscription')
+      end
     end
   end
 end


### PR DESCRIPTION
Using `build_stubbed` instead `build` to have some value in `created_at`.