### PR TITLE
Hotfix/fix-discounts-for-replaced-coupons

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -6,7 +6,7 @@ class CouponsController < ApplicationController
     ensure_user_has_access_rights(%w[stripe_management_access])
   end
   before_action :management_layout
-  before_action :set_coupon, only: %i[show edit update destroy]
+  before_action :set_coupon, only: %i[show edit update]
   before_action :form_variables, only: %i[new edit create]
 
   def index
@@ -40,16 +40,6 @@ class CouponsController < ApplicationController
       flash[:error] = I18n.t('controllers.coupons.update.flash.error')
       render action: :edit
     end
-  end
-
-  def destroy
-    if @coupon.destroy
-      flash[:success] = I18n.t('controllers.coupons.destroy.flash.success')
-    else
-      flash[:error] = I18n.t('controllers.coupons.destroy.flash.error')
-    end
-
-    redirect_to coupons_url
   end
 
   def validate_coupon

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -48,7 +48,6 @@ class Coupon < ApplicationRecord
 
   # callbacks
   before_create  :create_on_stripe
-  before_destroy :delete_on_stripe
   after_create   :activate
   after_update   :update_on_stripe
 
@@ -176,10 +175,5 @@ class Coupon < ApplicationRecord
     self.livemode = stripe_coupon[:livemode]
     self.times_redeemed = stripe_coupon[:times_redeemed]
     self.stripe_coupon_data = stripe_coupon.to_hash.deep_dup
-  end
-
-  def delete_on_stripe
-    stripe_coupon = Stripe::Coupon.retrieve(id: code) unless Rails.env.test?
-    stripe_coupon&.delete
   end
 end

--- a/app/views/coupons/index.html.haml
+++ b/app/views/coupons/index.html.haml
@@ -29,6 +29,5 @@
                     %td
                       =link_to t('views.general.view'), coupon_path(coupon), class: 'btn btn-primary btn-xs'
                       =link_to t('views.general.edit'), edit_coupon_path(coupon), class: 'btn btn-primary btn-xs'
-                      =link_to t('views.general.delete'), coupon, method: :delete, data: { confirm: t('views.general.delete_confirmation') }, class: 'btn btn-secondary btn-xs'
 
             =will_paginate @coupons, renderer: BootstrapPagination::Rails

--- a/spec/controllers/coupons_controller_spec.rb
+++ b/spec/controllers/coupons_controller_spec.rb
@@ -97,22 +97,6 @@ describe CouponsController, type: :controller do
       end
     end
 
-    describe "DELETE 'destroy'" do
-      it 'should be ERROR as children exist' do
-        delete :destroy, params: { id: coupon_subscriptions.id }
-
-        expect(flash[:success]).to be_nil
-        expect(flash[:error]).to be_present
-      end
-
-      it 'should be OK as no dependencies exist' do
-        delete :destroy, params: { id: coupon_2.id }
-
-        expect(flash[:success]).to be_present
-        expect(flash[:error]).to be_nil
-      end
-    end
-
     describe "Post to 'validate_coupon'" do
       it 'should OK for valid coupon' do
         post :validate_coupon, params: { code: coupon_1.code, plan_id: subscription_plan_gbp_m.id }, format: :json

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -56,7 +56,6 @@ describe Coupon do
 
   describe 'callbacks' do
     it { should callback(:create_on_stripe).before(:create) }
-    it { should callback(:delete_on_stripe).before(:destroy) }
     it { should callback(:update_on_stripe).after(:update) }
     it { should callback(:activate).after(:create) }
   end


### PR DESCRIPTION
**Updated the Invoice#apply_coupon_credit method to factor discount correctly when coupons have been replaced:**

 * Changed return conditional in Invoice apply_coupon_credit method to use original stripe data duration rather than checking for coupons in our DB as they've been deleted
 * Removed the ability for admins to delete coupons
 * Cleaned up the Invoice apply_coupon_credit method to use on the original_stripe data to calculate the discount rather than the coupon record in our db

https://learnsignal-team.atlassian.net/browse/AP-313