### PR TITLE
renamed ismobile var to avoid duplicate

### DIFF
--- a/app/views/library/group_show.html.haml
+++ b/app/views/library/group_show.html.haml
@@ -199,7 +199,7 @@
 
       }
 
-      const isMobile = {
+      const _isMobile = {
         Android: function() {
             return navigator.userAgent.match(/Android/i);
         },
@@ -216,12 +216,12 @@
             return navigator.userAgent.match(/IEMobile/i);
         },
         any: function() {
-            return (isMobile.Android() || isMobile.BlackBerry() || isMobile.iOS() || isMobile.Opera() || isMobile.Windows());
+            return (_isMobile.Android() || _isMobile.BlackBerry() || _isMobile.iOS() || _isMobile.Opera() || _isMobile.Windows());
         }
       };
 
       $(function () {
-        if( !isMobile.any() ){
+        if( !_isMobile.any() ){
           $('[data-toggle="tooltip"]').tooltip({
             template: '<div class="tooltip tooltip-custom" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>'
           })


### PR DESCRIPTION
- **What?** Getting error warning on the browser console that ismobile is duplicate
- **Why?** ismobile var is created on the responsive-nav.js file and being called again on the library/group_show.html.haml file
- **How?** Renamed var on the group_show.html.haml file
- **How to test?** Check if tooltip template is hidden when on mobile