### PR TITLE
Fix Successful Payment event type for change plans

### DIFF
--- a/app/services/stripe_subscription_service.rb
+++ b/app/services/stripe_subscription_service.rb
@@ -68,7 +68,7 @@ class StripeSubscriptionService < StripeService
       stripe_guid: stripe_sub.id, next_renewal_date: renewal_date(stripe_sub),
       stripe_customer_id: @subscription.stripe_customer_id,
       client_secret: client_secret,
-      kind: @subscription.kind
+      kind: 2 # Change Plan
     ), stripe_sub]
   end
 


### PR DESCRIPTION
* Set subscription kind to change_plan in the StripeSubscriptionService change plan as it was being set to the previous subscription kind and later updated in the flow but the Segment call happens in between these.

https://learnsignal-team.atlassian.net/browse/AP-314