### PR TITLE
Show verify email modal in each new session;

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -707,8 +707,8 @@ class User < ApplicationRecord
   def show_verify_email_message?
     return false if email_verified
 
-    if verify_remembered_at.nil? || verify_remembered_at.time <= 6.hours.ago
-      update(verify_remembered_at: Time.zone.now)
+    if verify_remembered_at.nil? || verify_remembered_at != current_login_at
+      update(verify_remembered_at: current_login_at)
       true
     else
       false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -835,7 +835,8 @@ describe User do
       end
 
       it 'do not show verify email message' do
-        user.update(verify_remembered_at: Time.zone.now)
+        time_now = Time.zone.now
+        user.update(current_login_at: time_now, verify_remembered_at: time_now)
         expect(user.show_verify_email_message?).to be_falsey
       end
     end


### PR DESCRIPTION
Change the show verify email modal logic, now we're showing this modal when user start a new session.