### PR TITLE
replace payment_properties method with subscription_payment_propertie…

### DIFF
--- a/app/services/segment_service.rb
+++ b/app/services/segment_service.rb
@@ -98,7 +98,7 @@ class SegmentService
     segment = Analytics.track(
       user_id: user&.id,
       event: 'payment_failed',
-      properties: payment_properties(subscription.subscription_plan, subscription.coupon_data, subscription.kind, user&.email).merge!(payment_error_properties(error_msg, error_code))
+      properties: subscription_payment_properties(subscription, user&.email).merge!(payment_error_properties(error_msg, error_code))
     )
   rescue StandardError => e
     Rails.logger.error "SegmentService#create_& - Error: #{e.inspect} - User Id #{user&.id} Segment Object - #{segment}"


### PR DESCRIPTION
- **What?** Getting airbrake error undefined method `payment_properties' for SegmentService
- **Why?** Old method being used that doesn't exist
- **How?** Replaced payment_properties method with subscription_payment_properties method

https://learnsignal.airbrake.io/projects/107826/groups/3183771535866539558?tab=overview