### PR TITLE
passing email and session id from server side for user_account_create…

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -24,7 +24,7 @@ module Api
           @user_token       = encode_token(payload(@user))
           @user_credentials = "#{session['user_credentials']}::#{session['user_credentials_id']}" if UserSession.create(@user)
 
-          SegmentService.new.track_user_account_created_event(@user, analytics_attributes_params&.to_h) if params[:analytics_attributes].present?
+          SegmentService.new.track_user_account_created_event(@user, session&.id, analytics_attributes_params&.to_h) if params[:analytics_attributes].present?
 
           render 'api/v1/users/show.json', status: :created
         else

--- a/app/controllers/student_sign_ups_controller.rb
+++ b/app/controllers/student_sign_ups_controller.rb
@@ -157,7 +157,7 @@ class StudentSignUpsController < ApplicationController
       @user.handle_post_user_creation(user_verification_url(email_verification_code: @user.email_verification_code))
       handle_course_enrollment(@user, params[:course_id]) if params[:course_id]
       analytics_attributes = params[:analytics_attributes].present? ? JSON.parse(params[:analytics_attributes]) : nil
-      SegmentService.new.track_user_account_created_event(@user, analytics_attributes)
+      SegmentService.new.track_user_account_created_event(@user, session&.id, analytics_attributes)
 
       # TODO: Refactor this to not use the flash
       if flash[:plan_guid]

--- a/app/services/segment_service.rb
+++ b/app/services/segment_service.rb
@@ -105,8 +105,8 @@ class SegmentService
     log_in_error(e)
   end
 
-  def track_user_account_created_event(user, analytics_attributes)
-    attributes = analytics_attributes_properties(analytics_attributes.with_indifferent_access)
+  def track_user_account_created_event(user, session_id, analytics_attributes)
+    attributes = analytics_attributes_properties(user, session_id, analytics_attributes.with_indifferent_access)
     return if attributes.nil?
 
     segment = Analytics.track(
@@ -252,7 +252,7 @@ class SegmentService
     }
   end
 
-  def analytics_attributes_properties(analytics_attributes)
+  def analytics_attributes_properties(user, session_id, analytics_attributes)
     valid_keys = %i[category clientOs deviceType email eventSentAt isLoggedIn pageUrl platform
                     programName sessionId sourceofRegistration]
 
@@ -261,13 +261,13 @@ class SegmentService
     {
       category: analytics_attributes[:category],
       deviceType: analytics_attributes[:deviceType],
-      email: analytics_attributes[:email],
+      email: user&.email,
       eventSentAt: analytics_attributes[:eventSentAt],
       isLoggedIn: analytics_attributes[:isLoggedIn],
       pageUrl: analytics_attributes[:pageUrl],
       platform: analytics_attributes[:platform],
       programName: analytics_attributes[:programName],
-      sessionId: analytics_attributes[:sessionId],
+      sessionId: session_id,
       sourceofRegistration: analytics_attributes[:sourceofRegistration]
     }
   end


### PR DESCRIPTION
- **What?** user_account_created event showing incorrect properties in some cases
- **Why?** if a user should fail in the registration process and reattempt later there could be some mismatching of properties from both attempts
- **How?** passing email and session id from server side