### PR TITLE
TrustPilot BCC for Payment Success Emails

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -289,6 +289,7 @@ class Invoice < ApplicationRecord
       user_id: user_id,
       kind: :account,
       template: 'send_successful_payment_email',
+      subscription_id: subscription_id,
       template_params: {
         url: account_url,
         invoice_url: invoice_url

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -28,6 +28,8 @@ class Message < ApplicationRecord
   # relationships
   belongs_to :user
   belongs_to :onboarding_process, optional: true
+  belongs_to :subscription, optional: true
+  belongs_to :order, optional: true
 
   validates :user_id, presence: true
   validates :kind, inclusion: { in: Message.kinds.keys }, presence: true
@@ -76,6 +78,11 @@ class Message < ApplicationRecord
     return unless kind == 'onboarding'
 
     UrlHelper.instance.unsubscribe_url(message_guid: guid, host: LEARNSIGNAL_HOST)
+  end
+
+  def include_bcc?
+    (template == 'send_successful_payment_email' && subscription&.invoices&.count == 1) ||
+      (template == 'send_successful_order_email' && order&.product&.product_type == 'lifetime_access')
   end
 
   protected

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -168,6 +168,7 @@ class Order < ApplicationRecord
         process_at: Time.zone.now,
         user_id: user_id,
         kind: :account,
+        order_id: id,
         template: 'send_mock_exam_email',
         template_params: {
           url: user_exercise_url,
@@ -180,6 +181,7 @@ class Order < ApplicationRecord
         process_at: Time.zone.now,
         user_id: user_id,
         kind: :account,
+        order_id: id,
         template: 'send_successful_order_email',
         template_params: {
           url: account_url,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -63,6 +63,7 @@ class Subscription < ApplicationRecord
   has_many :invoice_line_items
   has_many :charges
   has_many :refunds
+  has_many :messages
 
   # validation
   validates :user_id, presence: true,

--- a/app/workers/mandrill_worker.rb
+++ b/app/workers/mandrill_worker.rb
@@ -11,6 +11,7 @@ class MandrillWorker
     method_name    = message.template
     template_args  = message.template_params.values
     template_args << message.unsubscribe_url if message.unsubscribe_url
+    template_args << 'learnsignal.com+ec7befe2db@invite.trustpilot.com' if message.include_bcc?
     # The template_params are pulled out in different order than the order they were input to the hstore
 
     return unless message&.user&.email

--- a/db/migrate/20211015094110_add_subscriptioin_to_message.rb
+++ b/db/migrate/20211015094110_add_subscriptioin_to_message.rb
@@ -1,0 +1,6 @@
+class AddSubscriptioinToMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :subscription_id, :integer, default: nil
+    add_column :messages, :order_id, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_171118) do
+ActiveRecord::Schema.define(version: 2021_10_15_094110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1114,6 +1114,8 @@ ActiveRecord::Schema.define(version: 2021_10_07_171118) do
     t.hstore "template_params", default: {}
     t.string "guid"
     t.integer "onboarding_process_id"
+    t.integer "subscription_id"
+    t.integer "order_id"
     t.index ["mandrill_id"], name: "index_messages_on_mandrill_id"
     t.index ["process_at"], name: "index_messages_on_process_at"
     t.index ["user_id"], name: "index_messages_on_user_id"
@@ -1293,7 +1295,6 @@ ActiveRecord::Schema.define(version: 2021_10_07_171118) do
     t.text "payment_description"
     t.string "savings_label"
     t.index ["cbe_id"], name: "index_products_on_cbe_id"
-    t.index ["course_id"], name: "index_products_on_course_id"
     t.index ["currency_id"], name: "index_products_on_currency_id"
     t.index ["group_id"], name: "index_products_on_group_id"
     t.index ["mock_exam_id"], name: "index_products_on_mock_exam_id"

--- a/lib/mandrill_client.rb
+++ b/lib/mandrill_client.rb
@@ -53,15 +53,15 @@ class MandrillClient
     send_template('account-suspended-190605', msg)
   end
 
-  def send_successful_payment_email(account_url, invoice_url)
-    msg = message_stub.merge('subject' => 'LearnSignal - Payment Invoice')
+  def send_successful_payment_email(account_url, invoice_url, bcc_url = nil)
+    msg = message_stub.merge('subject' => 'LearnSignal - Payment Invoice', 'bcc_address' => bcc_url)
     msg['global_merge_vars'] << { 'name' => 'ACCOUNTURL', 'content' => account_url }
     msg['global_merge_vars'] << { 'name' => 'INVOICEURL', 'content' => invoice_url }
     send_template('payment-invoice-new-branding-190605', msg)
   end
 
-  def send_successful_order_email(account_url, product)
-    msg = message_stub.merge('subject' => 'LearnSignal - Payment Invoice')
+  def send_successful_order_email(account_url, product, bcc_url = nil)
+    msg = message_stub.merge('subject' => 'LearnSignal - Payment Invoice', 'bcc_address' => bcc_url)
     msg['global_merge_vars'] << { 'name' => 'ACCOUNTURL', 'content' => account_url }
     msg['global_merge_vars'] << { 'name' => 'PRODUCTNAME', 'content' => product }
     send_template('order-invoice-230920', msg)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -32,6 +32,10 @@ describe Message do
     it { should respond_to(:updated_at) }
     it { should respond_to(:state) }
     it { should respond_to(:template_params) }
+    it { should respond_to(:guid) }
+    it { should respond_to(:onboarding_process_id) }
+    it { should respond_to(:subscription_id) }
+    it { should respond_to(:order_id) }
   end
 
   describe 'Constants' do
@@ -95,4 +99,6 @@ describe Message do
     end
   end
 
+  it { should respond_to(:unsubscribe_url) }
+  it { should respond_to(:include_bcc?) }
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -74,6 +74,7 @@ describe Subscription do
     it { should belong_to(:coupon) }
     it { should have_many(:charges) }
     it { should have_many(:refunds) }
+    it { should have_many(:messages) }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
BCC URL added to first sub invoice email and lifetime order email:
 * Added relationship between subscription and messages so that the bcc_url can be added
 * Included lifetime product orders to bcc_url messages