### PR TITLE
CBE correction & exercise fixes

### DIFF
--- a/app/javascript/components/cbe/CbeExhibitsModal.vue
+++ b/app/javascript/components/cbe/CbeExhibitsModal.vue
@@ -8,7 +8,7 @@
         :componentType="componentType"
         :componentName="componentName"
         :componentModal="componentModal"
-        :componentContentData="componentContentData"
+        :componentSpreadsheetData="componentSpreadsheetData"
         :componentIcon="componentIcon"
         :height="450"
         :width="800"
@@ -16,7 +16,7 @@
         <div slot="body">
           <SpreadsheetEditor
             v-if="componentType === 'spreadsheet'"
-            :initial-data="componentContentData"
+            :initial-data="componentSpreadsheetData"
           />
           <div id="pdfvuer" v-else-if="componentType === 'pdf'">
             <div
@@ -98,7 +98,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    componentContentData: {
+    componentSpreadsheetData: {
       type: Object,
       default: () => ({}),
     },

--- a/app/views/exercises/_cbe_user_log.html.haml
+++ b/app/views/exercises/_cbe_user_log.html.haml
@@ -20,7 +20,7 @@
               .row
                 .col-sm-2
                   %nav.mb-4.account-nav
-                    %ul#questionTabs.nav.nav-tabs.nav-tabs-vertical{:role => "tablist"}
+                    %ul#questionTabs.nav.nav-tabs.nav-tabs-vertical.wrap-tabs{:role => "tablist"}
                       -section_questions.each_with_index do |question, index|
                         %li.nav-item
                           %a.nav-link{class: index == 0 ? 'active' : '', id: "#section-#{section.id}-question-#{question.id}", "aria-controls" => "section-#{section.id}-question-#{question.id}", "aria-selected" => "true", "data-toggle" => "tab", :href => "#section-#{section.id}-question-#{question.id}", :role => "tab"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -62,7 +62,7 @@
   - if controller_name == 'cbes'
     %body.page-light
       -if @layout == 'management'
-        #console-wrapper
+        #management-console-wrapper
           .d-none.d-sm-block
             =render partial: 'layouts/management_side_navbar'
           .main-content


### PR DESCRIPTION
CBE admin correction exhibits spreadsheet content fix and CBE exercise results question list:

 * Fixed VueModal exhibits spreadsheet data name
 
<img width="325" alt="Screenshot 2021-12-10 at 9 10 03 a m" src="https://user-images.githubusercontent.com/8065841/145548275-cc3e30d5-c1d2-4698-bb8f-22da7cb67d1c.png">
<img width="325" alt="Screenshot 2021-12-10 at 9 11 10 a m" src="https://user-images.githubusercontent.com/8065841/145548374-9103e54c-97ad-4d19-98ec-3d4b8d22f38d.png">

 * Added missing style class for CBE results questions list
 
<img width="325" alt="Screenshot 2021-12-10 at 10 06 10 a m" src="https://user-images.githubusercontent.com/8065841/145556400-14371cf5-0363-46f2-9479-a8fefa1d7ccc.png">
<img width="325" alt="Screenshot 2021-12-10 at 10 07 51 a m" src="https://user-images.githubusercontent.com/8065841/145556465-1b9b9258-33f2-4408-a4a8-1977c4a0717c.png">


 * Fixed missing styling on CBE admin sidebar