### PR TITLE
Update URL on video complete popover button to next step

### DIFF
--- a/app/views/courses/_show_video.html.haml
+++ b/app/views/courses/_show_video.html.haml
@@ -18,7 +18,7 @@
         .hidden.end-of-video-modal#js-end-of-video-modal
           .video-modal-actions
             -if @course_lesson.next_module
-              =link_to course_special_link(@course_step.next_element), class: 'videoModal-next-btn btn btn-primary btn-sm btn-sm-arrow-right mb-3 mb-sm-0 w-auto font-weight-bold', data: {destination_url: course_special_link(@course_lesson&.next_module&.first_active_cme), type: 'Next Module'} do
+              =link_to show_course_url(@course.name_url, @course_step&.next_element&.course_lesson&.course_section&.name_url, @course_step&.next_element&.course_lesson&.name_url, @course_step&.next_element&.name_url), class: 'videoModal-next-btn btn btn-primary btn-sm btn-sm-arrow-right mb-3 mb-sm-0 w-auto font-weight-bold', data: {destination_url: show_course_url(@course.name_url, @course_step&.next_element&.course_lesson&.course_section&.name_url, @course_step&.next_element&.course_lesson&.name_url, @course_step&.next_element&.name_url), type: 'Next Module'} do
                 Go to Next Lesson
 
     %header.course-header-mobile


### PR DESCRIPTION
Render the correct URL on video completion pop over modal, the direct link rather than `course_special_link` since the step has now been completed so the progress restriction has been satisfied.

[Jira ticket](https://learnsignal-team.atlassian.net/browse/AP-288)