### PR TITLE
json unexpected token error on single quote replaced by url encoding

### DIFF
--- a/app/assets/javascripts/event_tracking.js
+++ b/app/assets/javascripts/event_tracking.js
@@ -104,7 +104,8 @@ function gaBaseProperties() {
 }
 
 function getPageUrl() {
-  return { pageUrl: window.location.href };
+  var page_url = window.location.href.replace(/'/g, "%27");
+  return { pageUrl: page_url };
 }
 function isMobile() {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(


### PR DESCRIPTION
- **What?** Airbrake error on page url syntax retrieved for use on segment tracking
- **Why?** the string gets retrieved with a quote that breaks on parsing
- **How?** replaced quote with url encoding